### PR TITLE
Revert "jar: update 'get' docs to reflect what it produces"

### DIFF
--- a/content/language/hoon/reference/stdlib/2j.md
+++ b/content/language/hoon/reference/stdlib/2j.md
@@ -114,7 +114,7 @@ A core.
 
 Grab value by key
 
-Produces the list at key `b` in jar `a` if it exists.
+Produces the list at key `b` in jar `a`.
 
 #### Accepts
 
@@ -124,7 +124,7 @@ Produces the list at key `b` in jar `a` if it exists.
 
 #### Produces
 
-A unit.
+A `list`.
 
 #### Source
 


### PR DESCRIPTION
Reverts urbit/docs.urbit.org#106 - the original docs were correct