### PR TITLE
remove roadmap nav item and references

### DIFF
--- a/content/courses/core-academy/ca03.md
+++ b/content/courses/core-academy/ca03.md
@@ -422,7 +422,7 @@ We'll see more about this in `ca05` when we look at the structure of Vere.
 
 ### Breadth-First Move Ordering
 
-Imminent on the roadmap is [breadth-first move ordering](https://roadmap.urbit.org/project/breadth-first-moves) ([current PR](https://github.com/urbit/urbit/pull/6775)).  What does this mean?  (Much of this section quotes [~wicdev-wisryt's #6041 PR](https://github.com/urbit/urbit/pull/6041) description.)
+Planned for the future is breadth-first move ordering ([current PR](https://github.com/urbit/urbit/pull/6775)).  What does this mean?  (Much of this section quotes [~wicdev-wisryt's #6041 PR](https://github.com/urbit/urbit/pull/6041) description.)
 
 Arvo currently orders moves by depth first.  Visually, when evaluating depth-first an event may look like this:
 

--- a/content/courses/core-academy/ca05.md
+++ b/content/courses/core-academy/ca05.md
@@ -44,7 +44,7 @@ The serf process is the Nock runtime and bears responsible for:
 - Snapshotting
 - Noun allocation for Arvo
 
-[The Mars/Urth split](https://roadmap.urbit.org/project/mars-urth) reframes the worker process so that it includes the event log with the current serf responsibility (“Mars”), thus enabling online event log management and truncation.
+The Mars/Urth split reframes the worker process so that it includes the event log with the current serf responsibility (“Mars”), thus enabling online event log management and truncation.
 
 ### The Structure of Vere’s Source
 

--- a/src/components/IntraNav.jsx
+++ b/src/components/IntraNav.jsx
@@ -19,11 +19,11 @@ const sites = [
   //   href: "https://urbit.foundation",
   //   theme: "mos",
   // },
-  {
-    title: "Roadmap",
-    href: "https://roadmap.urbit.org",
-    theme: "mos-light",
-  },
+  // {
+  //   title: "Roadmap",
+  //   href: "https://roadmap.urbit.org",
+  //   theme: "mos-light",
+  // },
   {
     title: "Technical Journal",
     href: "https://ustj.urbit.org",


### PR DESCRIPTION
Removes the roadmap entry from the nav dropdown menu and removes links to it from a couple of Core Academy pages.