### PR TITLE
Correct summary of Iris

### DIFF
--- a/content/glossary/vane.md
+++ b/content/glossary/vane.md
@@ -20,9 +20,9 @@ A **vane** is an [Arvo](/glossary/arvo) kernel module that performs essential sy
 - [Clay](/glossary/clay), the filesystem, revision-control and build
   system vane.
 - [Dill](/glossary/dill), the terminal-driver vane.
-- [Eyre](/glossary/eyre), the HTTP vane.
+- [Eyre](/glossary/eyre), the HTTP server vane.
 - [Gall](/glossary/gall), the application vane.
-- [Iris](/glossary/iris), the server HTTP vane.
+- [Iris](/glossary/iris), the HTTP client vane.
 - [Jael](/glossary/jael), the security vane.
 - [Khan](/glossary/khan), the control vane.
 - [Lick](/glossary/lick), the interprocess communication (IPC) vane.


### PR DESCRIPTION
The current docs say:

>[Iris](https://docs.urbit.org/glossary/iris), the server HTTP vane.

Source: https://docs.urbit.org/glossary/vane

This seems totally incorrect. Eyre is the HTTP server vane. Iris is for creating HTTP _clients_. This PR corrects the definition of Iris and clarifies Eyre.