### PR TITLE
Update mic.md

### DIFF
--- a/content/language/hoon/reference/rune/mic.md
+++ b/content/language/hoon/reference/rune/mic.md
@@ -394,16 +394,6 @@ Two arguments, fixed.
 [%mcmc p=spec q=hoon]
 ```
 
-#### Expands to
-
-```hoon
-=+  a=(p q)
-?>  =(`*`a `*`q)
-a
-```
-
-> Note: the expansion implementation is hygienic -- it doesn't actually add the `a` face to the subject.
-
 #### Examples
 
 Fails because of auras:


### PR DESCRIPTION
the old expansion was wrong, so i removed it. ;; now crashes if the molds don't mold instead of normalizing their input. ;; is now the same as (,p q).