### PR TITLE
Fix broken tooltip link to ++lent

### DIFF
--- a/content/courses/hoon-school/H-libraries.md
+++ b/content/courses/hoon-school/H-libraries.md
@@ -324,7 +324,7 @@ it as a way of creating a random-value arm that we'll use later on with
 `++rads:random`.
 
 With `=/  remaining  (lent unshuffled)`, we get the length of the
-unshuffled deck with {% tooltip label="++lent
+unshuffled deck with {% tooltip label="++lent"
 href="/language/hoon/reference/stdlib/2b#lent" /%}.
 
 `?:  =(remaining 1)` checks if we have only one card remaining. If


### PR DESCRIPTION
## Current Version

![image](https://github.com/urbit/docs.urbit.org/assets/13981427/9c2fa725-9122-4edc-a7ac-a8762013558f)

## Local Version After Fix

![image](https://github.com/urbit/docs.urbit.org/assets/13981427/80b49b7e-6ffb-4193-a113-007198af5b4d)
