### PR TITLE
Deprecate ++rut:by

### DIFF
--- a/content/language/hoon/reference/stdlib/2i.md
+++ b/content/language/hoon/reference/stdlib/2i.md
@@ -161,7 +161,7 @@ name = "Transform nodes (map)"
 symbol = "rut:by"
 usage = "stdlib"
 slug = "#rutby"
-desc = "Used in the Hoon standard library."
+desc = "Used in the Hoon standard library.  (Deprecated 411 K)"
 
 [glossaryEntry."Listify pairs"]
 name = "Listify pairs"
@@ -1294,7 +1294,7 @@ A map.
 
 ### `++rut:by`
 
-Transform nodes
+Transform nodes  (Deprecated 411 K)
 
 Applies a gate `b` to nodes in map `a`. The sample of gate `b` is a key-value pair, and it produces a new value.
 


### PR DESCRIPTION
Also need a change to an example in https://github.com/urbit/docs.urbit.org/blob/sigilante/411-deprecate-rut/content/language/hoon/reference/arvo.md.