### PR TITLE
Fix errors in the parsing docs

### DIFF
--- a/content/courses/hoon-school/Q2-parsing.md
+++ b/content/courses/hoon-school/Q2-parsing.md
@@ -41,7 +41,7 @@ we have to wade directly into a sea of new types and processes.  To wit:
 -   A `hair` is the position in the text the parser is at, as a cell of
     column & line, `[p=@ud q=@ud]`.
 -   A `nail` is parser input, a cell of `hair` and `tape`.
--   An `edge` is parser output, a cell of `hair` and a `unit` of `hair`
+-   An `edge` is parser output, a cell of `hair` and a `unit` of `*`
     and `nail`.  (There are some subtleties around failure-to-parse here
     that we'll defer a moment.)
 -   A `rule` is a parser, a gate which applies a `nail` to yield an

--- a/content/courses/hoon-school/Q2-parsing.md
+++ b/content/courses/hoon-school/Q2-parsing.md
@@ -39,7 +39,7 @@ we have to wade directly into a sea of new types and processes.  To wit:
 -   A {% tooltip label="tape" href="/glossary/tape" /%} is the string to
     be parsed.
 -   A `hair` is the position in the text the parser is at, as a cell of
-    column & line, `[p=@ud q=@ud]`.
+    line & column, `[p=@ud q=@ud]`.
 -   A `nail` is parser input, a cell of `hair` and `tape`.
 -   An `edge` is parser output, a cell of `hair` and a `unit` of `*`
     and `nail`.  (There are some subtleties around failure-to-parse here

--- a/content/language/hoon/guides/parsing.md
+++ b/content/language/hoon/guides/parsing.md
@@ -173,7 +173,7 @@ We note that `p.edg` is `[p=1 q=2]`, indicating that the next character to be
 parsed is in line 1, column 2. `q.edg` is not null, indicating that parsing
 succeeded. `p.q.edg` is `'a'`, which is the result of the parse. `p.q.q.edg` is the same as `p.edg`, which is always the case for
 `rule`s built using standard library functions when parsing succeeds. Lastly,
-`q.q.edg` is `"bc"`, which is the part of the input `tape` that has yet to be parsed.
+`q.q.q.edg` is `"bc"`, which is the part of the input `tape` that has yet to be parsed.
 
 Now let's see what happens when parsing fails.
 
@@ -208,7 +208,7 @@ Let's see what happens when we successfully parse the entire input `tape`.
 line 1, column 4. Of course, this does not exist since the input `tape` was only
 3 characters long, so this actually indicates that the entire `tape` has been
 successfully parsed (since the `hair` does not advance in the case of failure).
-`p.q.edg` is `'abc'`, as expected. `q.q.edg` is `""`, indicating that nothing
+`p.q.edg` is `'abc'`, as expected. `q.q.q.edg` is `""`, indicating that nothing
 remains to be parsed.
 
 What happens if we only match some of the input `tape`?

--- a/content/language/hoon/guides/parsing.md
+++ b/content/language/hoon/guides/parsing.md
@@ -100,7 +100,7 @@ A `hair` is a pair of `@ud` used to keep track of what has already been parsed
 for stack tracing purposes. This allows the parser to reveal where the problem
 is in case it hits something unexpected during parsing.
 
-`p` represents the column and `q` represents the line.
+`p` represents the line and `q` represents the column.
 
 ### `nail`
 

--- a/content/language/hoon/guides/parsing.md
+++ b/content/language/hoon/guides/parsing.md
@@ -267,7 +267,7 @@ is `%foo`.
 
 ```
 > ((cold %foo (just 'a')) [[1 1] "abc"])
-[p=[p=1 q=2] q=[~ u=[p=%foo q=[p=[p=1 q=2] q="bc"]]]]
+[p=[p=1 q=2] q=[~ [p=%foo q=[p=[p=1 q=2] q="bc"]]]]
 ```
 
 One common scenario where `+cold` sees play is when writing [command line

--- a/content/language/hoon/guides/parsing.md
+++ b/content/language/hoon/guides/parsing.md
@@ -134,9 +134,9 @@ of the original input `tape `up to which the text has been parsed. If parsing
 failed, `p` will be the first `hair` at which parsing failed.
 
 `q` may be `~`, indicating that parsing has failed .
-If parsing did not fail, `p.q` is the data structure that is the result of the
-parse up to this point, while `q.q` is the `nail` which contains the remainder
-of what is to be parsed. If `q` is not null, `p` and `p.q.q` are identical.
+If parsing did not fail, `p.u.q` is the data structure that is the result of the
+parse up to this point, while `q.u.q` is the `nail` which contains the remainder
+of what is to be parsed. If `q` is not null, `p` and `p.q.u.q` are identical.
 
 ### `rule`
 

--- a/content/language/hoon/guides/parsing.md
+++ b/content/language/hoon/guides/parsing.md
@@ -134,9 +134,9 @@ of the original input `tape `up to which the text has been parsed. If parsing
 failed, `p` will be the first `hair` at which parsing failed.
 
 `q` may be `~`, indicating that parsing has failed .
-If parsing did not fail, `p.u.q` is the data structure that is the result of the
-parse up to this point, while `q.u.q` is the `nail` which contains the remainder
-of what is to be parsed. If `q` is not null, `p` and `p.q.u.q` are identical.
+If parsing did not fail, `p.q` is the data structure that is the result of the
+parse up to this point, while `q.q` is the `nail` which contains the remainder
+of what is to be parsed. If `q` is not null, `p` and `p.q.q` are identical.
 
 ### `rule`
 


### PR DESCRIPTION
Here are corrections to some small errors I found in the parsing docs.

There's another issue I haven't addressed here which I'd like to get feedback on. In an actual `edge`, `q.edg` is a `unit`, meaning all the references in the docs to `q.q.q.edg` (the remaining tape to be parsed) should actually be `q.q.u.q.edg`.

So my question is, should I go through and update all the references and dojo outputs in these pages to accurately reflect this `u` face in the `unit`, or just leave it as it is (which might be more readable)?

If we're going to update the faces, it should probably be in this PR, I would think.