### PR TITLE
Draft NEAR Gateways documentation

### DIFF
--- a/content/tools/_index.md
+++ b/content/tools/_index.md
@@ -37,4 +37,11 @@ and/or third-party apps, libraries and tools.
     small=true
   /%}
 
+  {% iconcard
+    title="NEAR Gateways"
+    description="Step-by-step tutorial for building and deploying NEAR apps and components on Urbit."
+    href="/tools/near-gateways"
+    small=true
+  /%}
+
 {% /grid %}

--- a/content/tools/near-gateways/_index.md
+++ b/content/tools/near-gateways/_index.md
@@ -1,0 +1,81 @@
++++
+title = "NEAR Gateways"
+weight = 999
+auto_expand = true
++++
+
+This tutorial will cover building and deploying your first Urbit-compatible [Blockchain Operating System (BOS)](https://wiki.near.org/overview/BOS/overall-bos) gateway, and deploying it to the urbit network.
+
+By the end of this tutorial you’ll be able to:
+- Set up a BOS gateway skeleton with [Urbit’s create-near-app fork](https://github.com/urbit/create-near-app).
+- Write and test Urbit-aware NEAR components with `create-near-app`.
+- Deploy Urbit-aware components to the NEAR blockchain.
+- Deploy a gateway to Urbit’s NEAR Gateways app, where people can use your gateway or mirror it to use on their own local machine.
+
+We anticipate you’re either an Urbit developer who isn’t so familiar with NEAR, or a NEAR developer who isn’t so familiar with Urbit. Either way, we only assume some familiarity with React.
+
+To make NEAR development on Urbit simple, we built an end-to-end workflow that covers development, deployment, and distribution of BOS gateways. We wanted something smaller, more opinionated, and more tightly integrated than NEAR developers might be used to. We were focussed on developing gateways, with no attention to smart contracts, so our `create-near-app` fork may not be suited to that.
+
+Once you’re familiar with this workflow, you can use whichever parts of it you like and leave the rest. If you want your gateway to interact with Urbit, the only part of this stack you need is [our NEAR Social VM fork](https://github.com/urbit/NearSocialVM), which defines an Urbit object and methods for interacting with an Urbit server.
+
+## What is BOS?
+
+NEAR’s Blockchain Operating System provides a secure way to leverage onchain React components in specialized React apps called gateways. Storing these on the NEAR blockchain only costs a few cents. The official [near.org](http://near.org) site itself is a NEAR component made of other NEAR components, with the NearOrg.HomePage component source available to read [here](https://near.org/near/widget/ComponentDetailsPage?src=near/widget/NearOrg.HomePage).
+
+If you’re not familiar with BOS, this tutorial will cover everything you need to know as it becomes relevant.
+
+## What is Urbit?
+
+Urbit is a personal server, which runs as a virtual machine on any Unix box, and a peer-to-peer network of those personal servers.
+
+An Urbit server is permanently bound to the Urbit ID that booted it, and there can only be one Urbit server per Urbit ID at any one time. Urbit ID is a decentralized identity system secured by Ethereum: your Urbit ID is an NFT you hold in your Ethereum wallet, so nobody can take your “account” away from you.
+
+Since Urbit IDs are scarce, spamming the network is prohibitively expensive. Since data packets are signed by their Urbit IDs, you can trust that messages are coming from the exact machine they claim to be. And since end-users run all their own data and software on their personal server, app developers have far fewer issues around deployment, uptime, and security to worry about.
+
+This makes Urbit an ideal setting for BOS gateways. Web 2.0 deployment platforms remain a single point of failure between end-users and the NEAR blockchain. Urbit totally removes this deployment infrastructure for hobbyist developers, commoditizes much of it for professionals, and it makes it simple for end-users to run their own server hosting gateways they want to be able to rely on.
+
+## Setting up
+
+You’ll need an Urbit server (called a “ship”) to deploy your gateway.
+
+{% callout %}
+
+Click here to get a hosted Urbit ship pre-configured to help you deploy to NEAR Gateways as fast as possible. Export the ship to your local machine, home server, or VPS at any time.
+
+{% /callout %}
+
+For development, you should probably use a locally-hosted “fakeship”; it’s not connected to the urbit network, which means you can use an ID you don’t really own. If you break it, you can just delete it and make another one for free.
+
+(If you run several of these fakeships in the same directory on your machine, they’ll automatically run as a kind of urbit “testnet”. You just need to recreate the network topology where ~tex and ~mex can send exchange packets directly, but ~samtex and ~sammex need ~tex and ~mex to be online to route packets to each other.)
+
+## Setting up a fakeship
+
+On your local machine, follow Steps 1 and 2 on this [command-line install guide](/manual/getting-started/self-hosted/cli) to download the `urbit` executable file.
+
+In the same directory you’ve installed the `urbit` executable, run this command to set up a fakeship. For this tutorial, we’ll use the Urbit ID ~zod.
+
+```
+> ./urbit -F zod
+```
+
+This command should take a few minutes to run. When the boot sequence is complete you’ll see this prompt in your fakeship’s terminal (AKA the “dojo”).
+
+```
+~zod:dojo>
+```
+
+You can shut your fakeship down at any time by typing `|exit` in the dojo. When you want to boot it up again, just run `./urbit zod` in your Unix terminal.
+
+You can control which port your fakeship is accessed from by using the `--http-port` flag while booting.
+
+```
+> ./urbit zod --http-port 8080
+```
+
+In your fakeship’s dojo, run this command to approve CORS requests from your web browser at `localhost:8081`. If you want to run your test gateway on a port other than `:8081`, you’ll have to `|cors-approve` that port too.
+
+```
+> |cors-approve 'http://localhost:8081'
+```
+
+Now that you're set up, let's create the BOS gateway itself.

--- a/content/tools/near-gateways/_index.md
+++ b/content/tools/near-gateways/_index.md
@@ -40,7 +40,7 @@ You’ll need an Urbit server (called a “ship”) to deploy your gateway.
 
 {% callout %}
 
-Click here to get a hosted Urbit ship pre-configured to help you deploy to NEAR Gateways as fast as possible. Export the ship to your local machine, home server, or VPS at any time.
+[Click here](https://redhorizon.com/join/61c3b5a7-9eba-437c-8049-b5b217625bcf) to get a hosted Urbit ship pre-configured to help you deploy to NEAR Gateways as fast as possible. Export the ship to your local machine, home server, or VPS at any time.
 
 {% /callout %}
 

--- a/content/tools/near-gateways/bos-gateway.md
+++ b/content/tools/near-gateways/bos-gateway.md
@@ -41,7 +41,7 @@ You can run `npm run dev` from the `hello-urbit` directory to preview your gatew
 
 The example components here allow you to send “pokes” and “scries” to your fakeship. For now, you can think of pokes as POST requests and scries as GET requests.
 
-In the “Poke ~zod” component, you can enter the placeholder App, Mark, and JSON values to show the following in your fakeship’s Dojo.
+In the “Poke ~zod” component, you can enter the placeholder App, Mark, and JSON values to send pokes to a ship. Entering the placeholder values in the form will show the following in your fakeship’s Dojo.
 
 ```
 < ~zod: hi ~zod

--- a/content/tools/near-gateways/bos-gateway.md
+++ b/content/tools/near-gateways/bos-gateway.md
@@ -1,5 +1,5 @@
 +++
-title = "1. Building a BOS Gateway"
+title = "1. Gateways"
 weight = 10
 template = "doc.html"
 +++

--- a/content/tools/near-gateways/bos-gateway.md
+++ b/content/tools/near-gateways/bos-gateway.md
@@ -48,7 +48,7 @@ In the “Poke ~zod” component, you can enter the placeholder App, Mark, and J
 ```
 
 Some more pokes include:
-{more}
+- **App: "hood", Mark: "helm-hi", JSON: any string**: Ping your ship and, optionally, print a message to the Dojo.
 
 The “Scry to ~zod” component will fetch some data from any app on your fakeship, assuming you’re authenticated and an endpoint exists.
 

--- a/content/tools/near-gateways/bos-gateway.md
+++ b/content/tools/near-gateways/bos-gateway.md
@@ -1,5 +1,5 @@
 +++
-title = "Building a BOS Gateway"
+title = "1. Building a BOS Gateway"
 weight = 10
 template = "doc.html"
 +++

--- a/content/tools/near-gateways/bos-gateway.md
+++ b/content/tools/near-gateways/bos-gateway.md
@@ -1,0 +1,102 @@
++++
+title = "Building a BOS Gateway"
+weight = 10
+template = "doc.html"
++++
+
+Run this npx command to create a new gateway.
+
+```
+> npx @urbit/create-near-app
+```
+
+By default, this will create a new directory called `hello-urbit`.
+
+## Configuring your development environment
+
+In production you’ll be serving your gateway from an Urbit ship, but in this testing environment your gateway isn’t connected to your ship by default. To test components which use the `Urbit` method, you’ll need to specify which ship you want to talk to on which port.
+
+You can specify this in the `.env` file at the root of the `hello-urbit` project. By default, we specify a fakeship called ~zod, which is running on `localhost:8080` and has the access code `lidlut-tabweb-pillex-ridrup`.
+
+```
+SHIP=zod
+URL=http://localhost:8080
+CODE=lidlut-tabwed-pillex-ridrup
+```
+
+Fakeships’ access codes are deterministic — every fake ~zod has the same code, every fake ~bud has the same code, etc. — so you don’t need to worry about leaking this info. You should, however, be careful to keep your real ships’ info in this `.env` file and avoid putting it in code that’s going to be uploaded to the blockchain.
+
+If you’re using a ship that’s not a fake ~zod, you can get your ship’s access code by entering `+code` in the Dojo.
+
+```
+> +code
+lidlut-tabwed-pillex-ridrup
+```
+
+(If you’ve not done so already, you can use this access key to log into your fakeship from your web browser.)
+
+## Using the example app
+
+You can run `npm run dev` from the `hello-urbit` directory to preview your gateway. This will automatically open the dev server in your browser at `localhost:8081`.
+
+The example components here allow you to send “pokes” and “scries” to your fakeship. For now, you can think of pokes as POST requests and scries as GET requests.
+
+In the “Poke ~zod” component, you can enter the placeholder App, Mark, and JSON values to show the following in your fakeship’s Dojo.
+
+```
+< ~zod: hi ~zod
+```
+
+Some more pokes include:
+{more}
+
+The “Scry to ~zod” component will fetch some data from any app on your fakeship, assuming you’re authenticated and an endpoint exists.
+
+Some examples include:
+- **App: “docket”, Path: “/charges”**: See information about the apps installed on your ship.
+
+## Developing and testing your BOS gateway
+
+You can now start modifying this default gateway. This gateway is an ideal environment to develop Urbit-aware components to deploy on the NEAR blockchain, or develop an entire gateway. Let’s go over the structure of the default gateway and see where you can find everything you need.
+
+The default gateway will have this structure. The most important parts are the gateway itself (`/src`), and your components (`/apps`).
+
+```
+.
+├── LICENSE
+├── README.md
+├── apps
+│   ├── bos.config.json
+│   └── widget
+│       ├── app.jsx
+│       └── components
+│           ├── header.jsx
+│           ├── pokeUrbit.jsx
+│           └── scryUrbit.jsx
+├── build
+│   └── data.json
+├── config
+│   ├── paths.js
+│   ├── presets
+│   │   ├── loadPreset.js
+│   │   └── webpack.analyze.js
+│   ├── webpack.development.js
+│   └── webpack.production.js
+├── package.json
+├── pnpm-lock.yaml
+├── public
+│   └── index.html
+├── src
+│   ├── App.js
+│   ├── App.scss
+│   ├── hooks
+│   │   ├── useHashRouterLegacy.js
+│   │   └── useScrollBlock.js
+│   ├── index.css
+│   ├── index.js
+│   └── pages
+│       └── ExamplePage.js
+└── webpack.config.js
+```
+
+Next, let's talk about `Widget`s and components.

--- a/content/tools/near-gateways/bos-gateway.md
+++ b/content/tools/near-gateways/bos-gateway.md
@@ -47,13 +47,12 @@ In the “Poke ~zod” component, you can enter the placeholder App, Mark, and J
 < ~zod: hi ~zod
 ```
 
-Some more pokes include:
-- **App: "hood", Mark: "helm-hi", JSON: any string**: Ping your ship and, optionally, print a message to the Dojo.
-
 The “Scry to ~zod” component will fetch some data from any app on your fakeship, assuming you’re authenticated and an endpoint exists.
 
 Some examples include:
 - **App: “docket”, Path: “/charges”**: See information about the apps installed on your ship.
+- **App: “groups”, Path: “/groups”**: See what Tlon groups you're in, including info about channels and roles.
+- **App: “storage”, Path: “/configuration”**: S3 bucket configuration for your ship.
 
 If you have the NEAR Gateways app on your ship, you can poke its `%near-storage` agent to store stringified JSON data. Gateways on Urbit can use this to store user data like settings. (Every Urbit app and gateway has root access to the ship, so don't store anything sensitive here. `%near-storage` only offers security through obscurity.)
 - **App: "near-storage", Mark: "near-store"**: Poke the `%near-storage` agent to add or remove data. Add data with `{"set-item": {"key": "foo", "val": "bar"}}`, where `"foo"` can be any string and `"bar"` can be any JSON object. Remove data by its key with `{"remove-item": {"key": "foo"}}`.

--- a/content/tools/near-gateways/bos-gateway.md
+++ b/content/tools/near-gateways/bos-gateway.md
@@ -55,6 +55,10 @@ The “Scry to ~zod” component will fetch some data from any app on your fakes
 Some examples include:
 - **App: “docket”, Path: “/charges”**: See information about the apps installed on your ship.
 
+If you have the NEAR Gateways app on your ship, you can poke its `%near-storage` agent to store stringified JSON data. Gateways on Urbit can use this to store user data like settings. (Every Urbit app and gateway has root access to the ship, so don't store anything sensitive here. `%near-storage` only offers security through obscurity.)
+- **App: "near-storage", Mark: "near-store"**: Poke the `%near-storage` agent to add or remove data. Add data with `{"set-item": {"key": "foo", "val": "bar"}}`, where `"foo"` can be any string and `"bar"` can be any JSON object. Remove data by its key with `{"remove-item": {"key": "foo"}}`.
+- **App: "near-storage", Path: any key**: Scry data you stored in `%near-storage`. After sending the `%set-item` poke above, scrying the path `/foo` would return `'bar'`. Scrying a key that does not exist will return an empty string.
+
 ## Developing and testing your BOS gateway
 
 You can now start modifying this default gateway. This gateway is an ideal environment to develop Urbit-aware components to deploy on the NEAR blockchain, or develop an entire gateway. Let’s go over the structure of the default gateway and see where you can find everything you need.

--- a/content/tools/near-gateways/deploying.md
+++ b/content/tools/near-gateways/deploying.md
@@ -1,5 +1,5 @@
 +++
-title = "Deploying BOS Gateways and Components on Urbit"
+title = "3. Deploying BOS Gateways and Components on Urbit"
 weight = 12
 template = "doc.html"
 +++

--- a/content/tools/near-gateways/deploying.md
+++ b/content/tools/near-gateways/deploying.md
@@ -61,7 +61,7 @@ To deploy your gateway to the NEAR Gateways app, you’ll need to upload the glo
 
 {% callout %}
 
-If you get a Red Horizon ship at this link, you’ll have an Urbit app called Silo pre-loaded. To get S3 working with this app, you’ll need to click “Set S3 credentials” in your Red Horizon dashboard. This will set up S3 bucket for your whole ship; Silo will detect when this changes and configure to the new bucket. When that’s all working, upload your glob to any folder and click to chain icon to grab the link. (The correct link should end in `.glob`.)
+If you get a Red Horizon ship at [this link](https://redhorizon.com/join/61c3b5a7-9eba-437c-8049-b5b217625bcf), you’ll have an Urbit app called Silo pre-loaded. To get S3 working with this app, you’ll need to click “Set S3 credentials” in your Red Horizon dashboard. This will set up S3 bucket for your whole ship; Silo will detect when this changes and configure to the new bucket. When that’s all working, upload your glob to any folder and click to chain icon to grab the link. (The correct link should end in `.glob`.)
 
 {% /callout %}
 

--- a/content/tools/near-gateways/deploying.md
+++ b/content/tools/near-gateways/deploying.md
@@ -1,5 +1,5 @@
 +++
-title = "3. Deploying BOS Gateways and Components on Urbit"
+title = "3. Deploying"
 weight = 12
 template = "doc.html"
 +++

--- a/content/tools/near-gateways/deploying.md
+++ b/content/tools/near-gateways/deploying.md
@@ -6,7 +6,7 @@ template = "doc.html"
 
 To deploy your gateway on Urbit, you’ll need to create a [glob](https://docs.urbit.org/userspace/apps/reference/dist/glob) containing the bundled frontend code and assets. After that, you can upload your gateway to the NEAR Gateways app for users on Urbit to use and mirror for themselves.
 
-### Creating the frontend glob
+## Creating the frontend glob
 
 First, run `npm run build`.
 
@@ -55,7 +55,7 @@ You should see something like this in the dojo:
 
 You can now `cd` to `/path/to/zod/.urb/put` where you’ll find a file like `glob-0v5.fdf99.nph65.qecq3.ncpjn.q13mb.glob`. This is your bundled frontend which we’ll upload to NEAR Gateways. Everything between `glob-` and `.glob` is a hash of the file’s content. You won’t need it for the rest of this process, so you could rename the file anything you like.
 
-### Deploying to NEAR Gateways
+## Deploying to NEAR Gateways
 
 To deploy your gateway to the NEAR Gateways app, you’ll need to upload the glob to an S3 bucket or some other publicly-available endpoint.
 
@@ -73,7 +73,7 @@ Once your glob is uploaded, open the NEAR Gateways app on your live ship and fil
 
 Click “Publish Gateway” and wait for your gateway to upload. This could take some time, but you don’t have to keep the window open while you wait; your ship is processing the glob in the background.
 
-### Sharing your gateway
+## Sharing your gateway
 
 The NEAR Gateways app gossips your gateways among your pals. What does that mean?
 

--- a/content/tools/near-gateways/deploying.md
+++ b/content/tools/near-gateways/deploying.md
@@ -1,0 +1,86 @@
++++
+title = "Deploying BOS Gateways and Components on Urbit"
+weight = 12
+template = "doc.html"
++++
+
+To deploy your gateway on Urbit, you’ll need to create a [glob](https://docs.urbit.org/userspace/apps/reference/dist/glob) containing the bundled frontend code and assets. After that, you can upload your gateway to the NEAR Gateways app for users on Urbit to use and mirror for themselves.
+
+### Creating the frontend glob
+
+First, run `npm run build`.
+
+Now we’ll run the fakeship’s built-in `make-glob` thread to make the glob. In your fakeship’s dojo run:
+
+```
+> |merge %work our %base
+> |mount %work
+```
+
+A “desk” in Urbit is a software package containing all its dependencies. An Urbit app is a desk and, optionally, a frontend glob in cases where the frontend isn’t generated inside the desk.
+
+At this point, you’ve just created the desk %work including essential dependencies from %base. When you `|mount` the %work desk, you’re making it visible to your OS’s filesystem. You can now see the desk in `/zod/work`, but since this is a new desk there won’t be anything interesting in there. (Run `|mount %base` if you want to see the entire Urbit OS kernel.)
+
+In your filesystem, create a new folder in `/zod/work` called something like `/hello-urbit`. You can now copy the contents of your gateway’s `/dist` folder to this `/hello-urbit` folder.
+
+```
+> cp -r /path/to/hello-urbit/dist/* /path/to/zod/work/hello-urbit
+```
+
+In your fakeship’s dojo, `|commit` your %work desk.
+
+```
+> |commit %work
+```
+
+Then make the glob, using the `make-glob` thread in the %landscape desk.
+
+```
+> -landscape!make-glob %work /hello-urbit
+```
+
+You should see something like this in the dojo:
+
+```
+[ %globbed
+  { /156.38d4ccbba1878fc86446.bundle/js
+    /assets/index-390be12d/js
+    ...
+    /index/html
+  }
+]
+> -landscape!make-glob %work /hello-urbit
+0
+```
+
+You can now `cd` to `/path/to/zod/.urb/put` where you’ll find a file like `glob-0v5.fdf99.nph65.qecq3.ncpjn.q13mb.glob`. This is your bundled frontend which we’ll upload to NEAR Gateways. Everything between `glob-` and `.glob` is a hash of the file’s content. You won’t need it for the rest of this process, so you could rename the file anything you like.
+
+### Deploying to NEAR Gateways
+
+To deploy your gateway to the NEAR Gateways app, you’ll need to upload the glob to an S3 bucket or some other publicly-available endpoint.
+
+{% callout %}
+
+If you get a Red Horizon ship at this link, you’ll have an Urbit app called Silo pre-loaded. To get S3 working with this app, you’ll need to click “Set S3 credentials” in your Red Horizon dashboard. This will set up S3 bucket for your whole ship; Silo will detect when this changes and configure to the new bucket. When that’s all working, upload your glob to any folder and click to chain icon to grab the link. (The correct link should end in `.glob`.)
+
+{% /callout %}
+
+Once your glob is uploaded, open the NEAR Gateways app on your live ship and fill out the form with your gateway’s details:
+- Your gateway’s title
+- The URL for your uploaded glob
+- The URL for a thumbnail preview image (optional, but encouraged)
+- A brief description of your gateway
+
+Click “Publish Gateway” and wait for your gateway to upload. This could take some time, but you don’t have to keep the window open while you wait; your ship is processing the glob in the background.
+
+### Sharing your gateway
+
+The NEAR Gateways app gossips your gateways among your pals. What does that mean?
+
+Urbit’s third-party Pals app serves as one friends list which any app can interact with. Several popular Urbit apps leverage a pals-based gossip mechanism to pass information around, most often to the people in your friends list and the people in their friends list.
+
+The NEAR Gateways app uses this to distribute gateways without the need for a centralized repository. We hard-coded a subscription to ~bitdeg’s gateways in there, but ~bitdeg won’t relay other ships’ gateways to you. Your Red Horizon ship comes pre-configured with one pal, ~palweb-dozzod-doldys, a ship run by Red Horizon which accepts all friend requests that come in.
+
+As soon as you upload your gateway, it’ll be sent to ~palweb-dozzod-doldys. If that ship has NEAR Gateways installed it’ll pass your gateway along to its first-degree pals.
+
+If you want to tell us about your gateway or find some more NEAR devs on Urbit, you can join our NEAR group by searching “~bitdeg” in the Tlon app’s Discovery page. If you’re using one of our Red Horizon ships, you’re already in this group as well as a selection of others. See you on the network!

--- a/content/tools/near-gateways/near-components.md
+++ b/content/tools/near-gateways/near-components.md
@@ -1,5 +1,5 @@
 +++
-title = "NEAR Components"
+title = "2. NEAR Components"
 weight = 11
 template = "doc.html"
 +++

--- a/content/tools/near-gateways/near-components.md
+++ b/content/tools/near-gateways/near-components.md
@@ -1,0 +1,162 @@
++++
+title = "NEAR Components"
+weight = 11
+template = "doc.html"
++++
+
+The `/src` folder isn’t so different from any other React app. The main difference is the use of NEAR components, which you’ll import from the NEAR blockchain or from your local testing environment.
+
+In either case, you’ll import each of your components through a component called `Widget`.
+
+```javascript
+import { Widget } from 'near-social-vm'
+```
+
+The `Widget` component has several optional attributes, but for now you only need to know about three: `src`, `props`, and `code`.
+
+The `src` attribute is the path to your component’s JavaScript code, stored onchain.
+
+```JSX
+<Widget src='influencer.testnet/widget/Greeter' />
+```
+
+The `props` attribute will be JSON data passed into a component. For example, this will return a component reading "3 cheers for Anna!"
+
+```JSX
+ <Widget src='influencer.testnet/widget/Greeter' props={{name: 'Anna', amount: 3}} />
+```
+
+The `code` attribute can accept stringified code and render it to the DOM. One highlight of our `create-near-app` fork is that we use this as an alternative to `src` to render local components from `/build/data.json`, which simulates onchain data. This makes it trivial to write and test local components which are ready to copy-paste onto the blockchain.
+
+## Writing local components
+
+The `/components` folder is where you’ll write new components. NEAR components mostly look like React components, but not wrapped in an exported class or function like `MyComponent()`. Out of the box, BOS supports [styled components](https://styled-components.com/); you don’t have to use them, but you might see them if you look at other NEAR components.
+
+Here’s a simple example of a NEAR component.
+
+```JSX
+const userName = props.userName || "Anna";
+const [count, setCount] = useState(1);
+
+return (
+  <div>
+    <p> {count} cheers for {userName}! </p>
+    <button onClick={() => setCount(count + 1)}>Cheers!</button>
+  </div>
+);
+```
+
+The only requirement for a NEAR component is a return statement. Usually these return JSX like a React component, but you can return any JavaScript you want.
+
+## Testing components
+
+When you’ve finished writing your components, you can make sure they build with this script.
+
+```
+> npm run component-build
+```
+
+This creates a file `/build/data.json` which encodes all your gateway’s components in one JSON file, simulating the component data you’d find onchain.
+
+You can see those components being referenced in `Widget`s in `/pages/ExamplePage.js`, which is the homepage of the example gateway.
+
+Now in your `Widget`s, you can import these local components by passing the JSON into the `code` attribute.
+
+```JSX
+import React from 'react'
+import { Widget } from 'near-social-vm'
+import localComponents from '../../build/data.json'
+
+function ExamplePage({ api }) {
+  const localUrbitHeader = localComponents['local.components/widget/components.header']
+  const localPokeUrbit = localComponents['local.components/widget/components.pokeUrbit']
+  const localScryUrbit = localComponents['local.components/widget/components.scryUrbit']
+
+  return (
+    <div>
+      <Widget
+        code={localUrbitHeader.code}
+      />
+        <div style={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          height: '500px',
+          width: '75vw',
+          margin: 'auto'
+        }}>
+          <div>
+            <Widget
+              // src={'urbitlabs.near/widget/pokeUrbit'}
+              code={localPokeUrbit.code}
+              props={{ api: api }}
+            />
+          </div>
+          <div>
+            <Widget
+              // src={'urbitlabs.near/widget/scryUrbit'}
+              code={localScryUrbit.code}
+              props={{ api: api }}
+            />
+          </div>
+        </div>
+    </div>
+  )
+}
+
+export default ExamplePage
+```
+
+When you want to see your components in action, you can run a dev server with `npm run dev`. (This script includes npm run build-component, so you’ll always be working with the latest version of your code.)
+
+## Urbit-aware NEAR components
+
+This gateway uses a fork of the NEAR Social VM that includes an `Urbit` object, and that object has three methods you can use to interact with your ship. The main ones are `Urbit.poke()` and `Urbit.scry()`.
+
+### poke(app, mark, json, OnSuccess, OnError)
+
+Send a poke (like a POST request) to the local ship.
+
+This method takes the `app` you’d like to send a poke to, the `mark` that tells the app what kind of poke it is, and a `json` object with the data you’d like to send. (Note: as in the example below, the json argument can also be a string.)
+
+The `OnSuccess` and `OnError` parameters are optional. These allow you to pass in callback functions which will run after the poke has succeeded or failed on the Urbit server.
+
+```Javascript
+Urbit.poke('hood', 'helm-hi', 'hello urbit!')
+.then(res => {
+  // code
+})
+```
+
+An app’s `mark`s are defined by the developer, so you’ll have to read the app’s source code or documentation to find those, as well as the keys the `json` object should have.
+
+Take a look at [this example Urbit app](https://docs.urbit.org/courses/app-school/6-pokes) from the App School course to see marks in context. With JSON keys, the key count in your JSON object should correspond to something like `count.action` or `count.act` in the app. If you want to understand more about the code in that example, it’s never been easier to [learn Hoon](https://docs.urbit.org/courses/hoon-school), Urbit’s native functional programming language.
+
+### scry(app, path)
+
+Send a scry (like a GET request) to the local ship.
+
+This method takes the `app` you’d like to scry, and the `path` of the endpoint in that app. You can find the endpoints for a given app in the `on-peek` section of the file at `/zod/<desk-name>/app/<app-name>.hoon`.
+
+As far as frontend developers are concerned a tuple like `[%x %charges ~]` corresponds to a scry path like `/charges`. A tuple like `[%x %foo %bar ~]` corresponds to a scry path like `/foo/bar`, etc.
+
+```Javascript
+Urbit.scry('docket', '/charges')
+.then(res => {
+  // code
+})
+```
+
+(Note that in both methods, the `app` argument corresponds to the name of a “Gall agent” and not a desk. An agent is a combined state machine and API that serves as the backend for an app, and that helps make Urbit software composable by default. An agent could be a small app on its own, or it could be one of several state machines that run a larger app. In any case a desk is a package containing an app. A desk’s agents are the files in its `/app` folder.)
+
+### setApi(api)
+
+Treat this as boilerplate. When you write an Urbit-aware NEAR component, paste in the following two lines at the top and add destructured props to the first line as needed.
+
+```Javascript
+let { api } = props
+Urbit.setApi(api)
+```
+
+With the `api` prop, your component can use `api.ship` and `api.url` to access the user’s Urbit ID and the host machine’s URL respectively. These are useful for UI text and navigation.


### PR DESCRIPTION
Adds a step-by-step tutorial in the Tools section on how to build and deploy NEAR gateways and components with `urbit/create-near-app` and NEAR Gateways.