### PR TITLE
Minor Hoon School Typo Fixes

### DIFF
--- a/content/courses/hoon-school/F-cores.md
+++ b/content/courses/hoon-school/F-cores.md
@@ -426,7 +426,7 @@ So legs are for data and arms are for computations.  But what
 _specifically_ is an arm, and how is it used for computation?  Let's
 begin with a preliminary explanation that we'll refine later.
 
-An {% tooltip label="arm" href="/glossary/arm" /%}} is some expression
+An {% tooltip label="arm" href="/glossary/arm" /%} is some expression
 of Hoon encoded as a noun.  (By 'encoded as a noun' we literally mean:
 'compiled to a Nock formula'.  But you don't need to know anything about
 {% tooltip label="Nock" href="/glossary/nock" /%} to understand Hoon.)

--- a/content/courses/hoon-school/M-typecheck.md
+++ b/content/courses/hoon-school/M-typecheck.md
@@ -409,7 +409,7 @@ of the `?` family are used for branch-specialized type inference.  The
 href="/language/hoon/reference/rune/wut#-wutpat" /%}, `?^` {% tooltip
 label="wutket" href="/language/hoon/reference/rune/wut#-wutket" /%}, and
 `?~` {% tooltip label="wutsig"
-href="/language/hoon/reference/rune/wut#-wutket" /%} conditionals each
+href="/language/hoon/reference/rune/wut#-wutsig" /%} conditionals each
 take three subexpressions, which play the same basic role as the
 corresponding subexpressions of `?:` wutcol—the first is the test
 condition, which evaluates to a flag `?`.  If the test condition is


### PR DESCRIPTION
3d53b81ecb1ead6decf5e7fe631bf5289b43b46b - Fixes a wrong reference to wutket instead of wutsig in the typechecking lesson
3f86b0a992729b9629cf95c4b57f0ca9783252e0 - Removes and extra curly bracket in the cores lesson