### PR TITLE
update for 411 remote scry changes

### DIFF
--- a/content/system/kernel/ames/reference/tasks.md
+++ b/content/system/kernel/ames/reference/tasks.md
@@ -248,15 +248,62 @@ This `task` returns no `gift`s.
 
 ### `%keen`
 
+Perform an unencrypted or multi-party encrypted remote scry.
+
 ```hoon
-[%keen =ship =path]
+[%keen sec=(unit [idx=@ key=@]) spar]
 ```
 
-A `%keen` `task` asks Ames to perform a remote scry, retrieving the value of
-`path` on the given `ship`. The `path` has the general format of
-`/[vane-letter]/[care]/[revision]/[rest-of-path]`. For a regular read into
-Gall, it's `/g/x/[revision]/[agent]//[rest-of-path]`. Note the empty element in
-between the agent and the rest of the path.
+A `%keen` `task` asks Ames to perform a remote scry, retrieving the
+value of `path` on the given `ship` in the `spar`. The `sec` field
+provides optional encryption details for multi-party encrypted scries.
+
+The `path` has the general format of
+`/[vane-letter]/[care]/[revision]/[rest-of-path]`. For a regular read
+into Gall, it's `/g/x/[revision]/[agent]//[rest-of-path]`. Note the
+empty element in between the agent and the rest of the path.
+
+Note that you would not use this task directly from userspace. For
+unencrypted or multi-party encrypted scries you'd use a [Gall `%keen`
+note](/system/kernel/gall/reference/gall-api#keen) and for two-party
+encrypted scries you'd use a [`%chum`](#chum) task.
+
+#### Returns
+
+A `%tune` gift. A `%tune` gift looks like:
+
+```hoon
+[%tune spar roar=(unit roar)]
+```
+
+It represents a *result*. The `roar` field is null if Ames doesn't have a
+response, but may have one in the future. The
+[`$roar`](/system/kernel/ames/reference/data-types#roar) contains a signature and the
+data. The data in the `$roar` will be null if there is no value at the path in
+question and will never be. These two cases are equivalent to `~` and `[~ ~]` of
+a local scry.
+
+---
+
+### `%chum`
+
+Perform a two-party encrypted remote scry.
+
+```hoon
+[%chum spar]
+```
+
+A `spar` is a pair of `ship` and remote scry `path` like
+`/c/x/4/base/sys/hoon/hoon`.
+
+The `path` has the general format of
+`/[vane-letter]/[care]/[revision]/[rest-of-path]`. For a regular read
+into Gall, it's `/g/x/[revision]/[agent]//[rest-of-path]`. Note the
+empty element in between the agent and the rest of the path.
+
+Note this is for two-party encrypted remote scries only. For unencrypted
+or multi-party encrypted scries you'd use a [Gall `%keen`
+note](/system/kernel/gall/reference/gall-api#keen).
 
 #### Returns
 
@@ -276,6 +323,8 @@ a local scry.
 ---
 
 ### `%yawn`
+
+Cancel a remote scry request.
 
 ```hoon
 [%keen =ship =path]

--- a/content/system/kernel/gall/reference/data-types.md
+++ b/content/system/kernel/gall/reference/data-types.md
@@ -55,6 +55,20 @@ Gall uses this to keep track of nonces for subscriptions.
 
 ---
 
+## `fans`
+
+Revisions for a remote scry file published at a particular path.
+
+```hoon
++$  fans  ((mop @ud (pair @da (each page @uvI))) lte)
+```
+
+The `mop` is organized by file revision number. Each value includes the
+date-time of the entry, and then either the file as a `page` or just the
+`@uvI` hash of the file if it has been tombstoned.
+
+---
+
 ## `bowl`
 
 Additional agent state.
@@ -64,12 +78,11 @@ Additional agent state.
   $:  $:  our=ship                                    ::  host
           src=ship                                    ::  guest
           dap=term                                    ::  agent
+          sap=path                                    ::  provenance
       ==                                              ::
       $:  wex=boat                                    ::  outgoing subs
           sup=bitt                                    ::  incoming subs
-          $=  sky                                     ::  scry bindings
-          %+  map  path                               ::
-          ((mop @ud (pair @da (each page @uvI))) lte) ::
+          sky=(map path fans)                         ::  scry bindings
       ==                                              ::
       $:  act=@ud                                     ::  change number
           eny=@uvJ                                    ::  entropy
@@ -89,8 +102,8 @@ as follows:
 - `sup`: Incoming subscriptions. That is, subscriptions others have made to our
   agent. See the [`bitt`](#bitt) section for details of the type.
 - `sky`: Remote scry bindings. A map from binding paths to a
-  [`mop`](/language/hoon/reference/zuse/2m#mop) (ordered map) of files by revision
-  number. Tombstoned files have an `@uvI` hash rather than `page`.
+  [`fans`](#fans), an ordered map of files by revision number.
+  Tombstoned files have an `@uvI` hash rather than `page`.
 - `act`: The total number of [`move`](/system/kernel/arvo#move)s our agent has
   processed so far.
 - `eny`: 512 bits of entropy.
@@ -215,6 +228,18 @@ Verbosity flags.
 ```
 
 Flags to set Gall verbosity. Currently only `%odd` for unusual errors.
+
+---
+
+## `coop`
+
+Verbosity flags.
+
+```hoon
++$  coop  spur
+```
+
+A security context for remote scries.
 
 ---
 

--- a/content/system/kernel/gall/reference/gall-api.md
+++ b/content/system/kernel/gall/reference/gall-api.md
@@ -17,6 +17,12 @@ one of:
       [%grow =spur =page]
       [%tomb =case =spur]
       [%cull =case =spur]
+  ::
+      [%tend =coop =path =page]
+      [%germ =coop]
+      [%snip =coop]
+  ::
+      [%keen secret=? spar:ames]
   ==
 ```
 
@@ -82,7 +88,7 @@ upgrade/installation to fail under some condition.
 
 ### `%grow`
 
-Publish remote scry file.
+Publish remote scry file without encryption.
 
 ```hoon
 [%grow =spur =page]
@@ -94,6 +100,9 @@ number will be determined implicitly. As an example, if the `spur` was
 remote scry path would be `/g/x/0/bar//foo`
 
 The `page` is the file, a pair of `[p=mark q=noun]`.
+
+Note the published file will not be encrypted. For the encrypted
+version, see [`%tend`](#tend)
 
 ---
 
@@ -125,6 +134,72 @@ All revisions of the remote scry file published at the `path` in `spur`
 up to and including the revision specified in `case` will be deleted.
 For example, if the `case` is `[%ud 2]`, then revisions `0`, `1`, and
 `2` will all be deleted.
+
+---
+
+### `%tend`
+
+Publish remote scry file with encryption.
+
+```hoon
+[%tend =coop =path =page]
+```
+
+The `coop` is a publisher-defined security context `path` like
+`/your/security/context`. The `path` is the path at which the file
+should be published like `/foo/bar/baz`.  The `page` is the file, a pair
+of `[p=mark q=noun]`.
+
+The security context must be registered with a [`%germ`](#germ) task
+before publishing the file.
+
+---
+
+### `%germ`
+
+Create an encrypted remote scry security context.
+
+```hoon
+[%germ =coop]
+````
+
+The `coop` is a publisher-defined security context `path` like
+`/your/security/context`.
+
+Once created, you can publish files to it with a [`%tend`](#tend) task.
+
+---
+
+### `%snip`
+
+Delete an encrypted remote scry security context.
+
+```hoon
+[%snip =coop]
+```
+
+The `coop` is a publisher-defined security context `path` like
+`/your/security/context`.
+
+---
+
+### `%keen`
+
+Perform either a multiparty encrypted remote scry or unencrypted remote
+scry.
+
+```hoon
+[%keen secret=? spar:ames]
+```
+
+`secret` specifies whether it should be encrypted or not. The `spar` is
+a pair of `ship` and the remote scry path like
+`/c/x/4/base/sys/hoon/hoon`.
+
+Note that multiparty encrypted scry (specified with a true `secret`)
+should only be used when you know the publisher expects it (i.e, as part
+of their application protocol). Otherwise, the two-party [Ames `%chum`
+task](/system/kernel/ames/reference/tasks#chum) should be used.
 
 ---
 

--- a/content/system/kernel/lick/guides/guide.md
+++ b/content/system/kernel/lick/guides/guide.md
@@ -308,7 +308,7 @@ cp -r zod/base/lib/{default-agent*,skeleton*} licker/desk/lib/
 Add a `desk.bill` `sys.kelvin` files:
 
 ``` {% copy=true %}
-echo "[%zuse 412]" > licker/desk/sys.kelvin
+echo "[%zuse 411]" > licker/desk/sys.kelvin
 echo "~[%licker]" > licker/desk/desk.bill
 ```
 

--- a/content/userspace/apps/guides/remote-scry.md
+++ b/content/userspace/apps/guides/remote-scry.md
@@ -4,61 +4,43 @@ description = "Learn about scrying over the network"
 weight = 5
 +++
 
-To [scry](/glossary/scry) is to perform a *read* from Urbit's
-referentially transparent namespace. In other words, it's a function from a
-`path` to a `noun` (although in some cases, the resulting type may be more
-constrained). Previously we only supported scrying within the same ship, but
-from Kernel version `[%zuse 413]`, it is possible to scry from *other* ships.
-
-{% callout %}
-
-**Warning**
-
-1. It should also be noted that, while responses are signed, encryption has not
-   yet been implemented.
-
-2. The initial release of `[%zuse 413]` had a bug in the remote scry client
-   implementation that causes crashes and failed downloads.  This issue was
-   fixed in [this PR](https://github.com/urbit/urbit/pull/6617), which was
-   [released](https://github.com/urbit/urbit/releases/tag/urbit-os-v2.141) (at
-   the same Kelvin) on June 1, 2023.  Any ships that are still on the initial
-   `[%zuse 413]` Kelvin release will continue to experience this bug. 
-
-   The recommended approach to dealing with this is to include a timer in clients
-   to fall back to using Ames for a download if a remote scry request doesn't
-   succeed within a certain amount of time.  This is what Clay uses, and its main
-   advantage is that client ships on older pre-remote-scry Kelvins can still
-   download data from newer server ships.
-
-{% /callout %}
+To {% tooltip label="scry" href="/glossary/scry" /%} is to perform a
+*read* from Urbit's referentially transparent namespace. In other words,
+it's a function from a `path` to a `noun` (although in some cases, the
+resulting type may be more constrained). Previously we only supported
+scrying within the same ship, but from Kernel version `[%zuse 413]`, it
+is possible to scry from *other* ships.
 
 ## Lifecycle of a scry
 
-When you think of scry, you probably think of [`.^`
-(dotket)](/language/hoon/reference/rune/dot#-dotket). However, since networking is
-asynchronous, this is not a suitable interface for remote scry. Instead, a ship
-that wants to read from a remote part of the namespace will have to pass a
-`%keen` task to its Ames, which then cooperates with Vere to produce the
-desired data. In some future event when the result is available, Ames gives it
-back as a `%tune` gift. From the requester's perspective, this is the entire
+When you think of scry, you probably think of `.^` {% tooltip
+label="dotket" href="/language/hoon/reference/rune/dot#-dotket" /%}.
+However, since networking is asynchronous, this is not a suitable
+interface for remote scry. Instead, a ship that wants to read from a
+remote part of the namespace will have to (directly or indirectly) ask
+Ames to perform the scry, which then cooperates with {% tooltip
+label="Vere" href="/glossary/vere" /%} to produce the desired data. In
+some future event when the result is available, Ames gives it back as a
+`%tune` gift. From the requester's perspective, this is the entire
 default lifecycle of a remote scry request.
 
-Of course, you need to know how `%keen` and `%tune` look to be able to use
-them. There are also a few exceptions to this default lifecycle. We'll go
-through all of this in a moment, but first, let's look at what kind of data is
-possible to scry.
+Of course, you need to know how Ame's `%chum` and `%tune` look, as well
+as Gall's `%keen` note, to be able to use them. There are also a few
+exceptions to this default lifecycle. We'll go through all of this in a
+moment, but first, let's look at what kind of data is possible to scry.
 
 ## Publishing
 
 At the moment, there are two vanes that can handle remote scry requests:
-[Clay](/system/kernel/clay) and [Gall](/system/kernel/gall). Clay
-uses it to distribute source code in a more efficient manner than is possible
-with conventional Ames, but conceptually it only extends its [local
-scries](/system/kernel/clay/reference/scry) over the network, with the notable
-difference that you can't scry at the *current* time, since the requester
-doesn't know when the request reaches the publisher. Additionally, the paths
-are modified so that the vane and care are specified separately, like so:
-`/c/x/1/base/sys/hoon/hoon`.
+{% tooltip label="Clay" href="/glossary/clay" /%} and {% tooltip
+label="Gall" href="/glossary/gall" /%}. Clay uses it to distribute
+source code in a more efficient manner than is possible with
+conventional Ames, but conceptually it only extends its [local
+scries](/system/kernel/clay/reference/scry) over the network, with the
+notable difference that you can't scry at the *current* time, since the
+requester doesn't know when the request reaches the publisher.
+Additionally, the paths are modified so that the vane and care are
+specified separately, like so: `/c/x/1/base/sys/hoon/hoon`.
 
 Gall is more interesting. First, let's clear up a possible misunderstanding
 that could easily come up: remote scry does *not* involve calling an agent's
@@ -66,19 +48,30 @@ that could easily come up: remote scry does *not* involve calling an agent's
 the requester can't know at which time the publisher handles the request, these
 aren't possible to reliably serve.
 
-Instead, agents *ask* Gall to `%grow` paths in the namespace on their behalf.
-Gall will take care of incrementing version numbers, so that the same path
-never maps to different nouns. The agent can also ask Gall to delete data,
-either at a specific version number, or everything up to and including a
-version number. Concretely, we've extended `$note:agent:gall` to include the
-following cases:
+Instead, agents *ask* Gall to `%grow` nouns to paths in the namespace on
+their behalf, and Gall stores the data in *its* state (not in the agent's
+state). Gall will take care of incrementing version numbers, so that the
+same path never maps to different nouns. The agent can also ask Gall to
+delete data, either at a specific version number, or everything up to
+and including a version
+number.
+
+{% callout %}
+
+Note: we'll only discuss the basic case of unencrypted and two-party
+encrypted scries here. Gall also supports multi-party encrypted scries
+with access control, which we'll look at in the next section.
+
+{% /callout %}
+
+`$note:agent:gall` includes the following cases:
 
 ```hoon
 +$  note
   $%  ...
-      [%grow =path =page]  ::  publish
-      [%tomb =case =path]  ::  delete one
-      [%cull =case =path]  ::  delete up to
+      [%grow =spur =page]  ::  publish
+      [%tomb =case =spur]  ::  delete one
+      [%cull =case =spur]  ::  delete up to
   ==
 ```
 
@@ -119,7 +112,7 @@ Let's pick apart the first one of these paths.
 
 What's that lone `/` before the path? It signifies that this data is published
 by *Gall* itself, instead of the `+on-peek` arm in the `%test` agent. As part
-of the remote scry release, we will *reserve* part of the scry namespace for
+of the remote scry release, we have *reserved* part of the scry namespace for
 Gall, effectively *preventing* any agents from directly publishing at those
 paths. Though as we've seen, they can do it indirectly, by asking Gall to do it
 for them using `%grow`.
@@ -131,7 +124,8 @@ results of calling `+on-peek`.
 
 ### Additional Gall cares
 
-Apart from supporting reads using the `%x` care, Gall now also supports three new cares:
+Apart from supporting reads using the `%x` care, Gall now also supports
+three new cares:
 
 - `%t` lists all subpaths that are bound under a path (only supported at the
   current time, i.e. not remotely!).
@@ -142,57 +136,250 @@ Apart from supporting reads using the `%x` care, Gall now also supports three ne
 
 All of these require the extra `/` to be present in the path, just as with `%x`.
 
-## Scrying tasks
+## Encryption
 
-With this, we're ready to look at all the new tasks to, and gifts from, Ames:
+As well as ordinary unencrypted scries, Ames also supports two-party and
+multi-party encrypted scries. Two-party encryption doesn't require any
+additional steps on the publisher's side, but multi-party encryption
+does:
+
+1. A *security context* must be created.
+2. You must implement an access-control scry handler for that security
+   context in the `++on-peek` arm.
+3. Data must be published to that security context.
+
+A security context is called a `coop`, which is just a `path` of your
+choosing, like `/foo/bar/baz`.
+
+`$note:agent:gall` includes the following two `note`s for managing
+security contexts and publishing data to them:
 
 ```hoon
-+$  task
-  $%  ...
-      [%keen =ship =path]  ::  peek [ship /vane/care/case/spur]
-      [%yawn =ship =path]  ::  cancel request from arvo
-      [%wham =ship =path]  ::  cancels all scry requests from any vane
-      ...
-  ==
-::
-+$  gift
-  $%  ...
-      [%tune spar roar=(unit roar)]
-      ...
-  ==
+$%  ...
+    [%tend =coop =path =page]
+    [%germ =coop]
+    ...
+==
+```
+#### `%germ`
+
+```hoon
+[%germ =coop]
 ```
 
-At this point, most of these should be very clear, but briefly:
+The `%germ` note creates the *security context* specified in the `coop`.
+It's just a `path` of your choice, like `/foo/bar/baz`. Once created,
+you can publish data to it with a [`%tend`](#tend) note.
 
-- We pass `[%keen =ship =path]` to Ames to request to read from `path` on
-  `ship`.  Example:
-  ```hoon
-  [%pass /call/back/path %arvo %a %keen ~sampel /c/x/4/base/sys/hoon/hoon]
-  ```
+Example:
 
-- We pass `[%yawn =ship =path]` to tell Ames that we're no longer interested in
-  a response.  Example: 
-  ```hoon
-  [%pass /call/back/path %arvo %a %yawn ~sampel /g/x/4/test//foo]
-  ```
+```hoon
+[%pass /call/back/path %germ /foo/bar/baz]
+```
 
-- We pass `[%wham =ship =path]` to tell Ames that *no-one* on this ship is
-  interested in a response.  Example:
-  ```hoon
-  [%pass /call/back/path %arvo %a %wham ~sampel /g/x/4/test//foo]
-  ```
+#### `%tend`
 
-- Ames gives the following to the original requester(s), either when it has a
-  response, or when the request gets `%wham`ed:
-  ```hoon
-  [%tune [=ship =path] roar=(unit roar)]
-  ```
-  The outer `unit` of `roar` will be `~` if Ames doesn't have a
-  response, but may have one in the future. Otherwise, it will
-  contain a signature and the data. The data in the
-  [`$roar`](/system/kernel/ames/reference/data-types#roar) may be `~`,
-  meaning that there is no value at this path and will never be
-  one.
+```hoon
+[%tend =coop =path =page]
+```
+
+The `%tend` note publishes the given `page` to the given `path` in the
+given `coop` security context. This is the same as a `%grow` note, just
+with the addition of the security context. The only difference is that
+access is limited to those allowed in the `coop`.
+
+### Access control
+
+For each security context created with the `%tend` task described above,
+the `++on-peek` arm of the agent should provide a scry handler for it,
+to decide whether a ship is allowed to access the resource or not. The
+scry path looks like:
+
+```hoon
+/c/your/security/context/~sampel-palnet
+```
+
+It has a `%c` `care`, the security context (in this case
+`/your/security/context`), and then the ship in question
+(`~sampel-palnet`). It must return a `?` boolean in a `%noun` mark which
+is true if the ship is allowed to access that security context, and
+false if not. How you determine whether a ship is allowed is up to you.
+Here's a trivial example:
+
+```hoon
+++  on-peek
+  |=  =path
+  ^-  (unit (unit cage))
+  ?.  ?=([%c %your %security %context @ ~] path)
+    ~
+  =/  =ship  (slav %p i.t.t.t.t.path)
+  ?:  =(~dinleb-rambep ship)  :: your whitelist logic here
+    ``[%noun !>(%.y)]
+  ``[%noun !>(%.n)]
+```
+
+Note this is unnecessary for unencrypted and two-party encrypted remote
+scries, only for files you publish in a security context with the
+[`%tend`](#tend) note.
+
+## Scrying
+
+Now we've looking at the publisher side, let's look at actually
+performing remote scries. There is one `$note:agent:gall` for performing
+unencrypted and multi-party encrypted remote scries, one Ames task for
+performing two-party encrypted remote scries, and two Ames tasks for
+cancelling pending remote scries. We'll look at each of these.
+
+### Tasks and Notes
+
+#### `%keen`
+
+```hoon
+[%keen secret=? spar:ames]
+```
+
+The `%keen` note performs either an unencrypted scry or a multi-party
+encrypted scry.
+
+{% callout %}
+
+Note that this is a `$note:agent:gall`, and is not to be confused with
+the Ames task of the same name. Under the hood, Gall will still use the
+`%keen` Ames task, but this way you don't have to deal with encryption
+keys. You shouldn't use the Ames task directly.
+
+{% /callout %}
+
+The `secret` boolean specifies whether it should be a multi-party
+encrypted scry or an ordinary unencrypted scry. The `spar` is a pair of
+`ship` and scry `path`.
+
+For an unencrypted remote scry to read (`%x` care) the `/sys/hoon/hoon`
+file from the `%base` desk at revision `4` in Clay (`%c`) on the
+`~sampel` ship, it would look like:
+
+```hoon
+[%pass /your/wire %keen %.n ~sampel /c/x/4/base/sys/hoon/hoon]
+```
+
+For an unencrypted scry to the `%example` agent in Gall (`%g`) of the
+`~sampel` ship at `/foo` path, revision `4`, it would look like:
+
+```hoon
+[%pass /your/wire %keen %.n ~sampel /g/x/4/example//1/foo]
+```
+
+{% callout %}
+
+Notice the `//` empty path element differentiating an agent scry from a
+Gall vane scry.
+
+Additionally, notice the `1` at the beginning of the path portion after
+the empty element. This is a path format version number introduced in
+`[%zuse 411]` to facilitate easier path format changes in the future.
+All remote scries to Gall agents must include the version number. Scries
+to places other than Gall agents are unaffected.
+
+{% /callout %}
+
+For a multi-party encrypted scry to the `%example` agent in Gall (`%g`)
+of the `~sampel` ship at the `/foo` path, revision `4` in the
+`/my/context` security context, it would look like:
+
+```hoon
+[%pass /your/wire %keen %.y ~sampel /g/x/4/example//1/my/context/foo]
+```
+
+Notice the `/my/context` security context and `/foo` path are combined
+into a single continuous path.
+
+You will receive a [`%tune`](#tune) gift from Ames with the response
+once completed.
+
+#### `%chum`
+
+```hoon
+[%chum spar]
+```
+
+The Ames `%chum` task performs a two-party encrypted remote scry. It
+behaves exactly the same as an unencrypted remote scry except that it's
+encrypted. You don't need a security context for this kind of remote
+scry & an unencrypted `%keen` can be swapped out for this without the
+publisher having to change any of their app logic. For details of the
+`spar` format, see the [`%keen` note entry above](#keen).
+
+Example:
+
+```hoon
+[%pass /your/wire %arvo %a %chum ~sampel /g/x/4/example//1/foo]
+```
+
+You will receive a [`%tune`](#tune) gift from Ames with the response
+once completed.
+
+#### `%yawn`
+
+```hoon
+[%yawn spar]
+```
+
+A `%yawn` Ames task tells Ames that *we're* no longer interest in a
+response from a pending request to the given `spar`. Ames uses the
+`duct` to determine which requests to cancel, which means the `wire`
+must be the same as the original `%chum` task or `%keen` note. Ames wi
+
+Example:
+
+```hoon
+[%pass /call/back/path %arvo %a %yawn ~sampel /g/x/4/test//foo]
+```
+
+You will receive a [`%tune`](#tune) gift from Ames with a null `roar`
+for any pending requests.
+
+#### `%wham`
+
+```hoon
+[%wham spar]
+```
+
+A `%wham` task to Ames tells Ames to cancel all pending requests to the
+given `spar`, regardless of where it came from on our ship. This will
+cancel pending requests from other agents or vanes too, so be careful.
+
+Example:
+
+```hoon
+[%pass /call/back/path %arvo %a %wham ~sampel /g/x/4/test//foo]
+```
+
+Everything on the ship with pending requests to the given `spar` will
+receive a [`%tune`](#tune) gift from Ames with a null `roar`.
+
+### Gifts
+
+There is only one kind of response you can receive from Ames for any
+kind of remote scry: a [`%tune`](#tune) gift.
+
+#### `%tune`
+
+In response to any kind of remote scry, Ames returns a `%tune` gift,
+which looks like:
+
+```hoon
+[%tune spar roar=(unit roar)]
+```
+
+The `spar` is the `ship` and `path` the request was made to, and the
+`roar` is the response. The outer `unit` of `roar` will be `~` if Ames
+doesn't have a response, but may have one in the future. Otherwise, it
+will contain a signature and the data. The data in the
+[`$roar`](/system/kernel/ames/reference/data-types#roar) may be `~`,
+meaning that there is no value at this path and will never be one.
+
+You'll receive a `%tune` whether it failed or succeeded on the target
+ship, as well as if the request was cancelled locally.
 
 ## `-keen`
 
@@ -210,7 +397,9 @@ the `%noun` mark's source code out of `~zod`'s `%kids` desk, try it!
 
 ## Additional reading
 
-- [Gall scry reference](/system/kernel/gall/reference/scry): Reference documentation of
-  Gall's vane-level and agent-level scry interface.
+- [Gall scry reference](/system/kernel/gall/reference/scry): Reference
+  documentation of Gall's vane-level and agent-level scry interface.
 
-- [Ames API reference](/system/kernel/ames/reference/tasks): Reference documentation of `task`s that can be passed to Ames, including those for remote scries.
+- [Ames API reference](/system/kernel/ames/reference/tasks): Reference
+  documentation of `task`s that can be passed to Ames, including those
+  for remote scries.


### PR DESCRIPTION
Change all instances of zuse 411 to 412, update gall & ames data types & apis for the encrypted remote scry changes, and update the remote scry guide to cover the encrypted stuff.