### PR TITLE
remote rut:by entirely

### DIFF
--- a/content/language/hoon/reference/arvo.md
+++ b/content/language/hoon/reference/arvo.md
@@ -357,7 +357,7 @@ so it contains the entire subtree rather than just one level.
   =+  .^(=arch %cy (en-beam [our %base da+now] path))
   ^-  (axal @uvI)
   :-  fil.arch
-  (~(rut by dir.arch) |=([name=@ta ~] ^$(path (snoc path name))))
+  (~(urn by dir.arch) |=([name=@ta ~] ^$(path (snoc path name))))
 [ fil=~
     dir
   { [p=~.iris q=[fil=~ dir={[p=~.hoon q=[fil=[~ 0v15.r0nos.81rq5.8t24j.vfnll.8ej0n.knuej.maetm.vr9ja.s3opn.5gtpd] dir={}]]}]]

--- a/content/language/hoon/reference/stdlib/2i.md
+++ b/content/language/hoon/reference/stdlib/2i.md
@@ -156,13 +156,6 @@ usage = "stdlib"
 slug = "#runby"
 desc = "Used in the Hoon standard library."
 
-[glossaryEntry."Transform nodes (map)"]
-name = "Transform nodes (map)"
-symbol = "rut:by"
-usage = "stdlib"
-slug = "#rutby"
-desc = "Used in the Hoon standard library.  (Deprecated 411 K)"
-
 [glossaryEntry."Listify pairs"]
 name = "Listify pairs"
 symbol = "tap:by"
@@ -1288,48 +1281,6 @@ A map.
 
 > `(map @t @)`(~(run by a) dec)
 {[p='e' q=4] [p='b' q=1] [p='d' q=3] [p='a' q=0] [p='c' q=2]}
-```
-
----
-
-### `++rut:by`
-
-Transform nodes  (Deprecated 411 K)
-
-Applies a gate `b` to nodes in map `a`. The sample of gate `b` is a key-value pair, and it produces a new value.
-
-#### Accepts
-
-`a` is a map, and is the sample of `+by`.
-
-`b` is a gate.
-
-#### Produces
-
-A map.
-
-#### Source
-
-```hoon
-++  rut
-  |*  b=gate
-  |-
-  ?~  a  a
-  [n=[p=p.n.a q=(b p.n.a q.n.a)] l=$(a l.a) r=$(a r.a)]
-```
-
-#### Examples
-
-```
-> =a `(map @ @)`(malt ~[[1 1] [2 2] [3 3] [4 4] [5 5]])
-
-> =b |=  [k=@ v=@]
-     ?:  (gth v 2)
-       (mul k v)
-     v
-
-> `(map @ @)`(~(rut by a) b)
-{[p=5 q=25] [p=1 q=1] [p=2 q=2] [p=3 q=9] [p=4 q=16]}
 ```
 
 ---


### PR DESCRIPTION
this just removes it entirely & changes the arvo example to use urn:by