### PR TITLE
tooltips: change to ordinary markdown links

### DIFF
--- a/content/courses/hoon-school/B-syntax.md
+++ b/content/courses/hoon-school/B-syntax.md
@@ -33,7 +33,7 @@ An
 is a combination of characters that a language interprets and evaluates
 to produce a value.  All Hoon programs are built of expressions, rather
 like mathematical equations.  Hoon expressions are built along a
-backbone of {% tooltip label="runes" href="/glossary/rune" /%}, which
+backbone of [runes](/glossary/rune), which
 are two-character symbols that act like keywords in other programming
 languages to define the syntax, or grammar, of the expression.
 
@@ -56,19 +56,18 @@ smaller expressions.  Complex expressions are made up of smaller
 expressions (which are called **subexpressions**).
 
 The Urbit operating system hews to a conceptual model wherein each
-expression takes place in a certain context (the {% tooltip
-label="subject" href="/glossary/subject" /%}).  While sharing a lot of
-practicality with other programming paradigms and platforms, Urbit's
-model is mathematically well-defined and unambiguously specified.  Every
+expression takes place in a certain context (the
+[subject](/glossary/subject)).  While sharing a lot of practicality with
+other programming paradigms and platforms, Urbit's model is
+mathematically well-defined and unambiguously specified.  Every
 expression of Hoon is evaluated relative to its subject, a piece of data
 that represents the environment, or the context, of an expression.
 
-At its root, Urbit is completely specified by {% tooltip label="Nock"
-href="/glossary/nock" /%}, sort of a machine language for the Urbit
-virtual machine layer and event log.  However, Nock code is basically
-unreadable (and unwriteable) for a human.  [One worked
-example](/language/nock/examples/decrement) yields, for decrementing a
-value by one, the Nock formula:
+At its root, Urbit is completely specified by [Nock](/glossary/nock),
+sort of a machine language for the Urbit virtual machine layer and event
+log.  However, Nock code is basically unreadable (and unwriteable) for a
+human.  [One worked example](/language/nock/examples/decrement) yields,
+for decrementing a value by one, the Nock formula:
 
 ```hoon
 [8 [1 0] 8 [1 6 [5 [0 7] 4 0 6] [0 6] 9 2 [0 2] [4 0 6] 0 7] 9 2 0 1]
@@ -97,17 +96,17 @@ In a very similar sense, everything in a Hoon program is an atom or a
 bond.  Metaphorically, a Hoon program is a complex molecule, a digital
 chemistry that describes one mathematical representation of data.
 
-The most general data category in Hoon is a {% tooltip label="noun"
-href="/glossary/noun" /%}.  This is just about as broad as saying
-“thing”, so let's be more specific:
+The most general data category in Hoon is a [noun](/glossary/noun).
+This is just about as broad as saying “thing”, so let's be more
+specific:
 
 > A noun is an atom or a cell.
 
 Progress?  We can say, in plain English, that
 
-- An {% tooltip label="atom" href="/glossary/atom" /%} is a non-negative
+- An [atom](/glossary/atom) is a non-negative
   integer number (0 to +∞), e.g. `42`.
-- A {% tooltip label="cell" href="/glossary/cell" /%} is a pair of two
+- A [cell](/glossary/cell) is a pair of two
   nouns, written in square brackets, e.g. `[0
   1]`.
 
@@ -118,9 +117,9 @@ Nock rules to change the noun in well-defined mechanical ways.
 ### Atoms
 
 If an atom is a non-negative number, how do we represent anything else?
-Hoon provides each atom an {% tooltip label="aura" href="/glossary/aura"
-/%} , a tag which lets you treat a number as text, time, date, Urbit
-address, IP address, and much more.
+Hoon provides each atom an [aura](/glossary/aura) , a tag which lets you
+treat a number as text, time, date, Urbit address, IP address, and much
+more.
 
 An aura always begins with `@` pat, which denotes an atom (as opposed to
 a cell, `^` ket, or the general noun, `*` tar).  The next letter or
@@ -164,8 +163,7 @@ of representing the same underlying data values.
 There's a special value that recurs in many contexts in Hoon:  `~` sig
 is the null or zero value.
 
-The `^-` {% tooltip label="kethep"
-href="/language/hoon/reference/rune/ket#--kethep" /%} rune is useful for
+The `^-` [kethep](/language/hoon/reference/rune/ket#--kethep) rune is useful for
 ensuring that everything in the second child matches the type (aura) of
 the first, e.g.
 
@@ -178,8 +176,7 @@ useful tool in Hoon code.
 
 ### Exercise:  Aura Conversions
 
-Convert between some of the given auras at the {% tooltip label="Dojo"
-href="/glossary/dojo" /%} prompt, e.g.:
+Convert between some of the given auras at the [Dojo](/glossary/dojo) prompt, e.g.:
 
 - `100` to `@p`
 - `0b1100.0101` to `@p`
@@ -189,7 +186,7 @@ href="/glossary/dojo" /%} prompt, e.g.:
 
 ### Cells
 
-A {% tooltip label="cell" href="/glossary/cell" /%} is a pair of nouns.
+A [cell](/glossary/cell) is a pair of nouns.
 Cells are traditionally written using square brackets:  `[]`.  For now,
 just recall the square brackets and that cells are always _pairs_ of
 values.
@@ -200,8 +197,7 @@ values.
 [[1 2] [3 4]]
 ```
 
-This is actually a shorthand for a rune as well, `:-` {% tooltip
-label="colhep" href="/language/hoon/reference/rune/col#--colhep" /%}
+This is actually a shorthand for a rune as well, `:-` [colhep](/language/hoon/reference/rune/col#--colhep)
 
 ```hoon
 :-  1  2
@@ -236,26 +232,22 @@ structure of the operating function itself as a noun.
 
 {% video src="https://media.urbit.org/docs/hoon-school-videos/HS113 - Basic Coding.mp4" /%}
 
-The backbone of any Hoon expression is a scaffolding of {% tooltip
-label="runes" href="/glossary/rune" /%} , which are essentially
-mathematical relationships between daughter components.  If nouns are
-nouns, then runes are verbs:  they describe how nouns relate.  Runes
-provide the structural and logical relationship between noun values.
+The backbone of any Hoon expression is a scaffolding of
+[runes](/glossary/rune) , which are essentially mathematical
+relationships between daughter components.  If nouns are nouns, then
+runes are verbs:  they describe how nouns relate.  Runes provide the
+structural and logical relationship between noun values.
 
-A rune is just a pair of ASCII characters (a digraph).  We usually {%
-tooltip label="pronounce runes" href="/glossary/aural-ascii" /%} by
-combining their characters’ names, e.g.: {% tooltip label="\"kethep\""
-href="/language/hoon/reference/rune/ket#--kethep" /%} for `^-`, {%
-tooltip label="\"bartis\""
-href="/language/hoon/reference/rune/bar#-bartis" /%} for `|=`, and {%
-tooltip label="\"barcen\""
-href="/language/hoon/reference/rune/bar#-barcen" /%} for `|%`.
+A rune is just a pair of ASCII characters (a digraph).  We usually
+[pronounce runes](/glossary/aural-ascii) by combining their characters’
+names, e.g.: ["kethep"](/language/hoon/reference/rune/ket#--kethep) for
+`^-`, ["bartis"](/language/hoon/reference/rune/bar#-bartis) for `|=`,
+and ["barcen"](/language/hoon/reference/rune/bar#-barcen) for `|%`.
 
 For instance, when we called a function earlier (in Hoon parlance, we
-_slammed a gate_), we needed to provide the `%-` {% tooltip
-label="cenhep" href="/language/hoon/reference/rune/cen#-cenhep" /%} rune
-with two bits of information, a function name and the values to
-associate with it:
+_slammed a gate_), we needed to provide the `%-`
+[cenhep](/language/hoon/reference/rune/cen#-cenhep) rune with two bits
+of information, a function name and the values to associate with it:
 
 ```hoon {% copy=true %}
 %-
@@ -270,15 +262,14 @@ like [Clojure](https://en.wikipedia.org/wiki/Clojure).  Literally, we
 can interpret `%-  add  [1 2]` as “evaluate the `add` core on the input
 values `[1 2]`”.
 
-The {% tooltip label="++add"
-href="/language/hoon/reference/stdlib/1a#add" /%} function expects
-precisely two values (or _arguments_), which are provided by {% tooltip
-label="%-" href="/language/hoon/reference/rune/cen#-cenhep" /%} in the
-neighboring child expression as a cell.  There's really no limit to the
-complexity of Hoon expressions:  they can track deep and wide.  They
-also don't care much about layout, which leaves you a lot of latitude.
-The only hard-and-fast rule is that there are single spaces (`ace`s) and
-everything else (`gap`s).
+The [++add](/language/hoon/reference/stdlib/1a#add) function expects
+precisely two values (or _arguments_), which are provided by
+[%-](/language/hoon/reference/rune/cen#-cenhep) in the neighboring child
+expression as a cell.  There's really no limit to the complexity of Hoon
+expressions:  they can track deep and wide.  They also don't care much
+about layout, which leaves you a lot of latitude. The only hard-and-fast
+rule is that there are single spaces (`ace`s) and everything else
+(`gap`s).
 
 ```hoon {% copy=true %}
 %-
@@ -323,8 +314,7 @@ runes that yield 80% of the capability.
 ### Exercise:  Identifying Unknown Runes
 
 Here is a lightly-edited snippet of Hoon code.  Anything written after a
-`::` {% tooltip label="colcol"
-href="/language/hoon/reference/rune/col#-colcol" /%} is a _comment_ and
+`::` [colcol](/language/hoon/reference/rune/col#-colcol) is a _comment_ and
 is ignored by the computer.  (Comments are useful for human-language
 explanations.)
 
@@ -368,17 +358,15 @@ Here is a snippet of Hoon code:
 ==
 ```
 
-Without looking it up first, what does the `==` {% tooltip
-label="tistis" href="/language/hoon/reference/rune/terminators#-tistis"
-/%} do for the `:~` {% tooltip label="colsig"
-href="/language/hoon/reference/rune/col#-colsig" /%} rune?  Hint: some
-runes can take any number of arguments.
+Without looking it up first, what does the `==`
+[tistis](/language/hoon/reference/rune/terminators#-tistis) do for the
+`:~` [colsig](/language/hoon/reference/rune/col#-colsig) rune?  Hint:
+some runes can take any number of arguments.
 
 Most runes are used at the beginning of a complex expression, but there
-are exceptions. For example, the runes `--` {% tooltip label="hephep"
-href="/language/hoon/reference/rune/terminators#---hephep" /%} and
-`==` {% tooltip label="tistis"
-href="/language/hoon/reference/rune/terminators#-tistis" /%} are used at
+are exceptions. For example, the runes `--`
+[hephep](/language/hoon/reference/rune/terminators#---hephep) and `==`
+[tistis](/language/hoon/reference/rune/terminators#-tistis) are used at
 the end of certain expressions.
 
 #### Aside:  Writing Incorrect Code
@@ -403,15 +391,14 @@ Any time you see a `need`/`have` pair, this is what it means.
 
 Runes are classified by family (with the exceptions of `--` hephep and
 `==` tistis). The first of the two symbols indicates the family—e.g.,
-the `^-` kethep rune is in the `^` {% tooltip label="ket"
-href="/language/hoon/reference/rune/ket" /%} family of runes, and the
-`|=` bartis and `|%` barcen runes are in the `|` {% tooltip label="bar"
-href="/language/hoon/reference/rune/bar" /%} family.  The runes of
+the `^-` kethep rune is in the `^`
+[ket](/language/hoon/reference/rune/ket) family of runes, and the `|=`
+bartis and `|%` barcen runes are in the `|`
+[bar](/language/hoon/reference/rune/bar) family.  The runes of
 particular family usually have related meanings.  Two simple examples:
 the runes in the `|` bar family are all used to create cores, and the
-runes in the `:` {% tooltip label="col"
-href="/language/hoon/reference/rune/col" /%} family are all used to
-create cells.
+runes in the `:` [col](/language/hoon/reference/rune/col) family are all
+used to create cells.
 
 Rune expressions are usually complex, which means they usually have one
 or more subexpressions.  The appropriate syntax varies from rune to
@@ -487,19 +474,18 @@ inside are separated by a single space. Any more spacing than that
 results in a syntax error.
 
 Nearly all rune expressions can be written in either form, but there are
-exceptions.  `|%` {% tooltip label="barcen"
-href="/language/hoon/reference/rune/bar#-barcen" /%} and `|_` {%
-tooltip label="barcab" href="/language/hoon/reference/rune/bar#_-barcab"
-/%} expressions, for example, can only be written in tall form.  (Those
-are a bit too complicated to fit comfortably on one line anyway.)
+exceptions.  `|%` [barcen](/language/hoon/reference/rune/bar#-barcen)
+and `|_` [barcab](/language/hoon/reference/rune/bar#_-barcab)
+expressions, for example, can only be written in tall form.  (Those are
+a bit too complicated to fit comfortably on one line anyway.)
 
 ### Nesting Runes
 
 Since runes take a fixed number of children, one can visualize how Hoon
 expressions are built by thinking of each rune being followed by a
 series of boxes to be filled—one for each of its children.  Let us
-illustrate this with the `:-` {% tooltip label="colhep"
-href="/language/hoon/reference/rune/col#--colhep" /%} rune.
+illustrate this with the `:-`
+[colhep](/language/hoon/reference/rune/col#--colhep) rune.
 
 ![Colhep rune with two empty boxes for children.](https://media.urbit.org/docs/hoon-syntax/cell1.png)
 
@@ -552,12 +538,11 @@ to the subject”.  Hoon faces aren't exactly like variables in other
 programming languages, but for now we can treat them that way, with the
 caveat that they are only accessible to daughter or sister expressions.
 
-When we used {% tooltip label="++add"
-href="/language/hoon/reference/stdlib/1a#add" /%} or {% tooltip
-label="++sub" href="/language/hoon/reference/stdlib/1a#sub" /%}
-previously, we wanted an immediate answer.  There's not much more to say
-than `5 + 1`.  In contrast, pinning a face accepts three daughter
-expressions:  a name (or face), a value, and the rest of the expression.
+When we used [++add](/language/hoon/reference/stdlib/1a#add) or
+[++sub](/language/hoon/reference/stdlib/1a#sub) previously, we wanted an
+immediate answer.  There's not much more to say than `5 + 1`.  In
+contrast, pinning a face accepts three daughter expressions:  a name (or
+face), a value, and the rest of the expression.
 
 ```hoon {% copy=true %}
 =/  perfect-number  28
@@ -693,10 +678,9 @@ dojo: hoon expression failed
 
 ### Text
 
-There are two ways to represent text in Urbit:  cords (`@t` {% tooltip
-label="aura" href="/glossary/aura" /%} atoms) and {% tooltip
-label="tapes" href="/glossary/tape" /%} (lists of individual
-characters).  Both of these are commonly called
+There are two ways to represent text in Urbit:  cords (`@t`
+[aura](/glossary/aura) atoms) and [tapes](/glossary/tape) (lists of
+individual characters).  Both of these are commonly called
 [“strings”](https://en.wikipedia.org/wiki/String_%28computer_science%29).
 
 Why represent text?  What does that mean?  We have to have a way of
@@ -728,7 +712,7 @@ actual code is [ASCII](https://en.wikipedia.org/wiki/ASCII).
 
 ### Exercise:  ASCII Values in Text
 
-A {% tooltip label="cord" href="/glossary/cord" /%} (`@t`) represents
+A [cord](/glossary/cord) (`@t`) represents
 text as a sequence of characters.  If you know the
 [ASCII](https://en.wikipedia.org/wiki/ASCII) value for a particular
 character, you can identify how the text is structured as a number.
@@ -756,7 +740,11 @@ between two different Hoon expressions, like picking a fork in a road.
 Any computational process requires the ability to distinguish options.
 For this, we first require a basis for discrimination:  truthness.
 
-Essentially, we have to be able to decide whether or not some value or expression evaluates as `%.y` _true_ (in which case we will do one thing) or `%.n` _false_ (in which case we do another).  At this point, our basic expressions are always mathematical; later on we will check for existence, for equality of two values, etc.
+Essentially, we have to be able to decide whether or not some value or
+expression evaluates as `%.y` _true_ (in which case we will do one
+thing) or `%.n` _false_ (in which case we do another).  At this point,
+our basic expressions are always mathematical; later on we will check
+for existence, for equality of two values, etc.
 
 - [`++gth`](/language/hoon/reference/stdlib/1a#gth) (greater than `>`)
 - [`++lth`](/language/hoon/reference/stdlib/1a#lth) (less than `<`)

--- a/content/courses/hoon-school/C-azimuth.md
+++ b/content/courses/hoon-school/C-azimuth.md
@@ -19,10 +19,10 @@ infrastructure](https://en.wikipedia.org/wiki/Public_key_infrastructure)?
 Essentially a PKI defines a protocol for asymmetrically revealing a
 public key (which anyone can use to check that a message came from where
 it says it came) and retaining a private key, used by the owner as a
-cryptographically secure tool for signing electronic transactions. {%
-tooltip label="Azimuth" href="/glossary/azimuth" /%} functions as a PKI
-so that Urbit ID points can be uniquely controlled, transferred, and
-used to work with instances of Urbit OS (ships).
+cryptographically secure tool for signing electronic transactions.
+[Azimuth](/glossary/azimuth) functions as a PKI so that Urbit ID points
+can be uniquely controlled, transferred, and used to work with instances
+of Urbit OS (ships).
 
 Urbit ID (=Azimuth) provides persistent and stable futureproof identity
 to its users through a hierarchical address space.  Any particular Urbit
@@ -77,7 +77,7 @@ sponsor is not readily apparent to a peer.
 
 #### Galaxy
 
-The {% tooltip label="Galaxies" href="/glossary/galaxy" /%} span the
+The [Galaxies](/glossary/galaxy) span the
 first 2⁸ addresses of Azimuth.  There are 255 (`0xff` - 1) associated
 stars; counting the galaxy yields 256 points (not counting moons).
 Galaxy names are suffix-only.
@@ -102,7 +102,7 @@ idea is, you need someone to sponsor your membership on the network. An
 address that can’t find a sponsor is probably a bot or a spammer”
 ([docs](https://urbit.org/understanding-urbit/)).
 
-The {% tooltip label="Stars" href="/glossary/star" /%} span the
+The [Stars](/glossary/star) span the
 remaining addresses to 2¹⁶. There are thus 65,536 - 256 = 65,280 stars.
 Star names have prefix and suffix. They share the suffix with their
 sponsoring galaxy.
@@ -119,7 +119,7 @@ is `0x100` ~marzod.  The last star of ~zod is `0xffff` - `0xff` =
 
 #### Planet
 
-The {% tooltip label="Planets" href="/glossary/planet" /%} span the
+The [Planets](/glossary/planet) span the
 remaining addresses to 2³².  There are thus 4,294,967,296 - 65,536 =
 4,294,901,760 planets.  Planet names occur in pairs separated by a
 single hyphen.  A planet's name is obfuscated so it is not immediately
@@ -145,9 +145,9 @@ star planet recur module 2¹⁶.
 
 #### Moon
 
-The {% tooltip label="Moons" href="/glossary/moon" /%} occupy the block
-to 2⁶⁴, with 2³² moons for each planet.  Moon names have more than two
-blocks (three or four) separated by single hyphens.
+The [Moons](/glossary/moon) occupy the block to 2⁶⁴, with 2³² moons for
+each planet.  Moon names have more than two blocks (three or four)
+separated by single hyphens.
 
 |              | First Address | Last Address |
 | ------------ | ------------- | ------------ |
@@ -159,10 +159,11 @@ Moons recur modulo 2³² from their sponsor.  Thus dividing a moon's
 address by 2³² and taking the remainder yields the address of the
 sponsor.
 
-Any moon that begins with the prefix ~dopzod-dozzod-doz___ is a
-galaxy moon, but not every galaxy moon begins with that prefix. The
-first galaxy moon of ~zod is 0x1.0000.0000 ~doznec-dozzod-dozzod; the
-last is `0xffff.ffff.ffff.ffff` - `0xffff.ffff` = `0xffff.ffff.0000.0000` ~fipfes-fipfes-dozzod-dozzod.
+Any moon that begins with the prefix ~dopzod-dozzod-doz___ is a galaxy
+moon, but not every galaxy moon begins with that prefix. The first
+galaxy moon of ~zod is 0x1.0000.0000 ~doznec-dozzod-dozzod; the last is
+`0xffff.ffff.ffff.ffff` - `0xffff.ffff` = `0xffff.ffff.0000.0000`
+~fipfes-fipfes-dozzod-dozzod.
 
 Any moon that begins with the prefix ~dopzod-dozzod-______ is a
 star moon (other than galaxy moons), but not every star moon begins with
@@ -176,11 +177,10 @@ moon.
 
 #### Comet
 
-The {% tooltip label="Comets" href="/glossary/comet" /%} occupy the
-upper portion of the Urbit address space.  There are approximately
-3.4×10³⁸ comets, a fantastically large number.  Comet names occur in
-blocks of five to eight syllable pairs, separated by a double hyphen at
-the fourth.
+The [Comets](/glossary/comet) occupy the upper portion of the Urbit
+address space.  There are approximately 3.4×10³⁸ comets, a fantastically
+large number.  Comet names occur in blocks of five to eight syllable
+pairs, separated by a double hyphen at the fourth.
 
 |              | First Address | Last Address |
 | ------------ | ------------- | ------------ |
@@ -190,8 +190,9 @@ the fourth.
 
 A comet is sponsored by a star.  Currently star sponsors are determined
 randomly from a list supplied to `u3_dawn_come` in
-`pkg/urbit/vere/dawn.c` from a [jamfile](/language/hoon/reference/stdlib/2p#jam) provided by urbit.org at
-`https://bootstrap.urbit.org/comet-stars.jam`.
+`pkg/urbit/vere/dawn.c` from a
+[jamfile](/language/hoon/reference/stdlib/2p#jam) provided by urbit.org
+at `https://bootstrap.urbit.org/comet-stars.jam`.
 
 Comets cannot be breached or rekeyed:  possession of the comet is *ipso
 facto* attestation of ownership.

--- a/content/courses/hoon-school/D-gates.md
+++ b/content/courses/hoon-school/D-gates.md
@@ -14,9 +14,8 @@ Until this point in Hoon School, we have rigorously adhered to the
 regular syntax of runes so that you could get used to using them.  In
 fact, the only two irregular forms we used were these:
 
-- Cell definition `[a b]` which represents the `:-` {% tooltip
-  label="colhep" href="/language/hoon/reference/rune/col#--colhep" /%}
-  rune, `:-  a  b`.
+- Cell definition `[a b]` which represents the `:-`
+  [colhep](/language/hoon/reference/rune/col#--colhep) rune, `:-  a  b`.
 
     That is, these expressions are all the same for Hoon:
 
@@ -33,9 +32,9 @@ fact, the only two irregular forms we used were these:
     [1 2]
     ```
 
-- Aura application `` `@ux`500 `` which represents a double `^-` {%
-  tooltip label="kethep"
-  href="/language/hoon/reference/rune/ket#--kethep" /%}, like `^-  @ux  ^-  @  500`.
+- Aura application `` `@ux`500 `` which represents a double `^-`
+  [kethep](/language/hoon/reference/rune/ket#--kethep), like `^-  @ux
+  ^-  @  500`.
 
     These are equivalent in Hoon:
 
@@ -52,8 +51,8 @@ fact, the only two irregular forms we used were these:
 
 Hoon developers often employ irregular forms, sometimes called “sugar
 syntax”.  Besides the `:-` colhep and `^-` kethep forms, we will
-commonly use a new form for `%-` {% tooltip label="cenhep"
-href="/language/hoon/reference/rune/cen#-cenhep" /%} “function calls”:
+commonly use a new form for `%-`
+[cenhep](/language/hoon/reference/rune/cen#-cenhep) “function calls”:
 
 ```hoon
 > %-  add  [1 2]
@@ -102,13 +101,13 @@ code structures defining the behavior.
 This has no flexibility:  if we want to change `a` we have to rewrite
 the whole thing every time!
 
-(Note also our introduction of the `::` {% tooltip label="colcol"
-href="/language/hoon/reference/rune/col#-colcol" /%} digraph in the
-above code block.  This marks anything following it as a _comment_,
-meaning that it is meant for the developer and reader, and ignored by
-the computer.)
+(Note also our introduction of the `::`
+[colcol](/language/hoon/reference/rune/col#-colcol) digraph in the above
+code block.  This marks anything following it as a _comment_, meaning
+that it is meant for the developer and reader, and ignored by the
+computer.)
 
-Hoon uses {% tooltip label="gates" href="/glossary/gate" /%} as deferred
+Hoon uses [gates](/glossary/gate) as deferred
 computations.  What this means is that we can build a Hoon expression
 now and use it at need later on, perhaps many times.  More than that, we
 can also use it on different data values.  A gate is the Hoon analogue
@@ -131,24 +130,20 @@ property of functions. This property is called [referential
 transparency](https://en.wikipedia.org/wiki/Referential_transparency),
 and it's one of the key ingredients to building a secure Urbit stack.
 
-Functions are implemented in Hoon with a special kind of {% tooltip
-label="core" href="/glossary/core" /%} called a _gate_.  In this lesson
-you'll learn what a gate is and how a gate represents a function.  (We
-_won't_ talk about what a core is quite yet.)  Along the way you'll
-build some example gates of your own.
+Functions are implemented in Hoon with a special kind of
+[core](/glossary/core) called a _gate_.  In this lesson you'll learn
+what a gate is and how a gate represents a function.  (We _won't_ talk
+about what a core is quite yet.)  Along the way you'll build some
+example gates of your own.
 
 ### Building a Gate
 
 {% video src="https://media.urbit.org/docs/hoon-school-videos/HS120 - Gates.mp4" /%}
 
-Syntactically, a gate is a `|=` {% tooltip label="bartis"
-href="/language/hoon/reference/rune/bar#-bartis" /%} rune with two
-children:  a {% tooltip label="spec"
-href="/language/hoon/reference/stdlib/4o#spec" /%} (specification of
-input) and a {% tooltip label="hoon"
-href="/language/hoon/reference/stdlib/4o#hoon" /%} (body). Think of just
-replacing the `=/` {% tooltip label="tisfas"
-href="/language/hoon/reference/rune/tis#-tisfas" /%} with the `|=`
+Syntactically, a gate is a `|=` [bartis](/language/hoon/reference/rune/bar#-bartis) rune with two
+children:  a [spec](/language/hoon/reference/stdlib/4o#spec) (specification of
+input) and a [hoon](/language/hoon/reference/stdlib/4o#hoon) (body). Think of just
+replacing the `=/` [tisfas](/language/hoon/reference/rune/tis#-tisfas) with the `|=`
 bartis:
 
 ```hoon {% copy=true %}
@@ -170,9 +165,8 @@ the gate.
 
 The `hoon` body expression evaluates and yields a result, ultimately
 sent back to the call site.  Frequently it is wise to explicitly require
-a particular type for the return value using the `^-` {% tooltip
-label="kethep" href="/language/hoon/reference/rune/ket#--kethep" /%}
-rune:
+a particular type for the return value using the `^-`
+[kethep](/language/hoon/reference/rune/ket#--kethep) rune:
 
 ```hoon {% copy=true %}
 ::  Confirm whether a value is greater than one.
@@ -208,8 +202,8 @@ Gates can take multiple arguments as a cell:
 b
 ```
 
-You can also call them different ways with raw `%` {% tooltip
-label="cen" href="/language/hoon/reference/rune/cen" /%} runes:
+You can also call them different ways with raw `%`
+[cen](/language/hoon/reference/rune/cen) runes:
 
 ```hoon {% copy=true %}
 %-  max  [100 200]
@@ -235,21 +229,19 @@ expression as valid Hoon code, but can't actually apply it to an input
   ]
 ```
 
-We need to attach a _name_ or a {% tooltip label="face"
-href="/glossary/face" /%} to the expression.  Then we'll be able to use
-it directly.  Somewhat confusingly, there are three common ways to do
-this:
+We need to attach a _name_ or a [face](/glossary/face) to the
+expression.  Then we'll be able to use it directly.  Somewhat
+confusingly, there are three common ways to do this:
 
 1. Attach the face (name) directly in Dojo.  (This is a good quick
    solution, and we'll use it when teaching and testing code, but it
    doesn't work inside of code files.)
-2. Save the gate as a {% tooltip label="generator"
-   href="/glossary/generator" /%} file and call it using the name of the
-   file.  (We'll do this in the next section of this lesson.)
-3. Attach the face (name) as an {% tooltip label="arm"
-   "href"="/glossary/arm" /%} in a {% tooltip label="core"
-   href="/glossary/core" /%}.  (We don't know what those are yet, so
-   we'll set them aside for a couple of lessons.)
+2. Save the gate as a [generator](/glossary/generator) file and call it
+   using the name of the file.  (We'll do this in the next section of
+   this lesson.)
+3. Attach the face (name) as an [arm](/glossary/arm") in a
+   [core](/glossary/core).  (We don't know what those are yet, so we'll
+   set them aside for a couple of lessons.)
 
 To name a gate in Dojo (or any expression resulting in a value, which is
 _every_ expression), you can use the Dojo-specific syntax `=name value`:
@@ -279,13 +271,12 @@ form:
 124
 ```
 
-To reiterate:  we typically use the `|=` {% tooltip label="bartis"
-href="/language/hoon/reference/rune/bar#-bartis" /%} rune to create a
+To reiterate:  we typically use the `|=`
+[bartis](/language/hoon/reference/rune/bar#-bartis) rune to create a
 gate. In the expression above the `|=` is immediately followed by a set
 of parentheses containing two subexpressions: `a=@` and `(add 1 a)`. The
-first defines the gate's {% tooltip label="sample"
-href="/glossary/sample" /%} (input value type), and the second defines
-the gate's product (output value).
+first defines the gate's [sample](/glossary/sample) (input value type),
+and the second defines the gate's product (output value).
 
 In the example gate above, `inc`, the sample is defined by `a=@`.  This
 means that the sample is defined as an atom `@` meaning that the gate
@@ -330,8 +321,7 @@ specification.  Others, like Python and MATLAB, are _laissez-faire_.
 Hoon tends to be strict, but leaves some discretion over _how_ strict to
 you, the developer.
 
-Remember `^-` {% tooltip label="kethep"
-href="/language/hoon/reference/rune/ket#--kethep" /%}?  We will use `^-`
+Remember `^-` [kethep](/language/hoon/reference/rune/ket#--kethep)?  We will use `^-`
 as a _fence_, a way of making sure only data matching the appropriate
 structure get passed on.
 
@@ -422,7 +412,7 @@ On Mars:
 ```
 
 You can verify the contents of the copied files are the same using the
-{% tooltip label="+cat" href="/manual/os/dojo-tools#cat" /%} command:
+[+cat](/manual/os/dojo-tools#cat) command:
 
 ```hoon
 > +cat %/desk/bill
@@ -430,25 +420,25 @@ You can verify the contents of the copied files are the same using the
 > +cat %/desk/txt
 ```
 
-(Dojo does know what a `bill` file is, so it displays the contents slightly formatted.  They are actually identical.)
+(Dojo does know what a `bill` file is, so it displays the contents
+slightly formatted.  They are actually identical.)
 
-We will use this {% tooltip label="|commit"
-href="/manual/os/dojo-tools#commit" /%} pattern to store persistent code
-as files, editing on Earth and then synchronizing to Mars.
+We will use this [|commit](/manual/os/dojo-tools#commit) pattern to
+store persistent code as files, editing on Earth and then synchronizing
+to Mars.
 
 
 ##  Building Code
 
 The missing piece to really tie all of this together is the ability to
 store a gate and use it at a later time, not just in the same long Dojo
-session.  Enter the {% tooltip label="generator"
-href="/glossary/generator" /%}.
+session.  Enter the [generator](/glossary/generator).
 
 A generator is a simple program which can be called from the Dojo.  It
 is a gate, so it takes some input as sample and produces some result.
 Naked generators are the simplest generators possible, having access
-only to information passed to them directly in their {% tooltip
-label="sample" href="/glossary/sample" /%}.
+only to information passed to them directly in their
+[sample](/glossary/sample).
 
 In this section, we will compose our first generator.
 
@@ -526,14 +516,14 @@ program yet.
 A generator gives us on-demand access to code, but it is helpful to load
 and use code from files while we work in the Dojo.
 
-A conventional library import with `/+` {% tooltip label="faslus"
-href="/language/hoon/reference/rune/fas#-faslus" /%} will work in a
+A conventional library import with `/+`
+[faslus](/language/hoon/reference/rune/fas#-faslus) will work in a
 generator or another file, but won't work in Dojo, so you can't use `/+`
 faslus interactively.
 
-Instead, you need to use the {% tooltip label="-build-file"
-href="/manual/os/dojo-tools#-build-file" /%} thread to load the code.
-Most commonly, you will do this with library code when you need a
+Instead, you need to use the
+[-build-file](/manual/os/dojo-tools#-build-file) thread to load the
+code. Most commonly, you will do this with library code when you need a
 particular core's functionality.
 
 `-build-file` accepts a file path and returns the built operational

--- a/content/courses/hoon-school/E-types.md
+++ b/content/courses/hoon-school/E-types.md
@@ -37,9 +37,9 @@ different kinds of things we could refer to as “type”.  It is
 instructive for learners to distinguish three kinds of types in Hoon:
 
 1. Atoms:  values with auras.
-2. {% tooltip label="Molds" href="/glossary/mold" /%}:  structures.
+2. [Molds](/glossary/mold):  structures.
    Think of cells, lists, and sets.
-3. {% tooltip label="Marks" href="/glossary/mark" /%}:  file types.
+3. [Marks](/glossary/mark):  file types.
    Compare to conventional files distinguished by extension and definite
    internal structure.
 
@@ -50,11 +50,10 @@ rule.  **All of these are molds, or Hoon types.  We are simply
 separating them by complexity as you learn.**
 
 You have seen and worked with the trivial atoms and cells.  We will
-leave marks until a later discussion of {% tooltip label="Gall"
-href="/glossary/gall" /%} {% tooltip label="agents"
-href="/glossary/agent" /%} or the {% tooltip label="Clay"
-href="/glossary/clay" /%} filesystem, which use marks to type file data.
-For now, we focus on {% tooltip label="molds" href="/glossary/mold" /%}.
+leave marks until a later discussion of [Gall](/glossary/gall)
+[agents](/glossary/agent) or the [Clay](/glossary/clay) filesystem,
+which use marks to type file data. For now, we focus on
+[molds](/glossary/mold).
 
 This lesson will talk about atoms, cells, then molds in a general sense.
 We allude to several topics which will be explored in Data Structures.
@@ -70,7 +69,7 @@ integer; but Hoon keeps track of type information about each atom, and
 this bit of metadata tells Hoon how to interpret the atom in question.
 
 The piece of type information that determines how Hoon interprets an
-atom is called an {% tooltip label="aura" href="/glossary/aura" /%}.
+atom is called an [aura](/glossary/aura).
 The set of all atoms is indicated with the symbol `@`.  An aura is
 indicated with `@` followed by some letters, e.g., `@ud` for unsigned
 decimal.  Accordingly, the Hoon type system does more than track sets of
@@ -113,8 +112,8 @@ Hoon know what the intended data type is?  The programmer must specify
 this explicitly by using a _cast_.  To cast for an unsigned decimal
 atom, you can use the `^-` kethep rune along with the `@ud` from above.
 
-What exactly does the `^-` {% tooltip label="kethep"
-href="/language/hoon/reference/rune/ket#--kethep" /%} rune do?  It
+What exactly does the `^-`
+[kethep](/language/hoon/reference/rune/ket#--kethep) rune do?  It
 compares the inferred type of some expression with the desired cast
 type.  If the expression's inferred type _nests_ under the desired type,
 then the product of the expression is returned.
@@ -128,10 +127,10 @@ Let's try one in the Dojo.
 
 Because `@ud` is the inferred type of `15`, the cast succeeds.  Notice
 that the `^-` kethep expression never does anything to modify the
-underlying {% tooltip label="noun" href="/glossary/noun" /%} of the
+underlying [noun](/glossary/noun) of the
 second subexpression.  It's used simply to mandate a type-check on that
 expression.  This check occurs at compile-time (when the expression is
-compiled to {% tooltip label="Nock" href="/glossary/nock" /%}).
+compiled to [Nock](/glossary/nock)).
 
 What if the inferred type doesn't fit under the cast type?  You will see
 a `nest-fail` crash at compile-time:
@@ -258,13 +257,13 @@ Here's another example of type inference at work:
 36
 ```
 
-The {% tooltip label="add" href="/language/hoon/reference/stdlib/1a#add"
-/%} function in the Hoon standard library operates on all atoms,
-regardless of aura, and returns atoms with no aura specified. Hoon isn't
-able to infer anything more specific than `@` for the product of `add`.
-This is by design, however. Notice that when you `add` a decimal and a
-hexadecimal above, the correct answer is returned (pretty-printed as a
-decimal). This works for all of the unsigned auras:
+The [add](/language/hoon/reference/stdlib/1a#add) function in the Hoon
+standard library operates on all atoms, regardless of aura, and returns
+atoms with no aura specified. Hoon isn't able to infer anything more
+specific than `@` for the product of `add`. This is by design, however.
+Notice that when you `add` a decimal and a hexadecimal above, the
+correct answer is returned (pretty-printed as a decimal). This works for
+all of the unsigned auras:
 
 ```hoon
 > (add 100 0b101)
@@ -365,8 +364,8 @@ nest-fail
 ```
 
 The `[@ @]` cast accepts any expression that evaluates to a cell with
-exactly two atoms, and crashes with a {% tooltip label="nest-fail"
-href="/language/hoon/reference/hoon-errors#nest-fail" /%} for any
+exactly two atoms, and crashes with a
+[nest-fail](/language/hoon/reference/hoon-errors#nest-fail) for any
 expression that evaluates to something different.  The expression `12`
 doesn't evaluate to a cell; and while the expression `[[12 13] 14]` does
 evaluate to a cell, the left-hand side isn't an atom, but is instead
@@ -435,12 +434,12 @@ atoms as unsigned integers.
 
 {% video src="https://media.urbit.org/docs/hoon-school-videos/HS156 - Molds.mp4" /%}
 
-A {% tooltip label="mold" href="/glossary/mold" /%} is a template or
-rule for identifying actual type structures. They are actually gates,
-meaning that they operate on a value to coerce it to a particular
-structure.  Technically, a mold is a function from a noun to a noun.
-What this means is that we can use a mold to map any noun to a typed
-value—if this fails, then the mold crashes.
+A [mold](/glossary/mold) is a template or rule for identifying actual
+type structures. They are actually gates, meaning that they operate on a
+value to coerce it to a particular structure.  Technically, a mold is a
+function from a noun to a noun. What this means is that we can use a
+mold to map any noun to a typed value—if this fails, then the mold
+crashes.
 
 ```hoon
 > (^ [1 2])
@@ -469,15 +468,14 @@ We commonly need to do one of two things with a mold:
     dojo: hoon expression failed
     ```
 
-2.  Produce an example value ({% tooltip label="bunt"
-    href="/glossary/bunt" /%}).
+2.  Produce an example value ([bunt](/glossary/bunt)).
 
 We often use bunts to clam; for example `@ud` implicitly uses the `@ud`
 default value (`0`) as the type specimen which the computation must
 match.
 
-To _actually_ get the bunt value, use the `^*` {% tooltip label="kettar"
-href="/language/hoon/reference/rune/ket#-kettar" /%} rune, almost always
+To _actually_ get the bunt value, use the `^*`
+[kettar](/language/hoon/reference/rune/ket#-kettar) rune, almost always
 used in its irregular form `*` tar:
 
 ```hoon
@@ -495,10 +493,10 @@ used in its irregular form `*` tar:
 ```
 
 One more way to validate against type is to use an example instead of
-the extracted mold.  This uses the `^+` {% tooltip label="ketlus"
-href="/language/hoon/reference/rune/ket#-ketlus" /%} rune similarly to
-how we used `^-` {% tooltip label="kethep"
-href="/language/hoon/reference/rune/ket#--kethep" /%} previously:
+the extracted mold.  This uses the `^+`
+[ketlus](/language/hoon/reference/rune/ket#-ketlus) rune similarly to
+how we used `^-` [kethep](/language/hoon/reference/rune/ket#--kethep)
+previously:
 
 ```hoon {% copy=true %}
 ^+(1.000 100)
@@ -509,8 +507,7 @@ q)`.  Many runes we use actually reduce to other rune forms, and have
 been introduced for ease of use.)
 
 We can use more complex structures for molds though, including built-in
-types like {% tooltip label="lists" href="/glossary/list" /%} and {%
-tooltip label="tapes" href="/glossary/tape" /%}.  (A `tape` represents
+types like [lists](/glossary/list) and [tapes](/glossary/tape).  (A `tape` represents
 text.)
 
 ```hoon {% copy=true %}
@@ -548,8 +545,7 @@ and “mold builder” tools.  Thus a `list` needs an associated type `(list
 
 Besides `?` (which is a Dojo-specific tool), the programmatic way to
 figure out which mold the Hoon compiler thinks something is to use the
-`!>` {% tooltip label="zapgar"
-href="/language/hoon/reference/rune/zap#-zapgar" /%} rune.
+`!>` [zapgar](/language/hoon/reference/rune/zap#-zapgar) rune.
 
 ```hoon
 > !>(0xace2.bead)
@@ -566,10 +562,9 @@ the so-called “type spear” `-:!>`:
 
 ### Type Unions
 
-`$?` {% tooltip label="bucwut"
-href="/language/hoon/reference/rune/buc#-bucwut" /%} forms a type union.
-Most commonly these are used with types having different structures,
-such as an atom and a cell.
+`$?` [bucwut](/language/hoon/reference/rune/buc#-bucwut) forms a type
+union. Most commonly these are used with types having different
+structures, such as an atom and a cell.
 
 For instance, if you wanted a gate to accept an atom of an unsigned aura
 type, but no other type, you could define a type union thus:

--- a/content/courses/hoon-school/F-cores.md
+++ b/content/courses/hoon-school/F-cores.md
@@ -11,19 +11,19 @@ _This module will introduce the key Hoon data structure known as the
 The Hoon subject is a noun.  One way to look at this noun is to denote
 each fragment of is as either a computation or data.  By strictly
 separating these two kinds of things, we derive the data structure known
-within Hoon as a {% tooltip label="core" href="/glossary/core" /%}.
+within Hoon as a [core](/glossary/core).
 
 Cores are the most important data structure in Hoon.  They allow you to
 solve many coding problems by identifying a pattern and supplying a
 proper data structure apt to the challenge.  You have already started
-using cores with `|=` {% tooltip label="bartis"
-href="/language/hoon/reference/rune/bar#-bartis" /%} {% tooltip
-label="gate" href="/glossary/gate" /%} construction and use.
+using cores with `|=`
+[bartis](/language/hoon/reference/rune/bar#-bartis)
+[gate](/glossary/gate) construction and use.
 
-This lesson will introduce another {% tooltip label="core"
-href="/glossary/core" /%} to solve a specific use case, then continue
-with a general discussion of cores.  Getting cores straight will be key
-to understanding why Hoon has the structure and internal logic it does.
+This lesson will introduce another [core](/glossary/core) to solve a
+specific use case, then continue with a general discussion of cores.
+Getting cores straight will be key to understanding why Hoon has the
+structure and internal logic it does.
 
 
 ##  Repeating Yourself Using a Trap
@@ -49,15 +49,15 @@ list.
 
 Hoon effects the concept of a loop using recursion, return to a
 particular point in an expression (presumably with some different
-values).  One way to do this is using the `|-` {% tooltip label="barhep"
-href="/language/hoon/reference/rune/bar#--barhep" /%} rune, which
-creates a structure called a {% tooltip label="trap"
-href="/glossary/trap" /%}.  (Think of the “trap” in the bottom of your
-sink.)  It means a point to which you can return again, perhaps with
-some key values (like a counter) changed.  Then you can repeat the
-calculation inside the trap again.  This continues until some single
-value, some noun, results, thereby handing a value back out of the
-expression.  (Remember that every Hoon expression results in a value.)
+values).  One way to do this is using the `|-`
+[barhep](/language/hoon/reference/rune/bar#--barhep) rune, which creates
+a structure called a [trap](/glossary/trap).  (Think of the “trap” in
+the bottom of your sink.)  It means a point to which you can return
+again, perhaps with some key values (like a counter) changed.  Then you
+can repeat the calculation inside the trap again.  This continues until
+some single value, some noun, results, thereby handing a value back out
+of the expression.  (Remember that every Hoon expression results in a
+value.)
 
 This program adds 1+2+3+4+5 and returns the sum:
 
@@ -106,9 +106,9 @@ Let's unroll it:
 And thus `sum` yields the final value of `15`.
 
 It is frequently helpful, when constructing these, to be able to output
-the values at each step of the process.  Use the `~&` {% tooltip
-label="sigpam" href="/language/hoon/reference/rune/sig#-sigpam" /%} rune
-to create output without changing any values:
+the values at each step of the process.  Use the `~&`
+[sigpam](/language/hoon/reference/rune/sig#-sigpam) rune to create
+output without changing any values:
 
 ```hoon {% copy=true %}
 =/  counter  1
@@ -148,8 +148,8 @@ You can do even better using _interpolation_:
   [factorial](https://mathworld.wolfram.com/Factorial.html).  The
   factorial of a number {% math %}n{% /math %} is {% math %}n \times
   (n-1) \times \ldots \times 2 \times 1{% /math %}.  We will introduce a
-  couple of new bits of syntax and a new gate ({% tooltip label="++dec"
-  href="/language/hoon/reference/stdlib/1a#dec" /%}).  Make this into a
+  couple of new bits of syntax and a new gate
+  ([++dec](/language/hoon/reference/stdlib/1a#dec)).  Make this into a
   generator `factorial.hoon`:
 
     ```hoon {% copy=true %}
@@ -165,9 +165,9 @@ You can do even better using _interpolation_:
     ==
     ```
 
-    - We are using the `=` irregular syntax for the `.=` {% tooltip
-      label="dottis" href="/language/hoon/reference/rune/dot#-dottis"
-      /%} rune, which tests for the equality of two expressions.
+    - We are using the `=` irregular syntax for the `.=`
+      [dottis](/language/hoon/reference/rune/dot#-dottis) rune, which
+      tests for the equality of two expressions.
 
     ```hoon
     > +factorial 5
@@ -213,7 +213,7 @@ You can do even better using _interpolation_:
 ### Exercise:  Tracking Expression Structure
 
 As we write more complicated programs, it is helpful to learn to read
-the {% tooltip label="runes" href="/glossary/rune" /%} by identifying
+the [runes](/glossary/rune) by identifying
 which daughter expressions attach to which runes, e.g.:
 
 ```hoon
@@ -243,11 +243,10 @@ human readers of the source code.  Here, we have also explicitly marked
 the expansion of the irregular forms.
 
 We will revert to the irregular form more and more.  If you would like
-to see exactly how an expression is structured, you can use the `!,` {%
-tooltip label="zapcom" href="/language/hoon/reference/rune/zap#-zapcom"
-/%} rune.  `!,` zapcom produces an annotated _abstract syntax tree_
-(AST) which labels every value and expands any irregular syntax into the
-regular runic form.
+to see exactly how an expression is structured, you can use the `!,`
+[zapcom](/language/hoon/reference/rune/zap#-zapcom) rune.  `!,` zapcom
+produces an annotated _abstract syntax tree_ (AST) which labels every
+value and expands any irregular syntax into the regular runic form.
 
 ```hoon
 > !,  *hoon  (add 5 6)
@@ -291,8 +290,8 @@ regular runic form.
 ```
 
 (_There's a lot going on in there._  Focus on the four-letter runic
-identifiers:  `%sgpm` for `~&` {% tooltip label="sigpam"
-href="/language/hoon/reference/rune/sig#-sigpam" /%}, for instance.)
+identifiers:  `%sgpm` for `~&`
+[sigpam](/language/hoon/reference/rune/sig#-sigpam), for instance.)
 
 ### Exercise:  Calculate a sequence of numbers
 
@@ -319,15 +318,13 @@ Calculate each one but only return the final value.
 
 ### Exercise:  Output each letter in a `tape`
 
-Produce a gate (generator) which accepts a {% tooltip label="tape"
-href="/glossary/tape" /%} value and returns a `(list @ud)` containing
-the ASCII value of each character.  Use a `|-` {% tooltip label="barhep"
-href="/language/hoon/reference/rune/bar#--barhep" /%} {% tooltip
-label="trap" href="/glossary/trap" /%}.
-The previous code simply modified a value by addition.  You can
-generalize this to other arithmetic processes, like multiplication, but
-you can also grow a data structure like a {% tooltip label="list"
-href="/glossary/list" /%}.
+Produce a gate (generator) which accepts a [tape](/glossary/tape) value
+and returns a `(list @ud)` containing the ASCII value of each character.
+Use a `|-` [barhep](/language/hoon/reference/rune/bar#--barhep)
+[trap](/glossary/trap). The previous code simply modified a value by
+addition.  You can generalize this to other arithmetic processes, like
+multiplication, but you can also grow a data structure like a
+[list](/glossary/list).
 
 For example, given the `tape` `"hello"`, the generator should return the
 list `[104 101 108 108 111 ~]`.  (A list is structurally a
@@ -337,10 +334,10 @@ special syntax reducing to the same thing.
 
 Two tools that may help:
 
-- You can retrieve the _n_^th^ element in a `tape` using the {% tooltip
-  label="++snag" href="/language/hoon/reference/stdlib/2b#snag" /%}
-  gate, e.g. ``(snag 3 `(list @ud)`~[1 2 3 4 5])`` yields `4` (so
-  `++snag` is zero-indexed; it counts from zero).
+- You can retrieve the _n_^th^ element in a `tape` using the
+  [++snag](/language/hoon/reference/stdlib/2b#snag) gate, e.g. ``(snag 3
+  `(list @ud)`~[1 2 3 4 5])`` yields `4` (so `++snag` is zero-indexed;
+  it counts from zero).
 - You can join an element to a list using the
   [`++snoc`](/language/hoon/reference/stdlib/2b#snoc) gate, e.g. ``(snoc
   `(list @ud)`~[1 2 3] 4)`` yields `~[1 2 3 4]`.
@@ -375,11 +372,10 @@ Some of them are _data_, like raw values:  `0x1234.5678.abcd` and `[5 6
 7]`.  Others are _code_, programs that do something.  What unifies all
 of these under the hood?
 
-A {% tooltip label="core" href="/glossary/core" /%} is a cell pairing
-operations to data.  Formally, we'll say a core is a cell `[battery
-payload]`, where {% tooltip label="battery" href="/glossary/battery" /%}
-describes the things that can be done (the operations) and {% tooltip
-label="payload" href="/glossary/payload" /%} describes the data on which
+A [core](/glossary/core) is a cell pairing operations to data.
+Formally, we'll say a core is a cell `[battery payload]`, where
+[battery](/glossary/battery) describes the things that can be done (the
+operations) and [payload](/glossary/payload) describes the data on which
 those operations rely.  (For many English speakers, the word “battery”
 evokes a [voltaic pile](https://en.wikipedia.org/wiki/Voltaic_pile) more
 than a bank of guns, but the artillery metaphor is a better mnemonic for
@@ -389,36 +385,33 @@ than a bank of guns, but the artillery metaphor is a better mnemonic for
 Hoon.**  Everything nontrivial is a core.  Some of the runes you have
 used already produce cores, like the gate.  That is, a gate marries a
 `battery` (the operating code) to the `payload` (the input values AND
-the {% tooltip label="subject" href="/glossary/subject" /%} or
+the [subject](/glossary/subject) or
 operating context).
 
-Urbit adopts an innovative programming paradigm called {% tooltip
-label="subject-oriented programming"
-href="/glossary/subject-oriented-programming" /%}.  By and large, Hoon
-(and {% tooltip label="Nock" href="/glossary/nock" /%}) is a functional
-programming language in that running a piece of code twice will always
-yield the same result, and because runs cause a program to explicitly
-compose various subexpressions in a somewhat mathematical way.
+Urbit adopts an innovative programming paradigm called [subject-oriented
+programming](/glossary/subject-oriented-programming).  By and large,
+Hoon (and [Nock](/glossary/nock)) is a functional programming language
+in that running a piece of code twice will always yield the same result,
+and because runs cause a program to explicitly compose various
+subexpressions in a somewhat mathematical way.
 
 Hoon (and Nock) very carefully bounds the known context of any part of
-the program as the {% tooltip label="subject" href="/glossary/subject"
-/%}.  Basically, the subject is the noun against which any arbitrary
-Hoon code is evaluated.
+the program as the [subject](/glossary/subject).  Basically, the subject
+is the noun against which any arbitrary Hoon code is evaluated.
 
 For instance, when we first composed generators, we made what are called
 “naked generators”:  that is, they do not have access to any information
-outside of the base subject (Arvo, Hoon, and `%zuse`) and their {%
-tooltip label="sample" href="/glossary/sample" /%} (arguments).  Other {%
-tooltip label="generators" href="/glossary/generator" /%} (such as
-`%say` generators, described below) can have more contextual
-information, including random number generators and optional arguments,
-passed to them to form part of their subject.
+outside of the base subject (Arvo, Hoon, and `%zuse`) and their
+[sample](/glossary/sample) (arguments).  Other
+[generators](/glossary/generator) (such as `%say` generators, described
+below) can have more contextual information, including random number
+generators and optional arguments, passed to them to form part of their
+subject.
 
-Cores have two kinds of values attached:  {% tooltip label="arms"
-href="/glossary/arm" /%} and _legs_, both called limbs.  Arms describe
-known labeled addresses (with `++` luslus or `+$` lusbuc) which carry
-out computations.  Legs are limbs which store data (with e.g. `=/`
-tisfas).
+Cores have two kinds of values attached:  [arms](/glossary/arm) and
+_legs_, both called limbs.  Arms describe known labeled addresses (with
+`++` luslus or `+$` lusbuc) which carry out computations.  Legs are
+limbs which store data (with e.g. `=/` tisfas).
 
 ### Arms
 
@@ -426,30 +419,28 @@ So legs are for data and arms are for computations.  But what
 _specifically_ is an arm, and how is it used for computation?  Let's
 begin with a preliminary explanation that we'll refine later.
 
-An {% tooltip label="arm" href="/glossary/arm" /%} is some expression
+An [arm](/glossary/arm) is some expression
 of Hoon encoded as a noun.  (By 'encoded as a noun' we literally mean:
 'compiled to a Nock formula'.  But you don't need to know anything about
-{% tooltip label="Nock" href="/glossary/nock" /%} to understand Hoon.)
+[Nock](/glossary/nock) to understand Hoon.)
 You virtually never need to treat an arm as raw data, even though
 technically you can—it's just a noun like any other.  You almost always
 want to think of an arm simply as a way of running some Hoon code.
 
-Every expression of Hoon is evaluated relative to a subject.  An {%
-tooltip label="arm" href="/glossary/arm" /%} is a Hoon expression to be
-evaluated against the {% tooltip label="core" href="/glossary/core" /%}
-subject (i.e. its parent core is its subject).
+Every expression of Hoon is evaluated relative to a subject.  An
+[arm](/glossary/arm) is a Hoon expression to be evaluated against the
+[core](/glossary/core) subject (i.e. its parent core is its subject).
 
 #### Arms for Gates
 
 Within a core, we label arms as Hoon expressions (frequently `|=` bartis
-gates) using the `++` {% tooltip label="luslus"
-href="/language/hoon/reference/rune/lus#-luslus" /%} digraph.  (`++`
+gates) using the `++`
+[luslus](/language/hoon/reference/rune/lus#-luslus) digraph.  (`++`
 isn't formally a rune because it doesn't actually change the structure
 of a Hoon expression, it simply marks a name for an expression or value.
-The `--` {% tooltip label="hephep"
-href="/language/hoon/reference/rune/terminators#---hephep" /%} limiter
-digraph is used because `|%` {% tooltip label="barcen"
-href="/language/hoon/reference/rune/bar#-barcen" /%} can have any number
+The `--` [hephep](/language/hoon/reference/rune/terminators#---hephep)
+limiter digraph is used because `|%`
+[barcen](/language/hoon/reference/rune/bar#-barcen) can have any number
 of arms attached.  Like `++`, it is not formally a rune.)
 
 ```hoon {% copy=true %}
@@ -485,10 +476,10 @@ isn't the only way to address an arm, but it's the most common one.
 
 #### Arms for Types
 
-We can define custom types for a core using `+$` {% tooltip
-label="lusbuc" href="/language/hoon/reference/rune/lus#-lusbuc" /%}
-digraphs.  We won't do much with these yet but they will come in handy
-for custom types later on.
+We can define custom types for a core using `+$`
+[lusbuc](/language/hoon/reference/rune/lus#-lusbuc) digraphs.  We won't
+do much with these yet but they will come in handy for custom types
+later on.
 
 This core defines a set of types intended to work with playing cards:
 
@@ -504,10 +495,9 @@ This core defines a set of types intended to work with playing cards:
 #### Cores in Generators
 
 When we write generators, we can include helpful tools as arms either
-before the main code (with `=>` {% tooltip label="tisgar"
-href="/language/hoon/reference/rune/tis#-tisgar" /%}) or after the main
-code (with `=<` {% tooltip label="tisgal"
-href="/language/hoon/reference/rune/tis#-tisgal" /%}):
+before the main code (with `=>`
+[tisgar](/language/hoon/reference/rune/tis#-tisgar)) or after the main
+code (with `=<` [tisgal](/language/hoon/reference/rune/tis#-tisgal)):
 
 ```hoon {% copy=true %}
 |=  n=@ud
@@ -521,9 +511,8 @@ href="/language/hoon/reference/rune/tis#-tisgal" /%}):
 --
 ```
 
-A library (a file in `/lib`) is typically structured as a `|%` {%
-tooltip label="barcen" href="/language/hoon/reference/rune/bar#-barcen"
-/%} core.
+A library (a file in `/lib`) is typically structured as a `|%`
+[barcen](/language/hoon/reference/rune/bar#-barcen) core.
 
 ### Legs
 
@@ -549,8 +538,7 @@ other applications.
 
 Often a leg of the subject is produced with its value unchanged. But
 there is a way to produce a modified version of the leg as well. To do
-so, we use the `%=` {% tooltip label="centis"
-href="/language/hoon/reference/rune/cen#-centis" /%} rune:
+so, we use the `%=` [centis](/language/hoon/reference/rune/cen#-centis) rune:
 
 ```hoon {% copy=true %}
 %=  subject-limb
@@ -586,10 +574,9 @@ $(counter (add counter 1), sum (add sum counter))
 
 This statement means that we recalculate the `$` buc arm of the current
 subject with the indicated changes.  But what is `$` buc?  `$` buc is
-the _default arm_ for many core structures, including `|=` {% tooltip
-label="bartis" href="/language/hoon/reference/rune/bar#-bartis" /%} gate
-cores and `|-` {% tooltip label="barhep"
-href="/language/hoon/reference/rune/bar#--barhep" /%} trap cores.
+the _default arm_ for many core structures, including `|=`
+[bartis](/language/hoon/reference/rune/bar#-bartis) gate cores and `|-`
+[barhep](/language/hoon/reference/rune/bar#--barhep) trap cores.
 
 ### What is a Gate?
 
@@ -597,12 +584,12 @@ A core is a cell:  `[battery payload]`.
 
 A gate is a core with two distinctive properties:
 
-1.  The {% tooltip label="battery" href="/glossary/battery" /%} of a
+1.  The [battery](/glossary/battery) of a
     gate contains an arm which has the special name `$` buc.  The `$`
     buc arm contains the instructions for the function in question.
-2.  The {% tooltip label="payload" href="/glossary/payload" /%} of a
+2.  The [payload](/glossary/payload) of a
     gate consists of a cell of `[sample context]`.
-    1.  The {% tooltip label="sample" href="/glossary/sample" /%} is the
+    1.  The [sample](/glossary/sample) is the
         part of the payload that stores the "argument" (i.e., input
         value) of the function call.
     2.  The **context** contains all other data that is needed for
@@ -644,9 +631,9 @@ Let's revisit our factorial code from above:
 ==
 ```
 
-We can write this code in several ways using the `%=` {% tooltip
-label="centis" href="/language/hoon/reference/rune/cen#-centis" /%} plus
-`$` buc structure.
+We can write this code in several ways using the `%=`
+[centis](/language/hoon/reference/rune/cen#-centis) plus `$` buc
+structure.
 
 For instance, we can eliminate the trap by recursing straight back to
 the gate:
@@ -677,9 +664,8 @@ layout.)
 
 #### The `$` Buc Arm
 
-The (only) {% tooltip label="arm" href="/glossary/arm" /%} of a {%
-tooltip label="gate" href="/glossary/gate" /%} encodes the instructions
-for the Hoon function in question.
+The (only) [arm](/glossary/arm) of a [gate](/glossary/gate) encodes the
+instructions for the Hoon function in question.
 
 ```hoon
 > =inc |=(a=@ (add 1 a))
@@ -716,7 +702,7 @@ little better.
 
 #### The Sample
 
-The {% tooltip label="sample" href="/glossary/sample" /%} of a gate is
+The [sample](/glossary/sample) of a gate is
 the address reserved for storing the argument(s) to the Hoon function.
 Although we don't know about addressing yet, you saw above that `+2`
 referred to the battery.  The sample is always at the head of the gate's
@@ -746,7 +732,7 @@ a=0
 ```
 
 We see now that the sample of `inc` is the value `0`, and has `a` as a
-{% tooltip label="face" href="/glossary/face" /%}.  This is a
+[face](/glossary/face).  This is a
 placeholder value for the function argument.  If you evaluate the `$`
 buc arm of `inc` without passing it an argument the placeholder value is
 used for the computation, and the return value will thus be `0+1`:
@@ -757,7 +743,7 @@ used for the computation, and the return value will thus be `0+1`:
 ```
 
 The placeholder value, as you saw in the previous module, is sometimes
-called the {% tooltip label="bunt" href="/glossary/bunt" /%} value.  The
+called the [bunt](/glossary/bunt) value.  The
 bunt value is determined by the input type; for `@` atoms the bunt value
 is typically `0`.
 
@@ -787,11 +773,10 @@ Let's look at the context of inc:
 ```
 
 This is the default Dojo subject from before we put `inc` into the
-subject. The `|=` {% tooltip label="bartis"
-href="/language/hoon/reference/rune/bar#-bartis" /%} expression defines
-the context as whatever the subject is.  This guarantees that the
-context has all the information it needs to have for the `$` buc arm to
-work correctly.
+subject. The `|=` [bartis](/language/hoon/reference/rune/bar#-bartis)
+expression defines the context as whatever the subject is.  This
+guarantees that the context has all the information it needs to have for
+the `$` buc arm to work correctly.
 
 #### Gates Define Functions of the Sample
 
@@ -821,11 +806,10 @@ core, the product is `235`.
 
 Notice that neither the arm nor the context is modified before the arm
 is evaluated.  That means that the only part of the gate that changes
-before the arm evaluation is the {% tooltip label="sample"
-href="/glossary/sample" /%}.  Hence, we may understand each gate as
-defining a function whose argument is the sample.  If you call a gate
-with the same sample, you'll get the same value returned to you every
-time.
+before the arm evaluation is the [sample](/glossary/sample).  Hence, we
+may understand each gate as defining a function whose argument is the
+sample.  If you call a gate with the same sample, you'll get the same
+value returned to you every time.
 
 Let's unbind inc to keep the subject tidy:
 
@@ -909,12 +893,11 @@ _Recursion_ refers to a return to the same logical point in a program
 again and again.  It's a common pattern for solving certain problems in
 most programming languages, and Hoon is no exception.
 
-In the following code, the `|-` {% tooltip label="barhep"
-href="/language/hoon/reference/rune/bar#--barhep" /%} {% tooltip
-label="trap" href="/glossary/trap" /%} serves as the point of recursion,
-and the return to that point (with changes) is indicated by the `%=`
-centis.  All this code does is count to the given number, then return
-that number.
+In the following code, the `|-`
+[barhep](/language/hoon/reference/rune/bar#--barhep)
+[trap](/glossary/trap) serves as the point of recursion, and the return
+to that point (with changes) is indicated by the `%=` centis.  All this
+code does is count to the given number, then return that number.
 
 ```hoon {% copy=true %}
 |=  n=@ud
@@ -925,9 +908,9 @@ that number.
 %=($ index +(index))
 ```
 
-We are using the `+` irregular syntax for the `.+` {% tooltip
-label="dotlus" href="/language/hoon/reference/rune/dot#-dotlus" /%}
-rune, which increments a value (adds one).
+We are using the `+` irregular syntax for the `.+`
+[dotlus](/language/hoon/reference/rune/dot#-dotlus) rune, which
+increments a value (adds one).
 
 In a formal sense, we have to make sure that there is always a base
 case, a way of actually ending the recursion—if there isn't, we end up
@@ -945,9 +928,9 @@ rely on such recursive humor.
 > This is the song that never ends
 > . . .
 
-You need to make sure when you compose a {% tooltip label="trap"
-href="/glossary/trap" /%} that it has a base case which returns a noun.
-The following trap results in an infinite loop:
+You need to make sure when you compose a [trap](/glossary/trap) that it
+has a base case which returns a noun. The following trap results in an
+infinite loop:
 
 ```hoon {% copy=true %}
 =/  index  1
@@ -984,8 +967,8 @@ F_n = F_{n-1} + F_{n-2}
 and verify that our program correctly produces the sequence of numbers
 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, ….
 
-- Compose a Fibonacci sequence program which produces a {% tooltip
-  label="list" href="/glossary/list" /%} of the appropriate values.
+- Compose a Fibonacci sequence program which produces a
+  [list](/glossary/list) of the appropriate values.
 
     We can elide some details of working with `list`s until the next
     lesson; simply recall that they are a way of storing multiple values
@@ -1002,8 +985,8 @@ and verify that our program correctly produces the sequence of numbers
     (add $(n (dec n)) $(n (dec (dec n))))
     ```
 
-    We can use _two_ recursion points for `%=` {% tooltip label="centis"
-    href="/language/hoon/reference/rune/cen#-centis" /%}.  The first
+    We can use _two_ recursion points for `%=`
+    [centis](/language/hoon/reference/rune/cen#-centis).  The first
     calculate {% math %}F{% /math %} for {% math %}n-1{% /math %}; the
     second calculate {% math %}F{% /math %} for {% math %}n-2{% /math
     %}.  These are then added together.  If we diagram what's happening,
@@ -1033,8 +1016,7 @@ and verify that our program correctly produces the sequence of numbers
 
     An improved version stores each value in the sequence as an element
     in a list so that it can be used rather than re-calculated.  We use
-    the {% tooltip label="++snoc"
-    href="/language/hoon/reference/stdlib/2b#snoc" /%} gate to append a
+    the [++snoc](/language/hoon/reference/stdlib/2b#snoc) gate to append a
     noun to a `list`.
 
     ```hoon {% copy=true %}
@@ -1055,11 +1037,11 @@ and verify that our program correctly produces the sequence of numbers
     ```
 
     (As in an earlier code example, `(add index 1)` can be replaced by
-    the Nock increment rune, `.+` {% tooltip label="dotlus"
-    href="/language/hoon/reference/rune/dot#-dotlus" /%}.)
+    the Nock increment rune, `.+`
+    [dotlus](/language/hoon/reference/rune/dot#-dotlus).)
 
     This version is a little more complicated to compare using a diagram
-    because of the {% trap, but yields something like this:
+    because of the [trap](/glossary/trap), but yields something like this:
 
     ```hoon
     (fibonacci 5)
@@ -1072,8 +1054,8 @@ and verify that our program correctly produces the sequence of numbers
 
     The program can be improved somewhat again by appending to the head
     of the cell (rather than using `++snoc`).  This builds a list in a
-    backwards order, so we apply the {% tooltip label="++flop"
-    href="/language/hoon/reference/stdlib/2b#flop" /%} gate to flip the
+    backwards order, so we apply the
+    [++flop](/language/hoon/reference/stdlib/2b#flop) gate to flip the
     order of the list before we return it.
 
     ```hoon {% copy=true %}
@@ -1205,9 +1187,9 @@ recursion.
 
     The above code should look familiar.  We are still building a gate
     that takes one argument a `@ud` unsigned decimal integer `n`.  The
-    `|-` here is used to create a new gate with one {% tooltip
-    label="arm" href="/glossary/arm" /%} `$` and immediately call it.
-    As before, think of `|-` as the recursion point.
+    `|-` here is used to create a new gate with one [arm](/glossary/arm)
+    `$` and immediately call it. As before, think of `|-` as the
+    recursion point.
 
     We then evaluate `n` to see if it is 1. If it is, we return the
     value of `t`. In case that `n` is anything other than 1, we perform

--- a/content/courses/hoon-school/G-trees.md
+++ b/content/courses/hoon-school/G-trees.md
@@ -14,9 +14,8 @@ a number of standard library operations._
 
 {% video src="https://media.urbit.org/docs/hoon-school-videos/HS135 - Trees.mp4" /%}
 
-Every {% tooltip label="noun" href="/glossary/noun" /%} in Urbit is a
-either an {% tooltip label="atom" href="/glossary/atom" /%} or a {%
-tooltip label="cell" href="/glossary/cell" /%}.  Since a cell has only
+Every [noun](/glossary/noun) in Urbit is a
+either an [atom](/glossary/atom) or a [cell](/glossary/cell).  Since a cell has only
 two elements, a head and a tail, we can derive that everything is
 representable as a [_binary
 tree_](https://en.wikipedia.org/wiki/Binary_tree).  We can draw this
@@ -30,8 +29,7 @@ children is a “leaf”.  You can think of a noun as a binary tree whose
 leaves are atoms, i.e., unsigned integers.  All non-leaf nodes are
 cells.  An atom is a trivial tree of just one node; e.g., `17`.
 
-For instance, if we produce a cell in the {% tooltip label="Dojo"
-href="/glossary/dojo" /%}
+For instance, if we produce a cell in the [Dojo](/glossary/dojo)
 
 ```hoon
 > =a [[[8 9] [10 11]] [[12 13] [14 15]]]
@@ -62,8 +60,7 @@ may be extended indefinitely downwards into ever-deeper tree
 representations.
 
 Most of any possible tree will be unoccupied for any actual data
-structure.  For instance, {% tooltip label="lists" href="/glossary/list"
-/%} (and thus {% tooltip label="tapes" href="/glossary/tape" /%}) are
+structure.  For instance, [lists](/glossary/list) (and thus [tapes](/glossary/tape)) are
 collections of values which occupy the tails of cells, leading to a
 rightwards-branching tree representation. (Although this may seem
 extravagant, it has effectively no bearing on efficiency in and of
@@ -82,7 +79,7 @@ itself—that's a function of the algorithms working with the data.)
 
 ### Exercise:  Produce a List of Numbers
 
-- Produce a {% tooltip label="generator" href="/glossary/generator" /%}
+- Produce a [generator](/glossary/generator)
   called `list.hoon` which accepts a single `@ud` number `n` as input
   and produces a list of numbers from `1` up to (but not including) `n`.
   For example, if the user provides the number `5`, the program will
@@ -197,25 +194,24 @@ dojo: hoon expression failed
 
 {% video src="https://media.urbit.org/docs/hoon-school-videos/HS140 - Lists.mp4" /%}
 
-We have used lists incidentally.  A {% tooltip label="list"
-href="/glossary/list" /%} is an ordered arrangement of elements ending
-in a `~` (null).  Most lists have the same kind of content in every
-element (for instance, a `(list @rs)`, a list of numbers with a
-fractional part), but some lists have many kinds of things within them.
-Some lists are even empty.
+We have used lists incidentally.  A [list](/glossary/list) is an ordered
+arrangement of elements ending in a `~` (null).  Most lists have the
+same kind of content in every element (for instance, a `(list @rs)`, a
+list of numbers with a fractional part), but some lists have many kinds
+of things within them. Some lists are even empty.
 
 ```hoon
 > `(list @)`['a' %b 100 ~]
 ~[97 98 100]
 ```
 
-(Notice that all values are converted to the specified {% tooltip
-label="aura" href="/glossary/aura" /%}, in this case the empty aura.)
+(Notice that all values are converted to the specified
+[aura](/glossary/aura), in this case the empty aura.)
 
 A `list` is built with the `list` mold.  A `list` is actually a _mold
-builder_, a {% tooltip label="gate" href="/glossary/gate" /%} that
+builder_, a [gate](/glossary/gate) that
 produces a gate.  This is a common design pattern in Hoon.  (Remember
-that a {% tooltip label="mold" href="/glossary/mold" /%} is a type and
+that a [mold](/glossary/mold) is a type and
 can be used as an enforcer:  it attempts to convert any data it receives
 into the given structure, and crashes if it fails to do so.)
 Lists are commonly written with a shorthand `~[]`:
@@ -250,22 +246,23 @@ to explicitly mark it as such:
 > -:!>(`(list @ud)`[3 4 5 ~])
 #t/it(@ud)
 ```
+
 A null-terminated tuple is almost the same thing as a list.  (That is,
 to Hoon all lists are null-terminated tuples, but not all
 null-terminated tuples are lists.  This gets rather involved in
 subtleties, but you should cast a value as `(list @)` or another type as
-appropriate whenever you need a `list`.  See also {% tooltip
-label="++limo" href="/language/hoon/reference/stdlib/2b#limo" /%} which
-explicitly marks a null-terminated tuple as a `list`.)
+appropriate whenever you need a `list`.  See also
+[++limo](/language/hoon/reference/stdlib/2b#limo) which explicitly marks
+a null-terminated tuple as a `list`.)
 
 ##  Addressing Limbs
 
 Everything in Urbit is a binary tree.  And all code in Urbit is also
 represented as data.  One corollary of these facts is that we can access
-any arbitrary part of an expression, gate, {% tooltip label="core"
-href="/glossary/core" /%}, whatever, via addressing (assuming proper
-permissions, of course).  (In fact, we can even hot-swap parts of cores,
-which is how [wet gates](/courses/hoon-school/R-metals#wet-gates) work.)
+any arbitrary part of an expression, gate, [core](/glossary/core),
+whatever, via addressing (assuming proper permissions, of course).  (In
+fact, we can even hot-swap parts of cores, which is how [wet
+gates](/courses/hoon-school/R-metals#wet-gates) work.)
 
 There are three different ways to access values:
 
@@ -293,7 +290,7 @@ it just happens.
 
 ### Exercise:  Tapes for Text
  
-A {% tooltip label="tape" href="/glossary/tape" /%} is one way of
+A [tape](/glossary/tape) is one way of
 representing a text message in Hoon.  It is written with double quotes:
  
 ```hoon {% copy=true %}
@@ -331,7 +328,7 @@ elements deep, but it can be helpful when working interactively with a
 complicated data structure like a JSON data object.
 
 When lark expressions resolve to the part of the subject containing an
-{% tooltip label="arm" href="/glossary/arm" /%}, they don't evaluate the
+[arm](/glossary/arm), they don't evaluate the
 arm.  They simply return the indicated noun fragment of the subject, as
 if it were a leg.
 
@@ -382,12 +379,11 @@ Solutions to these exercises may be found at the bottom of this lesson.
 
 ## Wings
 
-One can also identify a resource by a label, called a {% tooltip
-label="wing" href="/glossary/wing" /%}.  A wing represents a depth-first
-search into the current {% tooltip label="subject"
-href="/glossary/subject" /%} (context).  A wing is a limb resolution
-path into the subject. A wing expression indicates the path as a series
-of limb expressions separated by the `.` character. E.g.,
+One can also identify a resource by a label, called a
+[wing](/glossary/wing).  A wing represents a depth-first search into the
+current [subject](/glossary/subject) (context).  A wing is a limb
+resolution path into the subject. A wing expression indicates the path
+as a series of limb expressions separated by the `.` character. E.g.,
 
 ```hoon {% copy=true %}
 inner-limb.outer-limb.limb
@@ -461,7 +457,7 @@ computation is produced.  When a limb name resolves to a leg, the value
 of that leg is produced.
 
 Hoon doesn't have variables like other programming languages do; it has
-{% tooltip label="faces" href="/glossary/face" /%}.  Faces are like
+[faces](/glossary/face).  Faces are like
 variables in certain respects, but not in others.  Faces play various
 roles in Hoon, but most frequently faces are used simply as labels for
 legs.
@@ -639,15 +635,16 @@ We say that the inner face has been _shadowed_ when an outer name
 obscures it.
 
 If you run into `^$`, don't go look for a `^$` ketbuc rune:  it's
-matching the outer `$` buc arm.  `^$` is one way of setting up a `%=` {%
-tooltip label="centis" href="/language/hoon/reference/rune/cen#-centis"
-/%} loop/recursion of multiple cores with a `|-` {% tooltip
-label="barhep" href="/language/hoon/reference/rune/bar#--barhep" /%} {%
-tooltip label="trap" href="/glossary/trap" /%} nested inside of a
-`|=` {% tooltip label="bartis"
-href="/language/hoon/reference/rune/bar#-bartis" /%} gate, for instance.
+matching the outer `$` buc arm.  `^$` is one way of setting up a `%=`
+[centis](/language/hoon/reference/rune/cen#-centis) loop/recursion of
+multiple cores with a `|-`
+[barhep](/language/hoon/reference/rune/bar#--barhep)
+[trap](/glossary/trap) nested inside of a `|=`
+[bartis](/language/hoon/reference/rune/bar#-bartis) gate, for instance.
 
-Solution #1 in the [Rhonda Numbers](/language/hoon/examples/rhonda) tutorial in the Hoon Workbook illustrates using `^` ket to skip `$` buc matches.
+Solution #1 in the [Rhonda Numbers](/language/hoon/examples/rhonda)
+tutorial in the Hoon Workbook illustrates using `^` ket to skip `$` buc
+matches.
 
 ### Limb Resolution Operators
 
@@ -663,12 +660,12 @@ regular lookup, though.
 
 ### What `%=` Does
 
-Now we're equipped to go back and examine the syntax of the `%=` {%
-tooltip label="centis" href="/language/hoon/reference/rune/cen#-centis"
-/%} rune we have been using for recursion:  it _resolves a wing with
-changes_, which in this particular case means that it takes the `$`
-(default) arm of the {% tooltip label="trap" href="/glossary/trap" /%}
-core, applies certain changes, and re-evaluates the expression.
+Now we're equipped to go back and examine the syntax of the `%=`
+[centis](/language/hoon/reference/rune/cen#-centis) rune we have been
+using for recursion:  it _resolves a wing with changes_, which in this
+particular case means that it takes the `$` (default) arm of the
+[trap](/glossary/trap) core, applies certain changes, and re-evaluates
+the expression.
 
 ```hoon {% copy=true %}
 |=  n=@ud
@@ -681,9 +678,8 @@ core, applies certain changes, and re-evaluates the expression.
 $(n (dec n))
 ```
 
-The `$()` syntax is the commonly-used irregular form of the `%=` {%
-tooltip label="centis" href="/language/hoon/reference/rune/cen#-centis"
-/%} rune.
+The `$()` syntax is the commonly-used irregular form of the `%=`
+[centis](/language/hoon/reference/rune/cen#-centis) rune.
 
 Now, we noted that `$` buc is the default arm for the trap.  It turns
 out that `$` is also the default arm for some other structures, like the
@@ -698,13 +694,11 @@ write something more compact like this:
 ```
 
 It's far more common to just use a trap, but you will see `$` buc used
-to manipulate a {% tooltip label="core" href="/glossary/core" /%} in
-many in-depth code instances.
+to manipulate a [core](/glossary/core) in many in-depth code instances.
 
 ### Expanding the Runes
  
-`|=` {% tooltip label="bartis"
-href="/language/hoon/reference/rune/bar#-bartis" /%} produces a gate.
+`|=` [bartis](/language/hoon/reference/rune/bar#-bartis) produces a gate.
 It actually expands to
 
 ```hoon {% copy=true %}
@@ -713,20 +707,16 @@ It actually expands to
 --
 ``` 
 
-where `=|` {% tooltip label="tisbar"
-href="/language/hoon/reference/rune/tis#-tisbar" /%} means to add its
-sample to the current subject with the given {% tooltip label="face"
-href="/glossary/face" /%}.
+where `=|` [tisbar](/language/hoon/reference/rune/tis#-tisbar) means to add its
+sample to the current subject with the given [face](/glossary/face).
 
-Similarly, `|-` {% tooltip label="barhep"
-href="/language/hoon/reference/rune/bar#--barhep" /%} produces a {%
-tooltip label="core" href="/glossary/core" /%} with one arm `$`.  How
+Similarly, `|-` [barhep](/language/hoon/reference/rune/bar#--barhep) produces a [core](/glossary/core) with one arm `$`.  How
 could you write that in terms of `|%` and `++`?
 
 ### Example:  Number to Digits
 
 - Compose a generator which accepts a number as `@ud` unsigned decimal
-  and returns a {% tooltip label="list" href="/glossary/list" /%} of its
+  and returns a [list](/glossary/list) of its
   digits.
 
 One verbose Hoon program 
@@ -754,9 +744,8 @@ Save this as a file `/gen/num2dig.hoon`, `|commit %base`, and run it:
 ```
 
 A more idiomatic solution would use the `^` ket infix to compose a cell
-and build the list from the head first.  (This saves a call to {%
-tooltip label="++weld" href="/language/hoon/reference/stdlib/2b#weld"
-/%}.)
+and build the list from the head first.  (This saves a call to
+[++weld](/language/hoon/reference/stdlib/2b#weld).)
 
 ```hoon {% copy=true %}
 !:
@@ -784,15 +773,14 @@ A further tweak maps to `@t` ASCII characters instead of the digits.
 ==
 ```
 
-(Notice that we apply `@t` as a {% tooltip label="mold"
-href="/glossary/mold" /%} gate rather than using the tic notation.  This
-is because `^` ket is a rare case where the order of evaluation of
-operators would cause the intuitive writing to fail.)
+(Notice that we apply `@t` as a [mold](/glossary/mold) gate rather than
+using the tic notation.  This is because `^` ket is a rare case where
+the order of evaluation of operators would cause the intuitive writing
+to fail.)
 
-- Extend the above {% tooltip label="generator"
-  href="/glossary/generator" /%} so that it accepts a cell of type and
-  value (a `vase` as produced by the `!>` {% tooltip label="zapgar"
-  href="/language/hoon/reference/rune/zap#-zapgar" /%} rune).  Use the
+- Extend the above [generator](/glossary/generator) so that it accepts a
+  cell of type and value (a `vase` as produced by the `!>`
+  [zapgar](/language/hoon/reference/rune/zap#-zapgar) rune).  Use the
   type to determine which number base the digit string should be
   constructed from; e.g. `+num2dig !>(0xdead.beef)` should yield `~['d'
   'e' 'a' 'd' 'b' 'e' 'e' 'f']`.
@@ -827,8 +815,7 @@ Enter the following into dojo:
 Once you have your data in the form of a `list`, there are a lot of
 tools available to manipulate and analyze the data:
 
-- The {% tooltip label="++flop"
-  href="/language/hoon/reference/stdlib/2b#flop" /%} function reverses
+- The [++flop](/language/hoon/reference/stdlib/2b#flop) function reverses
   the order of the elements (exclusive of the `~`):
   
     ```hoon
@@ -840,19 +827,17 @@ tools available to manipulate and analyze the data:
   that takes a `(list @)` and returns it in reverse order.  There is a
   solution at the bottom of the page.
 
-- The {% tooltip label="++sort"
-  href="/language/hoon/reference/stdlib/2b#sort" /%} function uses a
-  `list` and a comparison function (like {% tooltip label="++lth"
-  href="/language/hoon/reference/stdlib/1a#lth" /%}) to order things:
+- The [++sort](/language/hoon/reference/stdlib/2b#sort) function uses a
+  `list` and a comparison function (like
+  [++lth](/language/hoon/reference/stdlib/1a#lth)) to order things:
 
     ```hoon
     > (sort ~[1 3 5 2 4] lth)
     ~[1 2 3 4 5]
     ```
 
-- The {% tooltip label="++snag"
-  href="/language/hoon/reference/stdlib/2b#snag" /%} function takes an
-  index and a `list` to grab out a particular element (note that it
+- The [++snag](/language/hoon/reference/stdlib/2b#snag) function takes
+  an index and a `list` to grab out a particular element (note that it
   starts counting at zero):
 
     ```hoon
@@ -875,9 +860,8 @@ tools available to manipulate and analyze the data:
     '!'
     ```
 
-- The {% tooltip label="++weld"
-  href="/language/hoon/reference/stdlib/2b#weld" /%} function takes two
-  lists of the same type and concatenates them:
+- The [++weld](/language/hoon/reference/stdlib/2b#weld) function takes
+  two lists of the same type and concatenates them:
 
     ```hoon
     > (weld ~[1 2 3] ~[4 5 6])
@@ -894,8 +878,7 @@ tools available to manipulate and analyze the data:
 
 There are a couple of sometimes-useful `list` builders:
 
-- The {% tooltip label="++gulf"
-  href="/language/hoon/reference/stdlib/2b#gulf" /%} function spans
+- The [++gulf](/language/hoon/reference/stdlib/2b#gulf) function spans
   between two numeric values (inclusive of both):
 
     ```hoon
@@ -903,8 +886,7 @@ There are a couple of sometimes-useful `list` builders:
     ~[5 6 7 8 9 10]
     ```
 
-- The {% tooltip label="++reap"
-  href="/language/hoon/reference/stdlib/2b#reap" /%} function repeats a
+- The [++reap](/language/hoon/reference/stdlib/2b#reap) function repeats a
   value many times in a `list`:
 
     ```hoon
@@ -921,9 +903,8 @@ There are a couple of sometimes-useful `list` builders:
     ~[~[5 6 7 8 9 10] ~[5 6 7 8 9 10] ~[5 6 7 8 9 10] ~[5 6 7 8 9 10] ~[5 6 7 8 9 10]]
     ```
 
-- The {% tooltip label="++roll"
-  href="/language/hoon/reference/stdlib/2b#roll" /%} function takes a
-  list and a {% tooltip label="gate" href="/glossary/gate" /%}, and
+- The [++roll](/language/hoon/reference/stdlib/2b#roll) function takes a
+  list and a [gate](/glossary/gate), and
   accumulates a value of the list items using that gate. For example, if
   you want to add or multiply all the items in a list of atoms, you
   would use roll:
@@ -936,27 +917,22 @@ There are a couple of sometimes-useful `list` builders:
     19.326.120
     ```
 
-Once you have a `list` (including a {% tooltip label="tape"
-href="/glossary/tape" /%}), there are a lot of manipulation tools you
-can use to extract data from it or modify it:
+Once you have a `list` (including a [tape](/glossary/tape)), there are a
+lot of manipulation tools you can use to extract data from it or modify
+it:
 
-- The {% tooltip label="++lent"
-  href="/language/hoon/reference/stdlib/2b#lent" /%} function takes
+- The [++lent](/language/hoon/reference/stdlib/2b#lent) function takes
   `[a=(list)]` and gets the number of elements (length) of the list
-- The {% tooltip label="++find"
-  href="/language/hoon/reference/stdlib/2b#find" /%} function takes
+- The [++find](/language/hoon/reference/stdlib/2b#find) function takes
   `[nedl=(list) hstk=(list)]` and locates a sublist (`nedl`, needle) in
   the list (`hstk`, haystack)
-- The {% tooltip label="++snap"
-  href="/language/hoon/reference/stdlib/2b#snap" /%} function takes
+- The [++snap](/language/hoon/reference/stdlib/2b#snap) function takes
   `[a=(list) b=@ c=*]` and replaces the element at an index in the list
   (zero-indexed) with something else
-- The {% tooltip label="++scag"
-  href="/language/hoon/reference/stdlib/2b#scag" /%} function takes
+- The [++scag](/language/hoon/reference/stdlib/2b#scag) function takes
   `[a=@ b=(list)]` and produces the first _a_ elements from the front of
   the list
-- The {% tooltip label="++slag"
-  href="/language/hoon/reference/stdlib/2b#slag" /%} function takes
+- The [++slag](/language/hoon/reference/stdlib/2b#slag) function takes
   `[a=@ b=(list)]` and produces all elements of the list including and
   after the element at index _a_
 
@@ -1002,8 +978,8 @@ First, bind these faces.
 ### Exercise:  Palindrome
 
 - Write a gate that takes in a list `a` and returns `%.y` if `a` is a
-  palindrome and `%.n` otherwise.  You may use the {% tooltip
-  label="++flop" href="/language/hoon/reference/stdlib/2b#flop" /%} function.
+  palindrome and `%.n` otherwise.  You may use the
+  [++flop](/language/hoon/reference/stdlib/2b#flop) function.
 
 ## Solutions to Exercises
 
@@ -1094,7 +1070,8 @@ First, bind these faces.
     <|moon planet star galaxy moon planet star galaxy|>
     ```
 
-    This will not run because `weld` expects the elements of both lists to be of the same type:
+    This will not run because `weld` expects the elements of both lists
+    to be of the same type:
 
     ```hoon
     > (weld b c)

--- a/content/courses/hoon-school/H-libraries.md
+++ b/content/courses/hoon-school/H-libraries.md
@@ -10,25 +10,22 @@ will discuss how libraries can be produced, imported, and used._
 
 ##  Importing a Library
 
-If you have only built {% tooltip label="generators"
-href="/glossary/generator" /%}, you will soon or later become frustrated
-with the apparent requirement that you manually reproduce helper cores
-and arms every time you need them in a different generator. Libraries
-are {% tooltip label="cores" href="/glossary/core" /%} stored in `/lib`
-which provide access to {% tooltip label="arms" href="/glossary/arm" /%}
-and legs (operations and data).  While the Hoon standard library is
-directly available in the regular {% tooltip label="subject"
-href="/glossary/subject" /%}, many other elements of functionality have
-been introduced by software authors.
+If you have only built [generators](/glossary/generator), you will soon
+or later become frustrated with the apparent requirement that you
+manually reproduce helper cores and arms every time you need them in a
+different generator. Libraries are [cores](/glossary/core) stored in
+`/lib` which provide access to [arms](/glossary/arm) and legs
+(operations and data).  While the Hoon standard library is directly
+available in the regular [subject](/glossary/subject), many other
+elements of functionality have been introduced by software authors.
 
 ### Building Code Generally
 
 A generator gives us on-demand access to code, but it is helpful to load
-and use code from files while we work in the {% tooltip label="Dojo"
-href="/glossary/dojo" /%}.
+and use code from files while we work in the [Dojo](/glossary/dojo).
 
-A conventional library import with `/+` {% tooltip label="faslus"
-href="/language/hoon/reference/rune/fas#-faslus" /%} will work in a
+A conventional library import with `/+`
+[faslus](/language/hoon/reference/rune/fas#-faslus) will work in a
 generator or another file, but won't work in Dojo, so you can't use `/+`
 faslus interactively.  The first line of many generators will include an
 import line like this:
@@ -37,8 +34,8 @@ import line like this:
 /+  number-to-words
 ```
 
-Subsequent invocations of the {% tooltip label="core"
-href="/glossary/core" /%} require you to refer to it by name:
+Subsequent invocations of the [core](/glossary/core) require you to
+refer to it by name:
 
 **/gen/n2w.hoon**
 
@@ -49,10 +46,10 @@ href="/glossary/core" /%} require you to refer to it by name:
 ```
 
 Since `/` fas runes don't work in the Dojo, you need to instead use the
-{% tooltip label="-build-file" href="/manual/os/dojo-tools#-build-file" /%} thread
-to load the code. Most commonly, you will do this with
-library code when you need a particular {% tooltip label="gate's"
-href="/glossary/gate" /%} functionality for interactive coding.
+[-build-file](/manual/os/dojo-tools#-build-file) thread to load the
+code. Most commonly, you will do this with library code when you need a
+particular [gate's](/glossary/gate) functionality for interactive
+coding.
 
 `-build-file` accepts a file path and returns the built operational
 code.  For instance:
@@ -67,43 +64,39 @@ code.  For instance:
 [~ "nineteen"]
 ```
 
-There are also a number of other import {% tooltip label="runes"
-href="/glossary/rune" /%} which make library, structure, and mark code
-available to you.  For now, the only one you need to worry about is
-`/+` {% tooltip label="faslus"
-href="/language/hoon/reference/rune/fas#-faslus" /%}.
+There are also a number of other import [runes](/glossary/rune) which
+make library, structure, and mark code available to you.  For now, the
+only one you need to worry about is `/+`
+[faslus](/language/hoon/reference/rune/fas#-faslus).
 
-For simplicity, everything we do will take place on the `%base` {%
-tooltip label="desk" href="/glossary/desk" /%} for now.  We will learn
-how to create a library in a subsequent lesson.
+For simplicity, everything we do will take place on the `%base`
+[desk](/glossary/desk) for now.  We will learn how to create a library
+in a subsequent lesson.
 
 ### Exercise: Loading a Library
 
-In a {% tooltip label="generator" href="/glossary/generator" /%}, load
-the `number-to-words` library using the `/+` {% tooltip label="tislus"
-href="/language/hoon/reference/rune/tis#-tislus" /%} rune.  (This must
+In a [generator](/glossary/generator), load the `number-to-words`
+library using the `/+`
+[tislus](/language/hoon/reference/rune/tis#-tislus) rune.  (This must
 take place at the very top of your file.)
 
-Use this to produce a {% tooltip label="gate" href="/glossary/gate" /%}
-which accepts an unsigned decimal integer and returns the text
-interpretation of its increment.
+Use this to produce a [gate](/glossary/gate) which accepts an unsigned
+decimal integer and returns the text interpretation of its increment.
 
 ## Helper Cores
 
 Another common design pattern besides creating a library is to sequester
-core-specific behavior in a helper {% tooltip label="core"
-href="/glossary/core" /%}, which sits next to the interface operations.
-Two runes are used to compose expressions together so that the subject
-has everything it needs to carry out the desired calculations.
+core-specific behavior in a helper [core](/glossary/core), which sits
+next to the interface operations. Two runes are used to compose
+expressions together so that the subject has everything it needs to
+carry out the desired calculations.
 
-- `=>` {% tooltip label="tisgar"
-  href="/language/hoon/reference/rune/tis#-tisgar" /%} composes two
-  expressions so that the first is included in the second's {% tooltip
-  label="subject" href="/glossary/subject" /%} (and thus can see it).
-- `=<` {% tooltip label="tisgal"
-  href="/language/hoon/reference/rune/tis#-tisgal" /%} inverts the order
-  of composition, allowing heavier helper cores to be composed after the
-  core's logic but still be available for use.
+- `=>` [tisgar](/language/hoon/reference/rune/tis#-tisgar) composes two
+  expressions so that the first is included in the second's
+  [subject](/glossary/subject) (and thus can see it).
+- `=<` [tisgal](/language/hoon/reference/rune/tis#-tisgal) inverts the
+  order of composition, allowing heavier helper cores to be composed
+  after the core's logic but still be available for use.
 
 Watch for these being used in generators and libraries over the next few
 modules.
@@ -111,19 +104,17 @@ modules.
 ### Exercise:  A Playing Card Library
 
 In this exercise, we examine a library that can be used to represent a
-deck of 52 playing cards.  The {% tooltip label="core"
-href="/glossary/core" /%} below builds such a library, and can be
-accessed by programs.  You should recognize most of the things this
-program does aside from the `++shuffle-deck` arm which uses a
-[door](/courses/hoon-school/K-doors) to produce
+deck of 52 playing cards.  The [core](/glossary/core) below builds such
+a library, and can be accessed by programs.  You should recognize most
+of the things this program does aside from the `++shuffle-deck` arm
+which uses a [door](/courses/hoon-school/K-doors) to produce
 [randomness](/courses/hoon-school/O-subject).  This is fairly idiomatic
 Hoon and it relies a lot on the convention that heavier code should be
-lower in the expression.  This means that instead of `?:` {% tooltip
-label="wutcol" href="/language/hoon/reference/rune/wut#-wutcol" /%} you
-may see `?.` {% tooltip label="wutdot"
-href="/language/hoon/reference/rune/wut#-wutdot" /%}, which inverts the
-order of the true/false {% tooltip label="arms" href="/glossary/arm"
-/%}, as well as other new constructions.
+lower in the expression.  This means that instead of `?:`
+[wutcol](/language/hoon/reference/rune/wut#-wutcol) you may see `?.`
+[wutdot](/language/hoon/reference/rune/wut#-wutdot), which inverts the
+order of the true/false [arms](/glossary/arm), as well as other new
+constructions.
 
 ```hoon {% copy=true mode="collapse" %}
 |%
@@ -178,42 +169,38 @@ order of the true/false {% tooltip label="arms" href="/glossary/arm"
 --
 ```
 
-The `|%` {% tooltip label="barcen"
-href="/language/hoon/reference/rune/bar#-barcen" /%} core created at the
-top of the file contains the entire library's code, and is closed by
-`--` {% tooltip label="hephep"
-href="/language/hoon/reference/rune/terminators#---hephep" /%} on the
+The `|%` [barcen](/language/hoon/reference/rune/bar#-barcen) core
+created at the top of the file contains the entire library's code, and
+is closed by `--`
+[hephep](/language/hoon/reference/rune/terminators#---hephep) on the
 last line.
 
-To create three types we're going to need, we use `+$` {% tooltip
-label="lusbuc" href="/language/hoon/reference/rune/lus#-lusbuc" /%},
-which is an {% tooltip label="arm" href="/glossary/arm" /%} used to
-define a type.
+To create three types we're going to need, we use `+$`
+[lusbuc](/language/hoon/reference/rune/lus#-lusbuc), which is an
+[arm](/glossary/arm) used to define a type.
 
 - `+$  suit  ?(%hearts %spades %clubs %diamonds)` defines `+$suit`,
   which can be either `%hearts`, `%spades`, `%clubs`, or `%diamonds`.
-  It's a type union created by the irregular form of `$?` {% tooltip
-  label="bucwut" href="/language/hoon/reference/rune/buc#-bucwut" /%}.
+  It's a type union created by the irregular form of `$?`
+  [bucwut](/language/hoon/reference/rune/buc#-bucwut).
 
 - `+$  darc  [sut=suit val=@ud]` defines `+$darc`, which is a pair of
   `suit` and a `@ud`. By pairing a suit and a number, it represents a
   particular playing card, such as “nine of hearts”.  Why do we call it
-  `darc` and not `card`?  Because `card` already has a meaning in {%
-  tooltip label="Gall" href="/glossary/gall" /%}, the {% tooltip
-  label="Arvo" href="/glossary/arvo" /%} app module, where one would
-  likely to use this (or any) library.  It's worthwhile to avoid any
-  confusion over names.
+  `darc` and not `card`?  Because `card` already has a meaning in
+  [Gall](/glossary/gall), the [Arvo](/glossary/arvo) app module, where
+  one would likely to use this (or any) library.  It's worthwhile to
+  avoid any confusion over names.
 
-- `+$  deck  (list darc)` is simply a {% tooltip label="list"
-  href="/glossary/list" /%} of `darc`.
+- `+$  deck  (list darc)` is simply a [list](/glossary/list) of `darc`.
 
-One way to get a feel for how a library works is to skim the `++` {%
-tooltip label="luslus" href="/language/hoon/reference/rune/lus#-luslus"
-/%} arm-names before diving into any specific {% tooltip label="arm"
-href="/glossary/arm" /%}.  In this library, the arms are `++make-deck`,
-`++num-to-suit`, `++shuffle-deck`, and `++draw`. These names should be
-very clear, with the exception of `++num-to-suit` (although you could
-hazard a guess at what it does).  Let's take a closer look at it first:
+One way to get a feel for how a library works is to skim the `++`
+[luslus](/language/hoon/reference/rune/lus#-luslus) arm-names before
+diving into any specific [arm](/glossary/arm).  In this library, the
+arms are `++make-deck`, `++num-to-suit`, `++shuffle-deck`, and `++draw`.
+These names should be very clear, with the exception of `++num-to-suit`
+(although you could hazard a guess at what it does).  Let's take a
+closer look at it first:
 
 ```hoon {% copy=true %}
 ++  num-to-suit
@@ -228,13 +215,12 @@ hazard a guess at what it does).  Let's take a closer look at it first:
 ```
 
 `++num-to-suit` defines a gate which takes a single `@ud` unsigned
-decimal integer and produces a `suit`.  The `?+` {% tooltip
-label="wutlus" href="/language/hoon/reference/rune/wut#-wutlus" /%} rune
-creates a structure to switch against a value with a default in case
-there are no matches.  (Here the default is to crash with `!!` {%
-tooltip label="zapzap" href="/language/hoon/reference/rune/zap#-zapzap"
-/%}.)  We then have options 1–4 which each resulting in a different
-suit.
+decimal integer and produces a `suit`.  The `?+`
+[wutlus](/language/hoon/reference/rune/wut#-wutlus) rune creates a
+structure to switch against a value with a default in case there are no
+matches.  (Here the default is to crash with `!!`
+[zapzap](/language/hoon/reference/rune/zap#-zapzap).)  We then have
+options 1–4 which each resulting in a different suit.
 
 ```hoon {% copy=true %}
 ++  make-deck
@@ -260,13 +246,12 @@ and a couple of loops to go through the counters.  It has an interesting
 `^$` loop skip where when `j` is greater than 14 it jumps instead to the
 outer loop, incrementing `i`.
 
-`?.` {% tooltip label="wutdot"
-href="/language/hoon/reference/rune/wut#-wutdot" /%} may be an
-unfamiliar rune; it is simply the inverted version of `?:` {% tooltip
-label="wutcol" href="/language/hoon/reference/rune/wut#-wutcol" /%}, so
-the first branch is actually the if-false branch and the second is the
-if-true branch.  This is done to keep the “heaviest” branch at the
-bottom, which makes for more idiomatic and readable Hoon code.
+`?.` [wutdot](/language/hoon/reference/rune/wut#-wutdot) may be an
+unfamiliar rune; it is simply the inverted version of `?:`
+[wutcol](/language/hoon/reference/rune/wut#-wutcol), so the first branch
+is actually the if-false branch and the second is the if-true branch.
+This is done to keep the “heaviest” branch at the bottom, which makes
+for more idiomatic and readable Hoon code.
 
 ```hoon {% copy=true %}
 ++  draw
@@ -277,19 +262,17 @@ bottom, which makes for more idiomatic and readable Hoon code.
 ```
 
 `++draw` takes two arguments:  `n`, an unsigned integer, and `d`, a
-`deck`.  The gate will produce a cell of two `decks` using {% tooltip
-label="++scag" href="/language/hoon/reference/stdlib/2b#scag" /%} and {%
-tooltip label="++slag" href="/language/hoon/reference/stdlib/2b#slag"
-/%}. {% tooltip label="++scag"
-href="/language/hoon/reference/stdlib/2b#scag" /%} is a standard library
-{% tooltip label="gate" href="/glossary/gate" /%} produces the first `n`
-elements from a {% tooltip label="list" href="/glossary/list" /%},
-while {% tooltip label="++slag" href="/language/hoon/reference/stdlib/2b#slag"
-/%} is a standard library gate that produces the remaining elements of a
-list starting after the `n`th element.  So we use `++scag` to produce
-the drawn hand of `n` cards in the head of the cell as `hand`, and
-`++slag` to produce the remaining deck in the tail of the cell as
-`rest`.
+`deck`.  The gate will produce a cell of two `decks` using
+[++scag](/language/hoon/reference/stdlib/2b#scag) and
+[++slag](/language/hoon/reference/stdlib/2b#slag).
+[++scag](/language/hoon/reference/stdlib/2b#scag) is a standard library
+[gate](/glossary/gate) produces the first `n` elements from a
+[list](/glossary/list), while
+[++slag](/language/hoon/reference/stdlib/2b#slag) is a standard library
+gate that produces the remaining elements of a list starting after the
+`n`th element.  So we use `++scag` to produce the drawn hand of `n`
+cards in the head of the cell as `hand`, and `++slag` to produce the
+remaining deck in the tail of the cell as `rest`.
 
 ```hoon {% copy=true %}
 ++  shuffle-deck
@@ -311,60 +294,53 @@ the drawn hand of `n` cards in the head of the cell as `hand`, and
 ```
 
 Finally we come to `++shuffle-deck`.  This gate takes two arguments:  a
-`deck`, and a `@` as a bit of `entropy` to seed the {% tooltip
-label="og" href="/language/hoon/reference/stdlib/3d#og" /%}
-random-number {% tooltip label="core" href="/glossary/core" /%}.  It
-will produce a `deck`.
+`deck`, and a `@` as a bit of `entropy` to seed the
+[og](/language/hoon/reference/stdlib/3d#og) random-number
+[core](/glossary/core).  It will produce a `deck`.
 
 We add a bunted `deck`, then encounter a very interesting statement that
-you haven't run into yet.  This is the irregular form of `%~` {% tooltip
-label="censig" href="/language/hoon/reference/rune/cen#-censig" /%},
-which “evaluates an arm in a door.”  For our purposes now, you can see
-it as a way of creating a random-value arm that we'll use later on with
+you haven't run into yet.  This is the irregular form of `%~`
+[censig](/language/hoon/reference/rune/cen#-censig), which “evaluates an
+arm in a door.”  For our purposes now, you can see it as a way of
+creating a random-value arm that we'll use later on with
 `++rads:random`.
 
 With `=/  remaining  (lent unshuffled)`, we get the length of the
-unshuffled deck with {% tooltip label="++lent"
-href="/language/hoon/reference/stdlib/2b#lent" /%}.
+unshuffled deck with [++lent](/language/hoon/reference/stdlib/2b#lent).
 
 `?:  =(remaining 1)` checks if we have only one card remaining. If
-that's true, we produce a {% tooltip label="cell" href="/glossary/cell"
-/%} of `shuffled` and the one card left in `unshuffled`. We use the
-`:_` {% tooltip label="colcab"
-href="/language/hoon/reference/rune/col#_-colcab" /%} rune here, so that
+that's true, we produce a [cell](/glossary/cell) of `shuffled` and the
+one card left in `unshuffled`. We use the `:_`
+[colcab](/language/hoon/reference/rune/col#_-colcab) rune here, so that
 the “heavier” expression is at the bottom.
 
 If the above conditional evaluates to `%.n` false, we need to do a
-little work. `=^` {% tooltip label="tisket"
-href="/language/hoon/reference/rune/tis#-tisket" /%} is a rune that pins
-the head of a pair and changes a leg in the {% tooltip label="subject"
-href="/glossary/subject" /%} with the tail.  It's useful for interacting
-with the {% tooltip label="og"
-href="/language/hoon/reference/stdlib/3d#og" /%} core arms, as many of
-them produce a pair of a random numbers and the next state of the core.
-We're going to put the random number in the {% tooltip label="subject"
-href="/glossary/subject" /%} with the {% tooltip label="face"
-href="/glossary/face" /%} `index` and change `random` to be the next
-core.
+little work. `=^` [tisket](/language/hoon/reference/rune/tis#-tisket) is
+a rune that pins the head of a pair and changes a leg in the
+[subject](/glossary/subject) with the tail.  It's useful for interacting
+with the [og](/language/hoon/reference/stdlib/3d#og) core arms, as many
+of them produce a pair of a random numbers and the next state of the
+core. We're going to put the random number in the
+[subject](/glossary/subject) with the [face](/glossary/face) `index` and
+change `random` to be the next core.
 
-With that completed, we use `%=` {% tooltip label="centis"
-href="/language/hoon/reference/rune/cen#-centis" /%} to call `$` buc to
-recurse back up to `|-` {% tooltip label="barhep"
-href="/language/hoon/reference/rune/bar#--barhep" /%} with a few
-changes:
+With that completed, we use `%=`
+[centis](/language/hoon/reference/rune/cen#-centis) to call `$` buc to
+recurse back up to `|-`
+[barhep](/language/hoon/reference/rune/bar#--barhep) with a few changes:
 
 - `shuffled` gets the `darc` from `unshuffled` at `index` added to the
   front of it.
 
 - `remaining` gets decremented. Why are we using a counter here instead
-  of just checking the length of `unshuffled` on each loop? {% tooltip
-  label="++lent" href="/language/hoon/reference/stdlib/2b#lent" /%}
-  traverses the entire list every time it's called so maintaining a
-  counter in this fashion is much faster.
+  of just checking the length of `unshuffled` on each loop?
+  [++lent](/language/hoon/reference/stdlib/2b#lent) traverses the entire
+  list every time it's called so maintaining a counter in this fashion
+  is much faster.
 
-- `unshuffled` becomes the result of using {% tooltip label="++oust"
-  href="/language/hoon/reference/stdlib/2b#oust" /%} to remove 1 `darc` at
-  `index` on `unshuffled`.
+- `unshuffled` becomes the result of using
+  [++oust](/language/hoon/reference/stdlib/2b#oust) to remove 1 `darc`
+  at `index` on `unshuffled`.
 
 This is a very naive shuffling algorithm.  We leave the implementation
 of a better shuffling algorithm as an exercise for the reader.
@@ -372,12 +348,10 @@ of a better shuffling algorithm as an exercise for the reader.
 
 ### Exercise:  Using the Playing Card Library
 
-Unfortunately `/` {% tooltip label="fas"
-href="/language/hoon/reference/rune/fas" /%} runes don't work in the {%
-tooltip label="Dojo" href="/glossary/dojo" /%} right now, so we need to
-build code using the {% tooltip label="-build-file"
-href="/manual/os/dojo-tools#-build-file" /%} thread if we want to use
-the library directly.
+Unfortunately `/` [fas](/language/hoon/reference/rune/fas) runes don't
+work in the [Dojo](/glossary/dojo) right now, so we need to build code
+using the [-build-file](/manual/os/dojo-tools#-build-file) thread if we
+want to use the library directly.
 
 - Import the `/lib/playing-cards.hoon` library and use it to shuffle and
   show a deck and a random hand of five cards.
@@ -444,18 +418,16 @@ the library directly.
 
 ##  Desks
 
-A {% tooltip label="desk" href="/glossary/desk" /%} organizes a
-collection of files, including {% tooltip label="generators"
-href="/glossary/generator" /%}, libraries, {% tooltip label="agents"
-href="/glossary/agent" /%}, and system code, into one coherent bundle. A
-desk is similar to a file drive in a conventional computer, or a Git
-branch.  Desks are supported by the {% tooltip label="Clay"
-href="/glossary/clay" /%} {% tooltip label="vane" href="/glossary/vane"
-/%} in {% tooltip label="Arvo" href="/glossary/arvo" /%}, the Urbit OS.
+A [desk](/glossary/desk) organizes a collection of files, including
+[generators](/glossary/generator), libraries, [agents](/glossary/agent),
+and system code, into one coherent bundle. A desk is similar to a file
+drive in a conventional computer, or a Git branch.  Desks are supported
+by the [Clay](/glossary/clay) [vane](/glossary/vane) in
+[Arvo](/glossary/arvo), the Urbit OS.
 
 At this point, you've likely only worked on the `%base` desk.  You can
-see data about any particular desk using the {% tooltip label="+vats"
-href="/manual/os/dojo-tools#vats" /%} generator:
+see data about any particular desk using the
+[+vats](/manual/os/dojo-tools#vats) generator:
 
 ```hoon
 > +vats %base
@@ -483,8 +455,8 @@ href="/manual/os/dojo-tools#vats" /%} generator:
   pending updates:  ~
 ```
 
-You'll see a slightly different configuration on the particular {%
-tooltip label="ship" href="/glossary/ship" /%} you are running.
+You'll see a slightly different configuration on the particular
+[ship](/glossary/ship) you are running.
 
 ### Aside:  Filesystems
 
@@ -535,20 +507,18 @@ type if such a conversion is possible.
 
 On Mars, we treat a filesystem as a way of organizing arbitrary access
 to blocks of persistent data.  There are some concessions to Earth-style
-filesystems, but {% tooltip label="Clay" href="/glossary/clay" /%}
-(Urbit's filesystem) organizes everything with respect to a {% tooltip
-label="desk" href="/glossary/desk" /%}, a discrete collection of static
-data on a particular {% tooltip label="ship" href="/glossary/ship" /%}.
-Of course, like everything else in Hoon, a desk is a tree as well.
+filesystems, but [Clay](/glossary/clay) (Urbit's filesystem) organizes
+everything with respect to a [desk](/glossary/desk), a discrete
+collection of static data on a particular [ship](/glossary/ship). Of
+course, like everything else in Hoon, a desk is a tree as well.
 
 So far everything we have done has taken place on the `%base` desk.  You
 have by this point become proficient at synchronizing Earthling data
-(Unix data) and Martian data (Urbit data), using {% tooltip
-label="|mount" href="/manual/os/dojo-tools#mount" /%} and {% tooltip
-label="|commit" href="/manual/os/dojo-tools#commit" /%}, and every time
-you've done this with `%base` that has been recorded in the update
-report the {% tooltip label="Dojo" href="/glossary/dojo" /%} makes to
-you.
+(Unix data) and Martian data (Urbit data), using
+[|mount](/manual/os/dojo-tools#mount) and
+[|commit](/manual/os/dojo-tools#commit), and every time you've done this
+with `%base` that has been recorded in the update report the
+[Dojo](/glossary/dojo) makes to you.
 
 ```hoon
 > |commit %base
@@ -558,8 +528,8 @@ you.
 
 This message says that a file `demo.hoon` was added to the Urbit
 filesystem at the path in `/gen`.  What is the rest of it, though, the
-first three components?  We call this the {% tooltip label="beak"
-href="/system/kernel/clay/reference/data-types#beak" /%}.  The beak lets
+first three components?  We call this the
+[beak](/system/kernel/clay/reference/data-types#beak).  The beak lets
 Clay globally identify any resource on any ship at any point in time.  A
 beak has three components:
 
@@ -587,9 +557,9 @@ Any one of those can be replaced as necessary:
 ```
 
 You'll also sometimes see `%` cen stand in for the whole including the
-“current” desk.  The current desk is a Dojo concept, since for {%
-tooltip label="Clay" href="/glossary/clay" /%} we can access any desk at
-any time (with permission).
+“current” desk.  The current desk is a Dojo concept, since for
+[Clay](/glossary/clay) we can access any desk at any time (with
+permission).
 
 ```hoon
 > %
@@ -602,9 +572,8 @@ A `path` is a `(list @ta)`, a list of text identifiers.  The first three
 are always the beak and the last one conventionally refers to the mark
 by which the file is represented.
 
-For instance, the {% tooltip label="+cat"
-href="/manual/os/dojo-tools#cat" /%} generator displays the contents of
-any path, e.g.
+For instance, the [+cat](/manual/os/dojo-tools#cat) generator displays
+the contents of any path, e.g.
 
 ```hoon
 > +cat /===/gen/ls/hoon
@@ -634,12 +603,12 @@ If no data are located at the given path, `+cat` simply shows `~` null:
 
 Every desk has a standard directory structure:
 
--   `/app` for {% tooltip label="agents" href="/glossary/agent" /%}
--   `/gen` for {% tooltip label="generators" href="/glossary/generator" /%}
+-   `/app` for [agents](/glossary/agent)
+-   `/gen` for [generators](/glossary/generator)
 -   `/lib` for library and helper files
--   `/mar` for {% tooltip label="marks" href="/glossary/mark" /%}
+-   `/mar` for [marks](/glossary/mark)
 -   `/sur` for shared structures
--   `/ted` for {% tooltip label="threads" href="/glossary/thread" /%}
+-   `/ted` for [threads](/glossary/thread)
 
 To run a generator from a different desk in Dojo, you need to prefix the
 desk name to the generator; to run `/=landscape=/gen/tally/hoon`, you
@@ -664,13 +633,12 @@ you are hosting 0 group(s):
 
 ### Marks
 
-{% tooltip label="Marks" href="/glossary/mark" /%} play the role of file
-extensions, with an important upgrade:  they are actually {% tooltip
-label="molds" href="/glossary/mold" /%} and define conversion paths.  We
-won't write them in Hoon School, but you will encounter them when you
-begin writing apps. They are used more broadly than merely as file
-types, because they act as smart molds to ingest and yield data
-structures such as JSON and HTML from Hoon data structures.
+[Marks](/glossary/mark) play the role of file extensions, with an
+important upgrade:  they are actually [molds](/glossary/mold) and define
+conversion paths.  We won't write them in Hoon School, but you will
+encounter them when you begin writing apps. They are used more broadly
+than merely as file types, because they act as smart molds to ingest and
+yield data structures such as JSON and HTML from Hoon data structures.
 
 In brief, each mark has a `++grab` arm to convert from other types to
 it; a `++grow` arm to convert it to other types; and a `++grad` arm for
@@ -684,17 +652,14 @@ The `++ford` arm of Clay builds Hoon code.  It provides [a number of
 runes](/language/hoon/reference/rune/fas) which allow fine-grained
 control over building and importing files.  These must be in the
 specific order at the top of any file.  (They also don't work in Dojo;
-see {% tooltip label="-build-file"
-href="/manual/os/dojo-tools#-build-file" /%} for a workaround.)  The
-runes include:
+see [-build-file](/manual/os/dojo-tools#-build-file) for a workaround.)
+The runes include:
 
-- `/-` {% tooltip label="fashep"
-  href="/language/hoon/reference/rune/fas#--fashep" /%} imports a
+- `/-` [fashep](/language/hoon/reference/rune/fas#--fashep) imports a
   structure file from `/sur`.  Structure files are a way to share common
   data structures (across agents, for instance).
-- `/+` {% tooltip label="faslus"
-  href="/language/hoon/reference/rune/fas#-faslus" /%} imports a library
-  file from `/lib`.
+- `/+` [faslus](/language/hoon/reference/rune/fas#-faslus) imports a
+  library file from `/lib`.
 
     Both `/-` fashep and `/+` faslus allow you to import by affecting
     the name of the exposed core:
@@ -721,12 +686,8 @@ runes include:
     otherwise should be avoided as it can shadow names in your current
     subject.
 
-- `/=` {% tooltip label="fastis"
-  href="/language/hoon/reference/rune/fas#-fastis" /%} builds a
-  user-specified path and wraps it with a given {% tooltip label="face"
-  href="/glossary/face" /%}.
-- `/*` {% tooltip label="fastar"
-  href="/language/hoon/reference/rune/fas#-fastar" /%} imports the
-  contents of a file, applies a {% tooltip label="mark"
-  href="/glossary/mark" /%} to convert it, and wraps it with a given
-  face.
+- `/=` [fastis](/language/hoon/reference/rune/fas#-fastis) builds a
+  user-specified path and wraps it with a given [face](/glossary/face).
+- `/*` [fastar](/language/hoon/reference/rune/fas#-fastar) imports the
+  contents of a file, applies a [mark](/glossary/mark) to convert it,
+  and wraps it with a given face.

--- a/content/courses/hoon-school/I-testing.md
+++ b/content/courses/hoon-school/I-testing.md
@@ -34,16 +34,14 @@ layers:  fences and unit tests.
 
 _Fences_ are barriers employed to block program execution if the state
 isn’t adequate to the intended task. Typically, these are implemented
-with `assert` or similar enforcement.  In Hoon, this means `?>` {%
-tooltip label="wutgar" href="/language/hoon/reference/rune/wut#-wutgar"
-/%}, `?<` {% tooltip label="wutgal"
-href="/language/hoon/reference/rune/wut#-wutgal" /%}, and `?~` {%
-tooltip label="wutsig" href="/language/hoon/reference/rune/wut#-wutsig"
-/%}, or judicious use of `^-` {% tooltip label="kethep"
-href="/language/hoon/reference/rune/ket#--kethep" /%} and `^+` {%
-tooltip label="ketlus" href="/language/hoon/reference/rune/ket#-ketlus"
-/%}. For conditions that must succeed, the failure branch in Hoon should
-be `!!`, which crashes the program.
+with `assert` or similar enforcement.  In Hoon, this means `?>`
+[wutgar](/language/hoon/reference/rune/wut#-wutgar), `?<`
+[wutgal](/language/hoon/reference/rune/wut#-wutgal), and `?~`
+[wutsig](/language/hoon/reference/rune/wut#-wutsig), or judicious use of
+`^-` [kethep](/language/hoon/reference/rune/ket#--kethep) and `^+`
+[ketlus](/language/hoon/reference/rune/ket#-ketlus). For conditions that
+must succeed, the failure branch in Hoon should be `!!`, which crashes
+the program.
 
 ### Unit Tests
 
@@ -62,9 +60,8 @@ Unit tests typically contain setup, assertions, and tear-down. In
 academic terms, they’re a grading script.
 
 In Hoon, the `tests/` directory contains the relevant tests for the
-testing framework to grab and utilize.  These can be invoked with the {%
-tooltip label="-test" href="/manual/os/dojo-tools#-test" /%} {% tooltip
-label="thread" href="/glossary/thread" /%}:
+testing framework to grab and utilize.  These can be invoked with the
+[-test](/manual/os/dojo-tools#-test) [thread](/glossary/thread):
 
 ```hoon
 > -test /=landscape=/tests ~  
@@ -92,9 +89,8 @@ ok=%.y
 (Depending on when you built your fakeship, particular tests may or may
 not be present.  You can download them from [the Urbit
 repo](https://github.com/urbit/urbit) and add them manually if you like.
-Regarding the example above (`%landscape` {% tooltip label="desk"
-href="/glossary/desk" /%}), the tests are likely missing, so download
-them from
+Regarding the example above (`%landscape` [desk](/glossary/desk)), the
+tests are likely missing, so download them from
 [here](https://github.com/urbit/urbit/tree/master/pkg/landscape) if you
 want to run them.)
 
@@ -200,16 +196,14 @@ is:
   result
 ```
 
-Test code deals in {% tooltip label="vases" href="/glossary/vase" /%},
-which are produced by `!>` {% tooltip label="zapgar"
-href="/language/hoon/reference/rune/zap#-zapgar" /%} as a {% tooltip
-label="cell" href="/glossary/cell" /%} of the type of a value and the
-value.
+Test code deals in [vases](/glossary/vase), which are produced by `!>`
+[zapgar](/language/hoon/reference/rune/zap#-zapgar) as a
+[cell](/glossary/cell) of the type of a value and the value.
 
-`++expect-fail` by contrast take a `|.` {% tooltip label="bardot"
-href="/language/hoon/reference/rune/bar#-bardot" /%} trap (a trap that
-has the `$` buc {% tooltip label="arm" href="/glossary/arm" /%} but
-hasn't been called yet) and verifies that the code within fails.
+`++expect-fail` by contrast take a `|.`
+[bardot](/language/hoon/reference/rune/bar#-bardot) trap (a trap that
+has the `$` buc [arm](/glossary/arm) but hasn't been called yet) and
+verifies that the code within fails.
 
 ```hoon
 > (expect-fail:test |.(!!))
@@ -241,16 +235,14 @@ notional point of computation.  When the code fails, any error hints
 currently on the stack are dumped to the terminal for you to see what
 has gone wrong.
 
-- The `~_` {% tooltip label="sigcab"
-  href="/language/hoon/reference/rune/sig#_-sigcab" /%} rune, described
-  as a “user-formatted tracing printf”, can include an error message for
-  you, requiring you to explicitly build the `tank`. (`printf` is a
-  reference to [C's I/O
+- The `~_` [sigcab](/language/hoon/reference/rune/sig#_-sigcab) rune,
+  described as a “user-formatted tracing printf”, can include an error
+  message for you, requiring you to explicitly build the `tank`.
+  (`printf` is a reference to [C's I/O
   library](https://en.wikipedia.org/wiki/Printf_format_string).)
-- The `~|` {% tooltip label="sigbar"
-  href="/language/hoon/reference/rune/sig#-sigbar" /%} rune, a “tracing
-  printf”, can include an error message from a simple `@t` {% tooltip
-  label="cord" href="/glossary/cord" /%}.
+- The `~|` [sigbar](/language/hoon/reference/rune/sig#-sigbar) rune, a
+  “tracing printf”, can include an error message from a simple `@t`
+  [cord](/glossary/cord).
     What this means is that these print to the stack trace if something
     fails, so you can use either rune to contribute to the error
     description:
@@ -260,13 +252,11 @@ has gone wrong.
     ~_  leaf+"This code failed"
     !!
     ```
-- The `!:` {% tooltip label="zapcol"
-  href="/language/hoon/reference/rune/zap#-zapcol" /%} rune turns on
-  line-by-line stack tracing, which is extremely helpful when debugging
-  programs.  Drop it in on the first Hoon line (after `/` {% tooltip
-  label="fas" href="/language/hoon/reference/rune/fas" /%} imports) of a
-  {% tooltip label="generator" href="/glossary/generator" /%} or library
-  while developing.
+- The `!:` [zapcol](/language/hoon/reference/rune/zap#-zapcol) rune
+  turns on line-by-line stack tracing, which is extremely helpful when
+  debugging programs.  Drop it in on the first Hoon line (after `/`
+  [fas](/language/hoon/reference/rune/fas) imports) of a
+  [generator](/glossary/generator) or library while developing.
 
     ```hoon
     > (sub 0 1)
@@ -279,9 +269,8 @@ has gone wrong.
     dojo: hoon expression failed
     ```
 
-When you compose your own library {% tooltip label="cores"
-href="/glossary/core" /%}, include error messages for likely failure
-modes.
+When you compose your own library [cores](/glossary/core), include error
+messages for likely failure modes.
 
 
 ##  Test-Driven Development
@@ -356,11 +345,9 @@ point:
 
 ### `nest-fail`
 
-A {% tooltip label="nest-fail"
-href="/language/hoon/reference/hoon-errors#nest-fail" /%} may be the
-most common.  Likely you are using an {% tooltip label="atom"
-href="/glossary/atom" /%} or a {% tooltip label="cell"
-href="/glossary/cell" /%} where the other is expected.
+A [nest-fail](/language/hoon/reference/hoon-errors#nest-fail) may be the
+most common.  Likely you are using an [atom](/glossary/atom) or a
+[cell](/glossary/cell) where the other is expected.
 
 ```hoon
 > (add 'a' 'b')
@@ -386,9 +373,8 @@ nest-fail
 dojo: hoon expression failed
 ```
 
-Conversion without casting via {% tooltip label="auras"
-href="/glossary/aura" /%} fails because the atom types (auras) don't
-nest without explicit downcasting to `@`.
+Conversion without casting via [auras](/glossary/aura) fails because the
+atom types (auras) don't nest without explicit downcasting to `@`.
 
 ```hoon
 > `(list @ud)`~[0x0 0x1 0x2]
@@ -404,10 +390,9 @@ dojo: hoon expression failed
 
 ### `fish-loop`
 
-A `fish-loop` arises when using a recursive mold definition like {%
-tooltip label="list" href="/glossary/list" /%}. (The relevant mnemonic
-is that `++fish` goes fishing for the type of an expression.)  Alas,
-this fails today:
+A `fish-loop` arises when using a recursive mold definition like
+[list](/glossary/list). (The relevant mnemonic is that `++fish` goes
+fishing for the type of an expression.)  Alas, this fails today:
 
 ```hoon
 > ?=((list @) ~[1 2 3 4])
@@ -418,8 +403,8 @@ fish-loop
 ### `generator-build-fail`
 
 A `generator-build-fail` most commonly results from composing code with
-mismatched {% tooltip label="runes" href="/glossary/rune" /%} (and thus
-the wrong children including hanging expected-but-empty slots).
+mismatched [runes](/glossary/rune) (and thus the wrong children
+including hanging expected-but-empty slots).
 
 Also check if you are using Windows-style line endings, as Unix-style
 line endings should be employed throughout Urbit.
@@ -430,14 +415,12 @@ Another common mistake is to attempt to use the default `$` buc arm in
 something that doesn't have it.  This typically happens for one of two
 reasons:
 
-- `$.+2` means that `%-` {% tooltip label="cenhep"
-  href="/language/hoon/reference/rune/cen#-cenhep" /%} or equivalent
-  function call cannot locate a {% tooltip label="battery"
-  href="/glossary/battery" /%}.  This can occur when you try to use a
-  non-gate as a {% tooltip label="gate" href="/glossary/gate" /%}.  In
-  particular, if you mask the name of a {% tooltip label="mold"
-  href="/glossary/mold" /%} (such as {% tooltip label="list"
-  href="/glossary/list" /%}), then a subsequent expression that requires
+- `$.+2` means that `%-`
+  [cenhep](/language/hoon/reference/rune/cen#-cenhep) or equivalent
+  function call cannot locate a [battery](/glossary/battery).  This can
+  occur when you try to use a non-gate as a [gate](/glossary/gate).  In
+  particular, if you mask the name of a [mold](/glossary/mold) (such as
+  [list](/glossary/list)), then a subsequent expression that requires
   the mold will experience this problem.
     ```hoon
     > =/  list  ~[1 2 3]
@@ -446,9 +429,8 @@ reasons:
     -find.$.+2
     ```
 
-- `-find.$` similarly looks for a `$` buc {% tooltip label="arm"
-  href="/glossary/arm" /%} in something that _is_ a core but doesn't
-  have the `$` buc arm present.
+- `-find.$` similarly looks for a `$` buc [arm](/glossary/arm) in
+  something that _is_ a core but doesn't have the `$` buc arm present.
 
     ```hoon
     > *tape
@@ -465,26 +447,24 @@ reasons:
 
 What are some strategies for debugging?
 
--   **Debugging stack.**  Use the `!:` {% tooltip label="zapcol"
-    href="/language/hoon/reference/rune/zap#-zapcol" /%} rune to turn on
-    the debugging stack, `!.` {% tooltip label="zapdot"
-    href="/language/hoon/reference/rune/zap#-zapdot" /%} to turn it off
+-   **Debugging stack.**  Use the `!:`
+    [zapcol](/language/hoon/reference/rune/zap#-zapcol) rune to turn on
+    the debugging stack, `!.`
+    [zapdot](/language/hoon/reference/rune/zap#-zapdot) to turn it off
     again.  (Most of the time you just pop this on at the top of a
     generator and leave it there.)
 -   **`printf` debugging.**  If your code will compile and run, employ
-    `~&` {% tooltip label="sigpam"
-    href="/language/hoon/reference/rune/sig#-sigpam" /%} frequently to
-    make sure that your code is doing what you think it’s doing.
--   **Typecast.**  Include `^` {% tooltip label="ket"
-    href="/language/hoon/reference/rune/ket" /%} casts frequently
-    throughout your code.  Entire categories of error can be excluded by
-    satisfying the Hoon typechecker.
+    `~&` [sigpam](/language/hoon/reference/rune/sig#-sigpam) frequently
+    to make sure that your code is doing what you think it’s doing.
+-   **Typecast.**  Include `^` [ket](/language/hoon/reference/rune/ket)
+    casts frequently throughout your code.  Entire categories of error
+    can be excluded by satisfying the Hoon typechecker.
 -   **The only wolf in Alaska.**  Essentially a bisection search, you
     split your code into smaller modules and run each part until you
     know where the bug arose (where the wolf howled).  Then you keep
     fencing it in tighter and tighter until you know where it arose. You
-    can stub out arms with `!!` {% tooltip label="zapzap"
-    href="/language/hoon/reference/rune/zap#-zapzap" /%}.
+    can stub out arms with `!!`
+    [zapzap](/language/hoon/reference/rune/zap#-zapzap).
 -   **Build it again.**  Remove all of the complicated code from your
     program and add it in one line at a time.  For instance, replace a
     complicated function with either a `~&` sigpam and `!!` zapzap, or
@@ -494,10 +474,9 @@ What are some strategies for debugging?
 -  **Run without networking**.  If you run the Urbit executable with
    `-L`, you cut off external networking.  This is helpful if you want
    to mess with a _copy_ of an actual ship without producing remote
-   effects.  That is, if other parts of {% tooltip label="Ames"
-   href="/glossary/ames" /%} don’t know what you’re doing, then you can
-   delete that copy (COPY!) of your pier and continue with the original.
-   This is an alternative to using fakezods which is occasionally
-   helpful in debugging userspace apps in {% tooltip label="Gall"
-   href="/glossary/gall" /%}. You can also develop using a {% tooltip
-   label="moon" href="/glossary/moon" /%} if you want to.
+   effects.  That is, if other parts of [Ames](/glossary/ames) don’t
+   know what you’re doing, then you can delete that copy (COPY!) of your
+   pier and continue with the original. This is an alternative to using
+   fakezods which is occasionally helpful in debugging userspace apps in
+   [Gall](/glossary/gall). You can also develop using a
+   [moon](/glossary/moon) if you want to.

--- a/content/courses/hoon-school/J-stdlib-text.md
+++ b/content/courses/hoon-school/J-stdlib-text.md
@@ -15,15 +15,14 @@ module](/courses/hoon-school/P-stdlib-io)._
 ##  Text in Hoon
 
 We've incidentally used `'messages written as cords'` and `"as tapes"`,
-but aside from taking a brief look at how {% tooltip label="lists"
-href="/glossary/list" /%} (and thus {% tooltip label="tapes"
-href="/glossary/tape" /%}) work with tree addressing, we haven't
+but aside from taking a brief look at how [lists](/glossary/list) (and
+thus [tapes](/glossary/tape)) work with tree addressing, we haven't
 discussed why these differ or how text works more broadly.
 
 There are four basic ways to represent text in Urbit:
 
-- `@t`, a {% tooltip label="cord" href="/glossary/cord" /%}, which is an
-  {% tooltip label="atom" href="/glossary/atom" /%} (single value)
+- `@t`, a [cord](/glossary/cord), which is an
+  [atom](/glossary/atom) (single value)
 - `@ta`, a `knot` used for URL-safe path elements, which is an atom
   (single value)
 - `@tas`, a `term` used primarily for constants, which is an atom
@@ -60,7 +59,7 @@ the [ASCII](https://en.wikipedia.org/wiki/ASCII) standard, which defines
 A   S   C   I   I
 ```
 
-A {% tooltip label="cord" href="/glossary/cord" /%} simply shunts these
+A [cord](/glossary/cord) simply shunts these
 values together in one-byte-wide slots and represents them as an
 integer.
 
@@ -72,10 +71,10 @@ integer.
 2.037.307.443.564.446.887.986.503.990.470.772
 ```
 
-It's very helpful to use the `@ux` {% tooltip label="aura"
-href="/glossary/aura" /%} if you are trying to see the internal
-structure of a `cord`.  Since the ASCII values align at the 8-bit wide
-characters, you can see each character delineated by a hexadecimal pair.
+It's very helpful to use the `@ux` [aura](/glossary/aura) if you are
+trying to see the internal structure of a `cord`.  Since the ASCII
+values align at the 8-bit wide characters, you can see each character
+delineated by a hexadecimal pair.
 
 ```hoon
 > `@ux`'HELLO'
@@ -110,9 +109,9 @@ uses UTF-8 for `@t` values (thus both `cord` and `tape`).
 ### `(list @t)` `tape`
 
 There are some tools to work with atom `cord`s of text, but most of the
-time it is more convenient to unpack the atom into a {% tooltip
-label="tape" href="/glossary/tape" /%}.  A `tape` splits out the
-individual characters from a `cord` into a `list` of character values.
+time it is more convenient to unpack the atom into a
+[tape](/glossary/tape).  A `tape` splits out the individual characters
+from a `cord` into a `list` of character values.
 
 ![](https://media.urbit.org/docs/userspace/hoon-school/binary-tree-tape.png)
 
@@ -123,9 +122,8 @@ single atom, they are stored sequentially in a rightwards-branching
 binary tree of cells.
 
 A tape is a list of `@tD` atoms (i.e., characters).  (The upper-case
-character at the end of the {% tooltip label="aura"
-href="/glossary/aura" /%} hints that the `@t` values are D→3 so 2³=8
-bits wide.)
+character at the end of the [aura](/glossary/aura) hints that the `@t`
+values are D→3 so 2³=8 bits wide.)
 
 ```hoon
 > "this is a tape"
@@ -135,7 +133,7 @@ bits wide.)
 ~[116 104 105 115 32 105 115 32 97 32 116 97 112 101]
 ```
 
-Since a {% tooltip label="tape" href="/glossary/tape" /%} is a `(list
+Since a [tape](/glossary/tape) is a `(list
 @tD)`, all of the `list` tools we have seen before work on them.
 
 ### `@ta` `knot`
@@ -205,9 +203,8 @@ but it shows off a point.)
 --
 ```
 
-(See how that `=<` {% tooltip label="tisgal"
-href="/language/hoon/reference/rune/tis#-tisgal" /%} works with the
-helper {% tooltip label="core?" href="/glossary/core" /%})
+(See how that `=<` [tisgal](/language/hoon/reference/rune/tis#-tisgal)
+works with the helper [core?](/glossary/core))
 
 
 ##  Text Operations
@@ -225,9 +222,8 @@ String interpolation puts the result of an expression directly into a
 "11 is the answer."
 ```
 
-The {% tooltip label="++weld"
-href="/language/hoon/reference/stdlib/2b#weld" /%} function can be used
-to glue two `tape`s together:
+The [++weld](/language/hoon/reference/stdlib/2b#weld) function can be
+used to glue two `tape`s together:
 
 ```hoon
 > (weld "Hello" "Mars!")
@@ -243,14 +239,13 @@ to glue two `tape`s together:
 ### Manipulating Text
 
 If you have text but you need to change part of it or alter its form,
-you can use standard library `list` operators like {% tooltip
-label="++flop" href="/language/hoon/reference/stdlib/2b#flop" /%} as
-well as `tape`-specific arms.
+you can use standard library `list` operators like
+[++flop](/language/hoon/reference/stdlib/2b#flop) as well as
+`tape`-specific arms.
 
 Applicable `list` operations—some of which you've seen before—include:
 
-- The {% tooltip label="++flop"
-  href="/language/hoon/reference/stdlib/2b#flop" /%} function takes a
+- The [++flop](/language/hoon/reference/stdlib/2b#flop) function takes a
   list and returns it in reverse order:
 
     ```hoon
@@ -261,21 +256,21 @@ Applicable `list` operations—some of which you've seen before—include:
     "Hello!"
     ```
 
-- The {% tooltip label="++sort"
-  href="/language/hoon/reference/stdlib/2b#sort" /%} function uses the
-  [quicksort algorithm](https://en.wikipedia.org/wiki/Quicksort) to sort
-  a list.  It takes a `list` to sort and a gate that serves as a
+- The [++sort](/language/hoon/reference/stdlib/2b#sort) function uses
+  the [quicksort algorithm](https://en.wikipedia.org/wiki/Quicksort) to
+  sort a list.  It takes a `list` to sort and a gate that serves as a
   comparator.  For example, if you want to sort the list `~[37 62 49 921
-  123]` from least to greatest, you would pass that list along with
-  the {% tooltip label="++lth" href="/language/hoon/reference/stdlib/1a#lth"
-  /%} gate (for “less than”):
+  123]` from least to greatest, you would pass that list along with the
+  [++lth](/language/hoon/reference/stdlib/1a#lth) gate (for “less
+  than”):
 
     ```hoon
     > (sort ~[37 62 49 921 123] lth)
     ~[37 49 62 123 921]
     ```
 
-    To sort the list from greatest to least, use the gth gate ("greater than") as the basis of comparison instead:
+    To sort the list from greatest to least, use the gth gate ("greater
+    than") as the basis of comparison instead:
 
     ```hoon
     > (sort ~[37 62 49 921 123] gth)
@@ -291,9 +286,8 @@ Applicable `list` operations—some of which you've seen before—include:
 
     The function passed to sort must produce a flag, i.e., `?`.
 
-- The {% tooltip label="++weld"
-  href="/language/hoon/reference/stdlib/2b#weld" /%} function takes two
-  lists of the same type and concatenates them:
+- The [++weld](/language/hoon/reference/stdlib/2b#weld) function takes
+  two lists of the same type and concatenates them:
 
     ```hoon
     > (weld "Happy " "Birthday!")
@@ -302,10 +296,9 @@ Applicable `list` operations—some of which you've seen before—include:
 
     It does not inject a separator character like a space.
 
-- The {% tooltip label="++snag"
-  href="/language/hoon/reference/stdlib/2b#snag" /%} function takes an
-  atom `n` and a list, and returns the `n`th item of the list, where 0
-  is the first item:
+- The [++snag](/language/hoon/reference/stdlib/2b#snag) function takes
+  an atom `n` and a list, and returns the `n`th item of the list, where
+  0 is the first item:
 
     ```hoon
     > (snag 3 "Hello!")
@@ -323,8 +316,7 @@ Applicable `list` operations—some of which you've seen before—include:
     - Without using `++snag`, write a gate that returns the `n`th item
       of a list.  There is a solution at the bottom of the page.
 
-- The {% tooltip label="++oust"
-  href="/language/hoon/reference/stdlib/2b#oust" /%} function takes a
+- The [++oust](/language/hoon/reference/stdlib/2b#oust) function takes a
   pair of atoms `[a=@ b=@]` and a list, and returns the list with b
   items removed, starting at item a:
 
@@ -342,8 +334,7 @@ Applicable `list` operations—some of which you've seen before—include:
     "Heo!"
     ```
 
-- The {% tooltip label="++lent"
-  href="/language/hoon/reference/stdlib/2b#lent" /%} function takes a
+- The [++lent](/language/hoon/reference/stdlib/2b#lent) function takes a
   list and returns the number of items in it:
 
     ```hoon
@@ -360,46 +351,41 @@ Applicable `list` operations—some of which you've seen before—include:
       characters in a `tape`.  Build your own `tape`-length character
       counting function without using `++lent`.
 
-    You may find the `?~` {% tooltip label="wutsig"
-    href="/language/hoon/reference/rune/wut#-wutsig" /%} rune to be
+    You may find the `?~`
+    [wutsig](/language/hoon/reference/rune/wut#-wutsig) rune to be
     helpful.  It tells you whether a value is `~` or not.  (How would
-    you do this with a regular `?:` {% tooltip label="wutcol"
-    href="/language/hoon/reference/rune/wut#-wutcol" /%}?)
+    you do this with a regular `?:`
+    [wutcol](/language/hoon/reference/rune/wut#-wutcol)?)
 
-The foregoing are {% tooltip label="list" href="/glossary/list" /%}
-operations.  The following, in contrast, are {% tooltip label="tape"
-href="/glossary/tape" /%}-specific operations:
+The foregoing are [list](/glossary/list) operations.  The following, in
+contrast, are [tape](/glossary/tape)-specific operations:
 
-- The {% tooltip label="++crip"
-  href="/language/hoon/reference/stdlib/4b#crip" /%} function converts a
-  `tape` to a `cord` (`tape`→`cord`).
+- The [++crip](/language/hoon/reference/stdlib/4b#crip) function
+  converts a `tape` to a `cord` (`tape`→`cord`).
 
     ```hoon
     > (crip "Mars")
     'Mars'
     ```
 
-- The {% tooltip label="++trip"
-  href="/language/hoon/reference/stdlib/4b#trip" /%} function converts a
-  `cord` to a `tape` (`cord`→`tape`).
+- The [++trip](/language/hoon/reference/stdlib/4b#trip) function
+  converts a `cord` to a `tape` (`cord`→`tape`).
 
     ```hoon
     > (trip 'Earth')
     "Earth"
     ```
 
-- The {% tooltip label="++cass"
-  href="/language/hoon/reference/stdlib/4b#cass" /%} function: convert
-  upper-case text to lower-case (`tape`→`tape`)
+- The [++cass](/language/hoon/reference/stdlib/4b#cass) function:
+  convert upper-case text to lower-case (`tape`→`tape`)
 
     ```hoon
     > (cass "Hello Mars")
     "hello mars"
     ```
 
-- The {% tooltip label="++cuss"
-  href="/language/hoon/reference/stdlib/4b#cuss" /%} function: convert
-  lower-case text to upper-case (`tape`→`tape`)
+- The [++cuss](/language/hoon/reference/stdlib/4b#cuss) function:
+  convert lower-case text to upper-case (`tape`→`tape`)
 
     ```hoon
     > (cuss "Hello Mars")
@@ -416,8 +402,7 @@ Given a string of text, what can you do with it?
 
 #### Search
 
-- The {% tooltip label="++find"
-  href="/language/hoon/reference/stdlib/2b#find" /%} function takes
+- The [++find](/language/hoon/reference/stdlib/2b#find) function takes
   `[nedl=(list) hstk=(list)]` and locates a sublist (`nedl`, needle) in
   the list (`hstk`, haystack).  (`++find` starts counting from zero.)
 
@@ -454,9 +439,9 @@ Hoon has a very powerful text parsing engine, built to compile Hoon
 itself.  However, it tends to be quite obscure to new learners.  We can
 build a simple one using `list` tools.
 
-- Compose a {% tooltip label="gate" href="/glossary/gate" /%} which
-  parses a long `tape` into smaller `tape`s by splitting the text at
-  single spaces.  For example, given a `tape`
+- Compose a [gate](/glossary/gate) which parses a long `tape` into
+  smaller `tape`s by splitting the text at single spaces.  For example,
+  given a `tape`
  
     ```hoon {% copy=true %}
     "the sky above the port was the color of television tuned to a dead channel"
@@ -468,10 +453,10 @@ build a simple one using `list` tools.
     ~["the" "sky" "above" "the" ...]
     ```
     
-    To complete this, you'll need {% tooltip label="++scag"
-    href="/language/hoon/reference/stdlib/2b#scag" /%} and {% tooltip
-    label="++slag" href="/language/hoon/reference/stdlib/2b#slag" /%}
-    (who sound like villainous henchmen from a children's cartoon).
+    To complete this, you'll need
+    [++scag](/language/hoon/reference/stdlib/2b#scag) and
+    [++slag](/language/hoon/reference/stdlib/2b#slag) (who sound like
+    villainous henchmen from a children's cartoon).
 
     ```hoon {% copy=true %}
     |=  ex=tape
@@ -488,16 +473,14 @@ build a simple one using `list` tools.
 #### Convert
 
 If you have a Hoon value and you want to convert it into text as such,
-use {% tooltip label="++scot"
-href="/language/hoon/reference/stdlib/4m#scot" /%} and {% tooltip
-label="++scow" href="/language/hoon/reference/stdlib/4m#scow" /%}.
-These call for a value of type `+$dime`, which means the `@tas`
-equivalent of a regular aura.  These are labeled as returning `cord`s
-(`@t`s) but in practice seem to return `knot`s (`@ta`s).
+use [++scot](/language/hoon/reference/stdlib/4m#scot) and
+[++scow](/language/hoon/reference/stdlib/4m#scow). These call for a
+value of type `+$dime`, which means the `@tas` equivalent of a regular
+aura.  These are labeled as returning `cord`s (`@t`s) but in practice
+seem to return `knot`s (`@ta`s).
 
-- The {% tooltip label="++scot"
-  href="/language/hoon/reference/stdlib/4m#scot" /%} function renders a
-  `dime` as a `cord` (`dime`→`cord`); the user must include any
+- The [++scot](/language/hoon/reference/stdlib/4m#scot) function renders
+  a `dime` as a `cord` (`dime`→`cord`); the user must include any
   necessary aura transformation.
 
     ```hoon
@@ -516,20 +499,17 @@ equivalent of a regular aura.  These are labeled as returning `cord`s
     '~sampel-palnet'
     ```
 
-- The {% tooltip label="++scow"
-  href="/language/hoon/reference/stdlib/4m#scow" /%} function renders a
-  `dime` as a `tape` (`dime`→`tape`); it is otherwise identical to {%
-  tooltip label="++scot" href="/language/hoon/reference/stdlib/4m#scot"
-  /%}.
+- The [++scow](/language/hoon/reference/stdlib/4m#scow) function renders
+  a `dime` as a `tape` (`dime`→`tape`); it is otherwise identical to
+  [++scot](/language/hoon/reference/stdlib/4m#scot).
 
-- The {% tooltip label="++sane"
-  href="/language/hoon/reference/stdlib/4b#sane" /%} function checks the
-  validity of a possible text string as a `knot` or `term`.  The usage
-  of `++sane` will feel a bit strange to you:  it doesn't apply directly
-  to the text you want to check, but it produces a gate that checks for
-  the aura (as `%ta` or `%tas`).  (The gate-builder is a fairly common
-  pattern in Hoon that we've started to hint at by using molds.)
-  `++sane` is also not infallible yet.
+- The [++sane](/language/hoon/reference/stdlib/4b#sane) function checks
+  the validity of a possible text string as a `knot` or `term`.  The
+  usage of `++sane` will feel a bit strange to you:  it doesn't apply
+  directly to the text you want to check, but it produces a gate that
+  checks for the aura (as `%ta` or `%tas`).  (The gate-builder is a
+  fairly common pattern in Hoon that we've started to hint at by using
+  molds.) `++sane` is also not infallible yet.
 
     ```hoon
     > ((sane %ta) 'ångstrom')
@@ -586,29 +566,27 @@ Let's take some of the code we've built above for processing text and
 turn them into a library we can use in another generator.
 
 - Take the space-breaking code and the element-counting code gates from
-  above and include them in a `|%` {% tooltip label="barcen"
-  href="/language/hoon/reference/rune/bar#-barcen" /%} core.  Save this
-  file as `lib/text.hoon` in the `%base` {% tooltip label="desk"
-  href="/glossary/desk" /%} of your fakeship and commit.
+  above and include them in a `|%`
+  [barcen](/language/hoon/reference/rune/bar#-barcen) core.  Save this
+  file as `lib/text.hoon` in the `%base` [desk](/glossary/desk) of your
+  fakeship and commit.
 
-- Produce a generator `gen/text-user.hoon` which accepts a {% tooltip
-  label="tape" href="/glossary/tape" /%} and returns the number of words
-  in the text (separated by spaces).  (How would you obtain this from
-  those two operations?)
+- Produce a generator `gen/text-user.hoon` which accepts a
+  [tape](/glossary/tape) and returns the number of words in the text
+  (separated by spaces).  (How would you obtain this from those two
+  operations?)
 
 
 ##  Logging
 
 The most time-honored method of debugging is to simply output relevant
 values at key points throughout a program in order to make sure they are
-doing what you think they are doing.  To this end, we introduced `~&` {%
-tooltip label="sigpam" href="/language/hoon/reference/rune/sig#-sigpam"
-/%} in the last lesson.
+doing what you think they are doing.  To this end, we introduced `~&`
+[sigpam](/language/hoon/reference/rune/sig#-sigpam) in the last lesson.
 
-The `~&` {% tooltip label="sigpam"
-href="/language/hoon/reference/rune/sig#-sigpam" /%} rune offers some
-finer-grained output options than just printing a simple value to the
-screen.  For instance, you can use it with string interpolation to
+The `~&` [sigpam](/language/hoon/reference/rune/sig#-sigpam) rune offers
+some finer-grained output options than just printing a simple value to
+the screen.  For instance, you can use it with string interpolation to
 produce detailed error messages.
 
 There are also `>` modifiers which can be included to mark “debugging
@@ -649,34 +627,32 @@ Dojo:
 
 ##  `%say` Generators
 
-A naked {% tooltip label="generator" href="/glossary/generator" /%} is
-merely a {% tooltip label="gate" href="/glossary/gate" /%}:  a {%
-tooltip label="core" href="/glossary/core" /%} with a `$` arm that Dojo
-knows to call.  However, we can also invoke a generator which is a cell
-of a metadata tag and a core.  The next level-up for our generator
+A naked [generator](/glossary/generator) is merely a
+[gate](/glossary/gate):  a [core](/glossary/core) with a `$` arm that
+Dojo knows to call.  However, we can also invoke a generator which is a
+cell of a metadata tag and a core.  The next level-up for our generator
 skills is the `%say` generator, a cell of `[%say core]` that affords
 slightly more sophisticated evaluation.
 
-We use `%say` generators when we want to provide something else in {%
-tooltip label="Arvo" href="/glossary/arvo" /%}, the Urbit operating
-system, with metadata about the generator's output. This is useful when
-a generator is needed to pipe data to another program, a frequent
-occurrence.
+We use `%say` generators when we want to provide something else in
+[Arvo](/glossary/arvo), the Urbit operating system, with metadata about
+the generator's output. This is useful when a generator is needed to
+pipe data to another program, a frequent occurrence.
 
 To that end, `%say` generators use `mark`s to make it clear, to other
-Arvo computations, exactly what kind of data their output is. A {%
-tooltip label="mark" href="/glossary/mark" /%} is akin to a MIME type on
-the Arvo level. A `mark` describes the data in some way, indicating that
-it's an `%atom`, or that it's a standard such as `%json`, or even that
-it's an application-specific data structure like `%talk-command`.
-`mark`s are not specific to `%say` generators; whenever data moves
-between programs in Arvo, that data is marked.
+Arvo computations, exactly what kind of data their output is. A
+[mark](/glossary/mark) is akin to a MIME type on the Arvo level. A
+`mark` describes the data in some way, indicating that it's an `%atom`,
+or that it's a standard such as `%json`, or even that it's an
+application-specific data structure like `%talk-command`. `mark`s are
+not specific to `%say` generators; whenever data moves between programs
+in Arvo, that data is marked.
 
-So, more formally, a `%say` generator is a {% tooltip label="cell"
-href="/glossary/cell" /%}. The head of that cell is the `%say` tag, and
-the tail is a `gate` that produces a `cask` -- a pair of the output data
-and the `mark` describing that data. -- Save this example as `add.hoon`
-in the `/gen` directory of your `%base` desk:
+So, more formally, a `%say` generator is a [cell](/glossary/cell). The
+head of that cell is the `%say` tag, and the tail is a `gate` that
+produces a `cask` -- a pair of the output data and the `mark` describing
+that data. -- Save this example as `add.hoon` in the `/gen` directory of
+your `%base` desk:
 
 ```hoon {% copy=true %}
 :-  %say
@@ -703,8 +679,8 @@ something a `%say` generator.
 :-  %say
 ```
 
-Recall that the rune `:-` {% tooltip label="colhep"
-href="/language/hoon/reference/rune/col#--colhep" /%} produces a cell,
+Recall that the rune `:-`
+[colhep](/language/hoon/reference/rune/col#--colhep) produces a cell,
 with the first following expression as its head and the second following
 expression as its tail.
 
@@ -717,12 +693,12 @@ the `|= *` expression on the line that follows.
 (add 40 2)
 ```
 
-`|= *` constructs a {% tooltip label="gate" href="/glossary/gate" /%}
-that takes a noun. This `gate` will itself produce a `cask`, which is
-cell formed by the prepending `:-`. The head of that `cask` is `%noun`
-and the tail is the rest of the program, `(add 40 2)`. The tail of the
-`cask` will be our actual data produced by the body of the program: in
-this case, just adding 40 and 2 together.
+`|= *` constructs a [gate](/glossary/gate) that takes a noun. This
+`gate` will itself produce a `cask`, which is cell formed by the
+prepending `:-`. The head of that `cask` is `%noun` and the tail is the
+rest of the program, `(add 40 2)`. The tail of the `cask` will be our
+actual data produced by the body of the program: in this case, just
+adding 40 and 2 together.
 
 A `%say` generator has access to values besides those passed into it and
 the Hoon standard subject.  Namely, a `%say` generator knows about
@@ -744,18 +720,18 @@ have if we just used a naked generator.
 
 Naked generators are limited because they have no way of accessing data
 that exists in Arvo, such as the date and time or pieces of fresh
-entropy.  In `%say` generators, however, we can access that kind of {%
-tooltip label="subject" href="/glossary/subject" /%} by identifying them
-in the gate's sample, which we only specified as `*` in the previous few
-examples. But we can do more with `%say` generators if we do more with
-that sample.  Any valid sample will follow this 3-tuple scheme:
+entropy.  In `%say` generators, however, we can access that kind of
+[subject](/glossary/subject) by identifying them in the gate's sample,
+which we only specified as `*` in the previous few examples. But we can
+do more with `%say` generators if we do more with that sample.  Any
+valid sample will follow this 3-tuple scheme:
 
 `[[now=@da eny=@uvJ bec=beak] [list of unnamed arguments] [list of named arguments]]`
 
-This entire structure is a {% tooltip label="noun" href="/glossary/noun"
-/%}, which is why `*` is a valid sample if we wish to not use any of the
-information here in a generator. But let's look at each of these three
-elements, piece by piece.
+This entire structure is a [noun](/glossary/noun), which is why `*` is a
+valid sample if we wish to not use any of the information here in a
+generator. But let's look at each of these three elements, piece by
+piece.
 
 ##  Exercise:  The Magic 8-Ball
 
@@ -797,8 +773,8 @@ response to a call.  In its entirety:
 
 `~(. og eny)` starts a random number generator with a seed from the
 current entropy.  Right now we don't know quite enough to interpret this
-line, but we'll revisit the {% tooltip label="++og"
-href="/language/hoon/reference/stdlib/3d#og" /%} aspect of this `%say`
+line, but we'll revisit the
+[++og](/language/hoon/reference/stdlib/3d#og) aspect of this `%say`
 generator in [the lesson on
 subject-oriented-programming](/courses/hoon-school/O-subject).  For now,
 just know that it allows us to produce a random (unpredictable) integer
@@ -836,8 +812,8 @@ Let's use it with a `%say` generator.
 ```
 
 Having already saved the library as `/lib/playing-cards.hoon`, you can
-import it with the `/+` {% tooltip label="faslus"
-href="/language/hoon/reference/rune/fas#-faslus" /%} rune.  When
+import it with the `/+`
+[faslus](/language/hoon/reference/rune/fas#-faslus) rune.  When
 `cards.hoon` gets built, the Hoon builder will pull in the requested
 library and also build that.  It will also create a dependency so that
 if `/lib/playing-cards.hoon` changes, this file will also get rebuilt.

--- a/content/courses/hoon-school/K-doors.md
+++ b/content/courses/hoon-school/K-doors.md
@@ -5,28 +5,25 @@ nodes = [150, 155]
 objectives = ["Identify the structure of a door and relate it to a core.", "Pull an arm in a door.", "Build cores for later use and with custom samples.", "Identify the `$` buc arm in several structures and its role."]
 +++
 
-_Hoon is statically typed, which means (among other things) that {%
-tooltip label="auras" href="/glossary/aura" /%} are subject to strict
-nesting rules, {% tooltip label="molds" href="/glossary/mold" /%} are
-crash-only, and the whole thing is rather cantankerous about matching
-types.  However, since gate-building arms are possible, Hoon developers
-frequently employ them as templates to build type-appropriate {% tooltip
-label="cores" href="/glossary/core" /%}, including {% tooltip
-label="gates" href="/glossary/gate" /%}.  This module will start by
-introducing the concept of gate-building gates; then it will expand our
-notion of cores to include {% tooltip label="doors"
-href="/glossary/door" /%}; finally it will introduce a common door,
-the {% tooltip label="++map" href="/language/hoon/reference/stdlib/2o#map"
-/%}, to illustrate how doors work._
+_Hoon is statically typed, which means (among other things) that
+[auras](/glossary/aura) are subject to strict nesting rules,
+[molds](/glossary/mold) are crash-only, and the whole thing is rather
+cantankerous about matching types.  However, since gate-building arms
+are possible, Hoon developers frequently employ them as templates to
+build type-appropriate [cores](/glossary/core), including
+[gates](/glossary/gate).  This module will start by introducing the
+concept of gate-building gates; then it will expand our notion of cores
+to include [doors](/glossary/door); finally it will introduce a common
+door, the [++map](/language/hoon/reference/stdlib/2o#map), to illustrate
+how doors work._
 
 ##  Gate-Building Gates
 
 ### Calling Gates
 
 There are two ways of making a function call in Hoon. First, you can
-call a gate in the {% tooltip label="subject" href="/glossary/subject"
-/%} by name.  For instance, we can produce a gate `inc` which adds `1`
-to an input:
+call a gate in the [subject](/glossary/subject) by name.  For instance,
+we can produce a gate `inc` which adds `1` to an input:
 
 ```hoon
 > =inc |=(a=@ (add 1 a))
@@ -52,10 +49,9 @@ The difference is subtle:  the first case has an already-created gate in
 the subject when we called it, while the latter involves producing a
 gate that doesn't exist anywhere in the subject, and then calling it.
 
-Are calls to {% tooltip label="++add"
-href="/language/hoon/reference/stdlib/1a#add" /%} and {% tooltip
-label="++mul" href="/language/hoon/reference/stdlib/1a#mul" /%} of the
-Hoon standard library of the first kind, or the second?
+Are calls to [++add](/language/hoon/reference/stdlib/1a#add) and
+[++mul](/language/hoon/reference/stdlib/1a#mul) of the Hoon standard
+library of the first kind, or the second?
 
 ```hoon
 > (add 12 23)
@@ -66,25 +62,21 @@ Hoon standard library of the first kind, or the second?
 ```
 
 They're of the second kind.  Neither `++add` nor `++mul` resolves to a
-gate directly; they're each {% tooltip label="arms" href="/glossary/arm"
-/%} that _produce_ gates.
+gate directly; they're each [arms](/glossary/arm) that _produce_ gates.
 
 Often the difference doesn't matter much. Either way you can do a
 function call using the `(gate arg)` syntax.
 
 It's important to learn the difference, however, because for certain use
 cases you'll want the extra flexibility that comes with having an
-already produced {% tooltip label="core" href="/glossary/core" /%} in
-the subject.
+already produced [core](/glossary/core) in the subject.
 
 ### Building Gates
 
-Let's make a core with arms that build {% tooltip label="gates"
-href="/glossary/gate" /%} of various kinds.  As we did in a previous
-lesson, we'll use the `|%` {% tooltip label="barcen"
-href="/language/hoon/reference/rune/bar#-barcen" /%} rune.  Copy and
-paste the following into the {% tooltip label="Dojo"
-href="/glossary/dojo" /%}:
+Let's make a core with arms that build [gates](/glossary/gate) of
+various kinds.  As we did in a previous lesson, we'll use the `|%`
+[barcen](/language/hoon/reference/rune/bar#-barcen) rune.  Copy and
+paste the following into the [Dojo](/glossary/dojo):
 
 ```hoon {% copy=true %}
 =c |%
@@ -111,18 +103,17 @@ Let's try out these arms, using them for function calls:
 30
 ```
 
-Notice that each {% tooltip label="arm" href="/glossary/arm" /%} in core
-`c` is able to call the other arms of `c`—`++add-two` uses the `++inc`
-arm to increment a number twice.  As a reminder, each arm is evaluated
-with its parent core as the {% tooltip label="subject"
-href="/glossary/subject" /%}.  In the case of `++add-two` the parent
+Notice that each [arm](/glossary/arm) in core `c` is able to call the
+other arms of `c`—`++add-two` uses the `++inc` arm to increment a number
+twice.  As a reminder, each arm is evaluated with its parent core as the
+[subject](/glossary/subject).  In the case of `++add-two` the parent
 core is `c`, which has `++inc` in it.
 
 #### Mutating a Gate
 
-Let's say you want to modify the default {% tooltip label="sample"
-href="/glossary/sample" /%} of the gate for `double`. We can infer the
-default sample by calling `double` with no argument:
+Let's say you want to modify the default [sample](/glossary/sample) of
+the gate for `double`. We can infer the default sample by calling
+`double` with no argument:
 
 ```hoon
 > (double:c)
@@ -156,8 +147,7 @@ subject:
 ```
 
 Now let's mutate the sample to `25`, and check that it worked with `+6`.
-(The sample lives at `+6` in a given {% tooltip label="core"
-href="/glossary/core" /%} tree.)
+(The sample lives at `+6` in a given [core](/glossary/core) tree.)
 
 ```hoon
 > +6:double-copy(a 25)
@@ -165,8 +155,7 @@ a=25
 ```
 
 Good. Let's call it with no argument and see if it returns double the
-value of the modified {% tooltip label="sample" href="/glossary/sample"
-/%}.
+value of the modified [sample](/glossary/sample).
 
 ```hoon
 > (double-copy(a 25))
@@ -181,8 +170,8 @@ It does indeed. Unbind `c` and `double-copy`:
 > =double-copy
 ```
 
-Contrast this with the behavior of {% tooltip label="++add"
-href="/language/hoon/reference/stdlib/1a#add" /%}. We can look at the
+Contrast this with the behavior of
+[++add](/language/hoon/reference/stdlib/1a#add). We can look at the
 sample of the gate for `add` with `+6:add`:
 
 ```hoon
@@ -199,15 +188,14 @@ If you try to mutate the default sample of `++add`, it won't work:
 dojo: hoon expression failed
 ```
 
-As before with `++double`, Hoon can't find an `a` to modify in a {%
-tooltip label="gate" href="/glossary/gate" /%} that doesn't exist yet.
+As before with `++double`, Hoon can't find an `a` to modify in a
+[gate](/glossary/gate) that doesn't exist yet.
 
 ### Slamming a Gate
 
-If you check the docs on our now-familiar `%-` {% tooltip label="cenhep"
-href="/language/hoon/reference/rune/cen#-cenhep" /%}, you'll find that
-it is actually sugar syntax for another {% tooltip label="rune"
-href="/glossary/rune" /%}:
+If you check the docs on our now-familiar `%-`
+[cenhep](/language/hoon/reference/rune/cen#-cenhep), you'll find that it
+is actually sugar syntax for another [rune](/glossary/rune):
 
 > This rune is for evaluating the `$` arm of a gate, i.e., calling a
 > gate as a function. `a` is the gate, and `b` is the desired sample value
@@ -217,49 +205,44 @@ href="/glossary/rune" /%}:
 > %~($ a b)
 > ```
 
-So all gate calls actually pass back through `%~` {% tooltip
-label="censig" href="/language/hoon/reference/rune/cen#-censig" /%}.
-What's the difference?
+So all gate calls actually pass back through `%~`
+[censig](/language/hoon/reference/rune/cen#-censig). What's the
+difference?
 
-The `%~` {% tooltip label="censig"
-href="/language/hoon/reference/rune/cen#-censig" /%} rune accepts three
-children, a wing which resolves to an arm in a {% tooltip label="door"
-href="/glossary/door" /%}; the aforesaid door; and a `sample` for the
-door.
+The `%~` [censig](/language/hoon/reference/rune/cen#-censig) rune
+accepts three children, a wing which resolves to an arm in a
+[door](/glossary/door); the aforesaid door; and a `sample` for the door.
 
-Basically, whenever you use `%-` {% tooltip label="cenhep"
-href="/language/hoon/reference/rune/cen#-cenhep" /%}, it actually looks
-up a wing in a door using `%~` {% tooltip label="censig"
-href="/language/hoon/reference/rune/cen#-censig" /%}, which is a more
+Basically, whenever you use `%-`
+[cenhep](/language/hoon/reference/rune/cen#-cenhep), it actually looks
+up a wing in a door using `%~`
+[censig](/language/hoon/reference/rune/cen#-censig), which is a more
 general type of core than a gate.  Whatever that wing resolves to is
-then provided a {% tooltip label="sample" href="/glossary/sample" /%}.
-The resulting Hoon expression is evaluated and the value is returned.
+then provided a [sample](/glossary/sample). The resulting Hoon
+expression is evaluated and the value is returned.
 
 
 ##  Doors
 
 {% video src="https://media.urbit.org/docs/hoon-school-videos/HS150 - Doors.mp4" /%}
 
-{% tooltip label="Doors" href="/glossary/door" /%} are another kind of
-{% tooltip label="core" href="/glossary/core" /%} whose {% tooltip
-label="arms" href="/glossary/arm" /%} evaluate to make {% tooltip
-label="gates" href="/glossary/gate" /%}, as we just discovered.  The
-difference is that a door also has its own {% tooltip label="sample"
-href="/glossary/sample" /%}. A door is the most general case of a
+[Doors](/glossary/door) are another kind of [core](/glossary/core) whose
+[arms](/glossary/arm) evaluate to make [gates](/glossary/gate), as we
+just discovered.  The difference is that a door also has its own
+[sample](/glossary/sample). A door is the most general case of a
 function in Hoon.  (You could say a "gate-building core" or a
 "function-building function" to clarify what the intent of most of these
 are.)
 
-A core is a {% tooltip label="cell" href="/glossary/cell" /%} of code
-and data, called `[battery payload]`.  The {% tooltip label="battery"
-href="/glossary/battery" /%} contains a series of arms, and the {%
-tooltip label="payload" href="/glossary/payload" /%} contains all the
-data necessary to run those arms correctly.
+A core is a [cell](/glossary/cell) of code and data, called `[battery
+payload]`.  The [battery](/glossary/battery) contains a series of arms,
+and the [payload](/glossary/payload) contains all the data necessary to
+run those arms correctly.
 
 A _door_ is a core with a sample.  That is, a door is a core whose
-payload is a cell of {% tooltip label="sample" href="/glossary/sample"
-/%} and context:  `[sample context]`.  A door's overall sample can
-affect how its gate-building arms work.
+payload is a cell of [sample](/glossary/sample) and context:  `[sample
+context]`.  A door's overall sample can affect how its gate-building
+arms work.
 
 ```
         door
@@ -272,12 +255,14 @@ battery      .
 It follows from this definition that a gate is a special case of a door.
 A gate is a door with exactly one arm, named `$` buc.
 
-Doors are created with the `|_` {% tooltip label="barcab"
-href="/language/hoon/reference/rune/bar#_-barcab" /%} rune.  Doors get
+Doors are created with the `|_`
+[barcab](/language/hoon/reference/rune/bar#_-barcab) rune.  Doors get
 used for a few different purposes in the standard library:
 
-- instrumenting and storing persistent data structures like `map`s (this module and the next)
-- implementing state machines (the [subject-oriented programming module](/courses/hoon-school/O-subject))
+- instrumenting and storing persistent data structures like `map`s (this
+  module and the next)
+- implementing state machines (the [subject-oriented programming
+  module](/courses/hoon-school/O-subject))
 
 One BIG pitfall for thinking about doors is thinking of them as
 “containing” gates, as if they were more like “objects”.  Instead, think
@@ -316,11 +301,10 @@ One way to accomplish this is to wrap the gate inside of another:
 
 If we built this as a door instead, we could push the parameters out to
 a different layer of the structure.  In this case, the parameters are
-the {% tooltip label="sample" href="/glossary/sample" /%} of the door,
-while the arm `++quad` builds a gate that corresponds to those
-parameters and only accepts one unknown variable `x`.  To make a door we
-use the `|_` {% tooltip label="barcab"
-href="/language/hoon/reference/rune/bar#_-barcab" /%} rune, which we'll
+the [sample](/glossary/sample) of the door, while the arm `++quad`
+builds a gate that corresponds to those parameters and only accepts one
+unknown variable `x`.  To make a door we use the `|_`
+[barcab](/language/hoon/reference/rune/bar#_-barcab) rune, which we'll
 discuss later:
 
 ```hoon
@@ -334,18 +318,18 @@ discuss later:
 This will be used in two steps:  a gate-building step then a gate usage
 step.
 
-We produce a gate from a door's arm using the `%~` {% tooltip
-label="censig" href="/language/hoon/reference/rune/cen#-censig" /%}
-rune, almost always used in its irregular form, `~()`.  Here we prime
-the door with `[5 4 3]`, which yields a gate:
+We produce a gate from a door's arm using the `%~`
+[censig](/language/hoon/reference/rune/cen#-censig) rune, almost always
+used in its irregular form, `~()`.  Here we prime the door with `[5 4
+3]`, which yields a gate:
 
 ```hoon {% copy=true %}
 ~(quad poly [5 4 3])
 ```
 
-By itself, not so much to say.  We could pin it into the {% tooltip
-label="Dojo" href="/glossary/dojo" /%}, for instance, to use later.  Our
-ultimate goal is to use the built gate on particular data, however:
+By itself, not so much to say.  We could pin it into the
+[Dojo](/glossary/dojo), for instance, to use later.  Our ultimate goal
+is to use the built gate on particular data, however:
 
 ```hoon
 > (~(quad poly [5 4 3]) 2)
@@ -360,12 +344,10 @@ and calculating the gate.
 
 #### Example:  A Calculator
 
-Let's unpack what's going on more with this next {% tooltip label="door"
-href="/glossary/door" /%}.  Each of the {% tooltip label="arms"
-href="/glossary/arm" /%} in this example door will define a simple gate.
-Let's bind the door to `c`.  To make a door we use the `|_` {% tooltip
-label="barcab" href="/language/hoon/reference/rune/bar#_-barcab" /%}
-rune:
+Let's unpack what's going on more with this next [door](/glossary/door).
+Each of the [arms](/glossary/arm) in this example door will define a
+simple gate. Let's bind the door to `c`.  To make a door we use the `|_`
+[barcab](/language/hoon/reference/rune/bar#_-barcab) rune:
 
 ```hoon {% copy=true %}
 =c |_  b=@
@@ -378,27 +360,22 @@ rune:
 If you type this into the dojo manually, make sure you attend carefully
 to the spacing. Feel free to cut and paste the code, if desired.
 
-Before getting into what these arms do, let's digress into how the
-`|_` {% tooltip label="barcab"
-href="/language/hoon/reference/rune/bar#_-barcab" /%} rune works in
+Before getting into what these arms do, let's digress into how the `|_`
+[barcab](/language/hoon/reference/rune/bar#_-barcab) rune works in
 general.
 
-`|_` {% tooltip label="barcab"
-href="/language/hoon/reference/rune/bar#_-barcab" /%} works exactly like
-the `|%` {% tooltip label="barcen"
-href="/language/hoon/reference/rune/bar#-barcen" /%} rune for making a
-core, except that it takes one additional daughter expression, the
-door's {% tooltip label="sample" href="/glossary/sample" /%}.  Following
-that are a series of `++` {% tooltip label="luslus"
-href="/language/hoon/reference/rune/lus#-luslus" /%} runes, each of
-which defines an arm of the door. Finally, the expression is terminated
-with a `--` {% tooltip label="hephep"
-href="/language/hoon/reference/rune/terminators#---hephep" /%} rune.
+`|_` [barcab](/language/hoon/reference/rune/bar#_-barcab) works exactly
+like the `|%` [barcen](/language/hoon/reference/rune/bar#-barcen) rune
+for making a core, except that it takes one additional daughter
+expression, the door's [sample](/glossary/sample).  Following that are a
+series of `++` [luslus](/language/hoon/reference/rune/lus#-luslus)
+runes, each of which defines an arm of the door. Finally, the expression
+is terminated with a `--`
+[hephep](/language/hoon/reference/rune/terminators#---hephep) rune.
 
-A door really is, at the bedrock level, the same thing as a {% tooltip
-label="core" href="/glossary/core" /%} with a {% tooltip label="sample"
-href="/glossary/sample" /%}.  Let's ask Dojo to pretty print a simple
-door.
+A door really is, at the bedrock level, the same thing as a
+[core](/glossary/core) with a [sample](/glossary/sample).  Let's ask
+Dojo to pretty print a simple door.
 
 ```hoon
 > =a =>  ~  |_  b=@  ++  foo  b  --
@@ -407,23 +384,22 @@ door.
 <1.zgd [b=@ %~]>
 ```
 
-Dojo tells us that `a` is a core with one arm and a {% tooltip
-label="payload" href="/glossary/payload" /%} of `[b=@ %~]`.  Since a
-door's payload is `[sample context]`, this means that `b` is the sample
-and the context is null.  (The `=> ~` set the context.  We did this to
-avoid including the standard library that is included in the context by
-default in Dojo, which would have made the pretty-printed core much more
-verbose.  Try it without `=>  ~` as well.)
+Dojo tells us that `a` is a core with one arm and a
+[payload](/glossary/payload) of `[b=@ %~]`.  Since a door's payload is
+`[sample context]`, this means that `b` is the sample and the context is
+null.  (The `=> ~` set the context.  We did this to avoid including the
+standard library that is included in the context by default in Dojo,
+which would have made the pretty-printed core much more verbose.  Try it
+without `=>  ~` as well.)
 
-For the {% tooltip label="door" href="/glossary/door" /%} defined above,
-`c`, the sample is defined as an `@` {% tooltip label="atom"
-href="/glossary/atom" /%} and given the face `b`.  The `++plus` arm
-defines a {% tooltip label="gate" href="/glossary/gate" /%} that takes a
-single atom as its argument `a` and returns the sum of `a` and `b`.  The
-`++times` arm defines a gate that takes a single atom `a` and returns
-the product of `a` and `b`. The `++greater` arm defines a gate that
-takes a single atom `a`, and returns `%.y` if `a` is greater than `b`;
-otherwise it returns `%.n`.
+For the [door](/glossary/door) defined above, `c`, the sample is defined
+as an `@` [atom](/glossary/atom) and given the face `b`.  The `++plus`
+arm defines a [gate](/glossary/gate) that takes a single atom as its
+argument `a` and returns the sum of `a` and `b`.  The `++times` arm
+defines a gate that takes a single atom `a` and returns the product of
+`a` and `b`. The `++greater` arm defines a gate that takes a single atom
+`a`, and returns `%.y` if `a` is greater than `b`; otherwise it returns
+`%.n`.
 
 Let's try out the arms of `c` with ordinary function calls:
 
@@ -538,15 +514,14 @@ doors.
 
 #### Creating Doors with a Modified Sample
 
-In the above example we created a {% tooltip label="door"
-href="/glossary/door" /%} `c` with {% tooltip label="sample"
-href="/glossary/sample" /%} `b=@` and found that the initial value of
-`b` was `0`, the bunt value of `@`. We then created new door from `c` by
+In the above example we created a [door](/glossary/door) `c` with
+[sample](/glossary/sample) `b=@` and found that the initial value of `b`
+was `0`, the bunt value of `@`. We then created new door from `c` by
 modifying the value of `b`. But what if we wish to define a door with a
-chosen sample value directly? We make use of the `$_` {% tooltip
-label="buccab" href="/language/hoon/reference/rune/buc#_-buccab" /%}
-rune, whose irregular form is simply `_`. To create the door `c` with
-the sample `b=@` set to have the value `7` in the dojo, we would write
+chosen sample value directly? We make use of the `$_`
+[buccab](/language/hoon/reference/rune/buc#_-buccab) rune, whose
+irregular form is simply `_`. To create the door `c` with the sample
+`b=@` set to have the value `7` in the dojo, we would write
 
 ```hoon {% copy=true %}
 =c |_  b=_7
@@ -556,12 +531,14 @@ the sample `b=@` set to have the value `7` in the dojo, we would write
 --
 ```
 
-Here the type of `b` is inferred to be `@` based on the example value `7`, similar to how we've seen casting done by example.  You will learn more about how types are inferred in the [next module](/courses/hoon-school/L-struct).
+Here the type of `b` is inferred to be `@` based on the example value
+`7`, similar to how we've seen casting done by example.  You will learn
+more about how types are inferred in the [next
+module](/courses/hoon-school/L-struct).
 
 ### Exercise:  Adding Arms to a Door
 
-Recall the quadratic equation {% tooltip label="door"
-href="/glossary/door" /%}.
+Recall the quadratic equation [door](/glossary/door).
 
 ```hoon {% copy=true %}
 |_  [a=@ud b=@ud c=@ud]
@@ -571,7 +548,7 @@ href="/glossary/door" /%}.
 --
 ```
 
-- Add an {% tooltip label="arm" href="/glossary/arm" /%} to the door
+- Add an [arm](/glossary/arm) to the door
   which calculates the linear function _a_ × _x_
   + _b_.
 
@@ -583,12 +560,11 @@ href="/glossary/door" /%}.
 
 {% video src="https://media.urbit.org/docs/hoon-school-videos/HS183 - Maps and Sets.mp4" /%}
 
-In general terms, a {% tooltip label="map"
-href="/language/hoon/reference/stdlib/2o#map" /%} is a pattern from a
-key to a value.  You can think of a dictionary, or an index, or a data
-table.  Essentially it scans for a particular key, then returns the data
-associated with that key (which may be any {% tooltip label="noun"
-href="/glossary/noun" /%}).
+In general terms, a [map](/language/hoon/reference/stdlib/2o#map) is a
+pattern from a key to a value.  You can think of a dictionary, or an
+index, or a data table.  Essentially it scans for a particular key, then
+returns the data associated with that key (which may be any
+[noun](/glossary/noun)).
 
 | Key         | Value      |
 | ----------- | ---------- |
@@ -599,38 +575,36 @@ href="/glossary/noun" /%}).
 | 'Porsche'   | 'Boxster'  |
 | 'Bugatti'   | 'Type 22'  |
 
-While `map` is the {%tooltip label="mold" href="/glossary/mold" /%} or
-type of the value, the {% tooltip label="door" href="/glossary/door" /%}
-which affords `map`-related functionality is named {% tooltip
-label="++by" href="/language/hoon/reference/stdlib/2i#by" /%}.  (This
-felicitously affords us a way to read `map` operations in an
-English-friendly phrasing.)
+While `map` is the [mold](/glossary/mold) or type of the value, the
+[door](/glossary/door) which affords `map`-related functionality is
+named [++by](/language/hoon/reference/stdlib/2i#by).  (This felicitously
+affords us a way to read `map` operations in an English-friendly
+phrasing.)
 
 In Urbit, all values are static and never change.  (This is why we
-“overwrite” or replace the values in a limb to change it with `%=` {%
-tooltip label="centis" href="/language/hoon/reference/rune/cen#-centis"
-/%}.)  This means that when we build a `map`, we often rather awkwardly
-replace it with its modified value explicitly.
+“overwrite” or replace the values in a limb to change it with `%=`
+[centis](/language/hoon/reference/rune/cen#-centis).)  This means that
+when we build a `map`, we often rather awkwardly replace it with its
+modified value explicitly.
 
 We'll build a color `map`, from a `@tas` of a [color's
 name](https://en.wikipedia.org/wiki/List_of_Crayola_crayon_colors) to
 its HTML hexadecimal representation as a `@ux` hex value.
 
-We can produce a `map` from a {% tooltip label="list"
-href="/glossary/list" /%} of key-value cells using the {% tooltip
-label="++malt" href="/language/hoon/reference/stdlib/2l#malt" /%}
-function.  Using `@tas` terms as keys (which is common) requires us to
-explicitly mark the list as `(list (pair @tas @ux))`:
+We can produce a `map` from a [list](/glossary/list) of key-value cells
+using the [++malt](/language/hoon/reference/stdlib/2l#malt) function.
+Using `@tas` terms as keys (which is common) requires us to explicitly
+mark the list as `(list (pair @tas @ux))`:
 
 ```hoon {% copy=true %}
 =colors (malt `(list (pair @tas @ux))`~[[%red 0xed.0a3f] [%yellow 0xfb.e870] [%green 0x1.a638] [%blue 0x66ff]])
 ```
 
-To insert one key-value pair at a time, we use {% tooltip label="put"
-href="/language/hoon/reference/stdlib/2i#putby" /%}.  In Dojo, we need
-to either pin it into the subject or modify a copy of the map for the
-rest of the expression using `=/` {% tooltip label="tisfas"
-href="/language/hoon/reference/rune/tis#-tisfas" /%}.
+To insert one key-value pair at a time, we use
+[put](/language/hoon/reference/stdlib/2i#putby).  In Dojo, we need to
+either pin it into the subject or modify a copy of the map for the rest
+of the expression using `=/`
+[tisfas](/language/hoon/reference/rune/tis#-tisfas).
 
 ```hoon {% copy=true %}
 =colors (~(put by colors) [%orange 0xff.8833])
@@ -638,10 +612,10 @@ href="/language/hoon/reference/rune/tis#-tisfas" /%}.
 =colors (~(put by colors) [%black 0x0])
 ```
 
-Note the pattern here:  there is a {% tooltip label="++put"
-href="/language/hoon/reference/stdlib/2i#putby" /%} arm of {% tooltip
-label="++by" href="/language/hoon/reference/stdlib/2i#by" /%} which
-builds a gate to modify `colors` by inserting a value.
+Note the pattern here:  there is a
+[++put](/language/hoon/reference/stdlib/2i#putby) arm of
+[++by](/language/hoon/reference/stdlib/2i#by) which builds a gate to
+modify `colors` by inserting a value.
 
 What happens if we try to add something that doesn't match the type?
 
@@ -649,29 +623,28 @@ What happens if we try to add something that doesn't match the type?
 =colors (~(put by colors) [%cerulean '#02A4D3'])
 ```
 
-We'll see a `mull-grow`, a `mull-nice`, and a {% tooltip
-label="nest-fail" href="/language/hoon/reference/hoon-errors#nest-fail"
-/%}.  Essentially these are all flavors of mold-matching errors.
+We'll see a `mull-grow`, a `mull-nice`, and a
+[nest-fail](/language/hoon/reference/hoon-errors#nest-fail).
+Essentially these are all flavors of mold-matching errors.
 
 (As an aside, `++put:by` is also how you'd replace a key's value.)
 
 The point of a `map` is to make it easy to retrieve data values given
-their appropriate key.  Use {% tooltip label="++get:by"
-href="/language/hoon/reference/stdlib/2i#getby" /%}:
+their appropriate key.  Use
+[++get:by](/language/hoon/reference/stdlib/2i#getby):
 
 ```hoon
 > (~(get by colors) %orange)
 [~ 0xff.8833]
 ```
 
-What is that {% tooltip label="cell" href="/glossary/cell" /%}?  Wasn't
-the value stored as `0xff.8833`?  Well, one fundamental problem that
-a {% tooltip label="map" href="/language/hoon/reference/stdlib/2o#map" /%}
-needs to solve is to allow us to distinguish an _empty_ result (or
-failure to locate a value) from a _zero_ result (or an answer that's
-actually zero).  To this end, the {% tooltip label="unit"
-href="/language/hoon/reference/stdlib/1c#unit" /%} was introduced, a
-type union of a `~` (for no result) and `[~ item]` (for when a result
+What is that [cell](/glossary/cell)?  Wasn't the value stored as
+`0xff.8833`?  Well, one fundamental problem that a
+[map](/language/hoon/reference/stdlib/2o#map) needs to solve is to allow
+us to distinguish an _empty_ result (or failure to locate a value) from
+a _zero_ result (or an answer that's actually zero).  To this end, the
+[unit](/language/hoon/reference/stdlib/1c#unit) was introduced, a type
+union of a `~` (for no result) and `[~ item]` (for when a result
 exists).
 
 - What does `[~ ~]` mean when returned from a `map`?
@@ -685,17 +658,16 @@ module](/courses/hoon-school/L-struct).
 ~
 ```
 
-({% tooltip label="++got:by"
-href="/language/hoon/reference/stdlib/2i#gotby" /%} returns the value
+([++got:by](/language/hoon/reference/stdlib/2i#gotby) returns the value
 without the `unit` wrapper, but crashes on failure to locate.  I
 recommend just using `++get` and extracting the tail of the resulting
-cell after confirming it isn't null with `?~` {% tooltip label="wutsig"
-href="/language/hoon/reference/rune/wut#-wutsig" /%}.  See also {%
-tooltip label="++gut:by" href="/language/hoon/reference/stdlib/2i#gutby"
-/%} which allows a default in case of failure to locate.)
+cell after confirming it isn't null with `?~`
+[wutsig](/language/hoon/reference/rune/wut#-wutsig).  See also
+[++gut:by](/language/hoon/reference/stdlib/2i#gutby) which allows a
+default in case of failure to locate.)
 
-You can check whether a key is present using {% tooltip label="++has:by"
-href="/language/hoon/reference/stdlib/2i#hasby" /%}:
+You can check whether a key is present using
+[++has:by](/language/hoon/reference/stdlib/2i#hasby):
 
 ```hoon
 > (~(has by colors) %teal)
@@ -705,16 +677,16 @@ href="/language/hoon/reference/stdlib/2i#hasby" /%}:
 %.y
 ```
 
-You can get a list of all keys with {% tooltip label="++key:by"
-href="/language/hoon/reference/stdlib/2i#keyby" /%}:
+You can get a list of all keys with
+[++key:by](/language/hoon/reference/stdlib/2i#keyby):
 
 ```hoon
 > ~(key by colors)
 {%black %red %blue %violet %green %yellow %orange}
 ```
 
-You can apply a gate to each value using {% tooltip label="++run:by"
-href="/language/hoon/reference/stdlib/2i#runby" /%}.  For instance,
+You can apply a gate to each value using
+[++run:by](/language/hoon/reference/stdlib/2i#runby).  For instance,
 these gates will break the color hexadecimal value into red, green, and
 blue components:
 
@@ -741,13 +713,13 @@ blue components:
 - Recall the `/lib/playing-cards.hoon` library.  Use a map to
   pretty-print the `darc`s as Unicode card symbols.
 
-    The map type should be `(map darc @t)`.  We'll use {% tooltip
-    label="++malt" href="/language/hoon/reference/stdlib/2l#malt" /%} to
-    build it and associate the fancy (if tiny) [Unicode playing card
+    The map type should be `(map darc @t)`.  We'll use
+    [++malt](/language/hoon/reference/stdlib/2l#malt) to build it and
+    associate the fancy (if tiny) [Unicode playing card
     symbols](https://en.wikipedia.org/wiki/Playing_cards_in_Unicode).
 
-    Add the following {% tooltip label="arms" href="/glossary/arm" /%}
-    to the library {% tooltip label="core" href="/glossary/core" /%}:
+    Add the following [arms](/glossary/arm)
+    to the library [core](/glossary/core):
 
     ```hoon {% copy=true mode="collapse" %}
     ++  pp-card
@@ -811,9 +783,9 @@ blue components:
       ==
     ```
 
-    Import the library in Dojo (or use `/+` {% tooltip label="faslus"
-    href="/language/hoon/reference/rune/fas#-faslus" /%} in a {% tooltip
-    label="generator" href="/glossary/generator" /%}) and build a deck:
+    Import the library in Dojo (or use `/+`
+    [faslus](/language/hoon/reference/rune/fas#-faslus) in a
+    [generator](/glossary/generator)) and build a deck:
 
     ```hoon
     > =playing-cards -build-file /===/lib/playing-cards/hoon
@@ -864,12 +836,11 @@ Plaintext message:    "do not give way to anger"
 Right-shifted cipher: "ep opu hjwf xbz up bohfs"
 ```
 
-Below is a generator that performs a Caesar cipher on a {% tooltip
-label="tape" href="/glossary/tape" /%}.  This example isn't the most
-compact implementation of such a cipher in Hoon, but it demonstrates
-important principles that more laconic code would not.  Save it as
-`/gen/caesar.hoon` on your `%base` {% tooltip label="desk"
-href="/glossary/desk" /%}.
+Below is a generator that performs a Caesar cipher on a
+[tape](/glossary/tape).  This example isn't the most compact
+implementation of such a cipher in Hoon, but it demonstrates important
+principles that more laconic code would not.  Save it as
+`/gen/caesar.hoon` on your `%base` [desk](/glossary/desk).
 
 **/gen/caesar.hoon**
 
@@ -946,12 +917,11 @@ href="/glossary/desk" /%}.
 --
 ```
 
-This generator takes two arguments:  a {% tooltip label="tape"
-href="/glossary/tape" /%}, which is your plaintext message, and an
-unsigned integer, which is the shift-value of the cipher.  It produces a
-cell of two `tape`s:  one that has been shifted right by the value, and
-another that has been shifted left.  It also converts any uppercase
-input into lowercase.
+This generator takes two arguments:  a [tape](/glossary/tape), which is
+your plaintext message, and an unsigned integer, which is the
+shift-value of the cipher.  It produces a cell of two `tape`s:  one that
+has been shifted right by the value, and another that has been shifted
+left.  It also converts any uppercase input into lowercase.
 
 Try it out in the Dojo:
 
@@ -985,7 +955,7 @@ go in written order; instead, we'll cover code in the intuitive order of
 the program.  For each chunk that we cover, try to read and understand
 the code itself before reading the explanation.
 
-There are a few {% tooltip label="runes" href="/glossary/rune" /%} in
+There are a few [runes](/glossary/rune) in
 this which we haven't seen yet; we will deal with them incidentally in
 the commentary.
 
@@ -995,28 +965,24 @@ the commentary.
 =<
 ```
 
-The `!:` {% tooltip label="zapcol"
-href="/language/hoon/reference/rune/zap#-zapcol" /%} in the first line
-of the above code enables a full stack trace in the event of an error.
+The `!:` [zapcol](/language/hoon/reference/rune/zap#-zapcol) in the
+first line of the above code enables a full stack trace in the event of
+an error.
 
-`|= [msg=tape steps=@ud]` creates a {% tooltip label="gate"
-href="/glossary/gate" /%} that takes a {% tooltip label="cell"
-href="/glossary/cell" /%}. The head of this cell is a `tape`, which is a
+`|= [msg=tape steps=@ud]` creates a [gate](/glossary/gate) that takes a
+[cell](/glossary/cell). The head of this cell is a `tape`, which is a
 string type that's a list of `cord`s. Tapes are represented as text
 surrounded by double-quotes, such as this: `"a tape"`. We give this
 input tape the face `msg`. The tail of our cell is a `@ud` -- an
-unsigned decimal {% tooltip label="atom" href="/glossary/atom" /%} --
-that we give the {% tooltip label="face" href="/glossary/face" /%}
-`steps`.
+unsigned decimal [atom](/glossary/atom) -- that we give the
+[face](/glossary/face) `steps`.
 
-`=<` {% tooltip label="zapgal"
-href="/language/hoon/reference/rune/tis#-tisgal" /%} is the rune that
-evaluates its first child expression with respect to its second child
-expression as the {% tooltip label="subject" href="/glossary/subject"
-/%}. In this case, we evaluate the expressions in the code chunk below
-against the {% tooltip label="core" href="/glossary/core" /%} declared
-later, which allows us reference the core's contained {% tooltip
-label="arms" href="/glossary/arm" /%} before they are defined. Without
+`=<` [zapgal](/language/hoon/reference/rune/tis#-tisgal) is the rune
+that evaluates its first child expression with respect to its second
+child expression as the [subject](/glossary/subject). In this case, we
+evaluate the expressions in the code chunk below against the
+[core](/glossary/core) declared later, which allows us reference the
+core's contained [arms](/glossary/arm) before they are defined. Without
 `=<`, we would need to put the code chunk below at the bottom of our
 program. In Hoon, as previously stated, we always want to keep the
 longer code towards the bottom of our programs - `=<` helps us do that.
@@ -1027,36 +993,30 @@ longer code towards the bottom of our programs - `=<` helps us do that.
     (unshift msg steps)
 ```
 
-`=. msg (cass msg)` changes the input string `msg` to lowercases.
-`=.` {% tooltip label="tisdot"
-href="/language/hoon/reference/rune/tis#-tisdot" /%} changes the leg of
+`=. msg (cass msg)` changes the input string `msg` to lowercases. `=.`
+[tisdot](/language/hoon/reference/rune/tis#-tisdot) changes the leg of
 the subject to something else. In our case, the leg to be changed is
 `msg`, and the thing to replace it is `(cass msg)`. `cass` is a
 standard-library gate that converts uppercase letters to lowercase.
 
-`:- (shift msg steps)` and `(unshift msg steps)` simply composes a {%
-tooltip label="cell" href="/glossary/cell" /%} of a right-shifted cipher
-and a left-shifted cipher of our original message. We will see how this
-is done using the {% tooltip label="core" href="/glossary/core" /%}
-described below, but this is the final output of our {% tooltip
-label="generator" href="/glossary/generator" /%}. We have indented the
-lower line, which is not strictly good Hoon style but makes the intent
-clearer.
+`:- (shift msg steps)` and `(unshift msg steps)` simply composes a
+[cell](/glossary/cell) of a right-shifted cipher and a left-shifted
+cipher of our original message. We will see how this is done using the
+[core](/glossary/core) described below, but this is the final output of
+our [generator](/glossary/generator). We have indented the lower line,
+which is not strictly good Hoon style but makes the intent clearer.
 
 ```hoon {% copy=true %}
 |%
 ```
 
-`|%` {% tooltip label="barcen"
-href="/language/hoon/reference/rune/bar#-barcen" /%} creates a {%
-tooltip label="core" href="/glossary/core" /%}, the second child of
-`=<` {% tooltip label="tisgal"
-href="/language/hoon/reference/rune/tis#-tisgal" /%}. Everything after
+`|%` [barcen](/language/hoon/reference/rune/bar#-barcen) creates a
+[core](/glossary/core), the second child of `=<`
+[tisgal](/language/hoon/reference/rune/tis#-tisgal). Everything after
 `|%` is part of that second child `core`, and will be used as the
 subject of the first child of `=<`, described above. The various parts,
-or {% tooltip label="arms" href="/glossary/arm" /%}, of the `core` are
-denoted by `++` {% tooltip label="luslus"
-href="/language/hoon/reference/rune/lus#-luslus" /%} beneath it, for
+or [arms](/glossary/arm), of the `core` are denoted by `++`
+[luslus](/language/hoon/reference/rune/lus#-luslus) beneath it, for
 instance:
 
 ```hoon {% copy=true %}
@@ -1068,7 +1028,7 @@ instance:
 ```
 
 The `++rotation` arm takes takes a specified number of characters off of
-a {% tooltip label="tape" href="/glossary/tape" /%} and puts them on the
+a [tape](/glossary/tape) and puts them on the
 end of the tape. We're going to use this to create our shifted alphabet,
 based on the number of `steps` given as an argument to our gate.
 
@@ -1078,16 +1038,14 @@ arguments: `my-alphabet`, a `tape`, and `my-steps`, a `@ud`.
 `=/ length=@ud (lent my-alphabet)` stores the length of `my-alphabet` to
 make the following code a little clearer.
 
-The {% tooltip label="++trim"
-href="/language/hoon/reference/stdlib/4b#trim" /%} gate from the
+The [++trim](/language/hoon/reference/stdlib/4b#trim) gate from the
 standard library splits a tape into two parts at a specified position.
 So `=+ (trim (mod my-steps length) my-alphabet)` splits the tape
 `my-alphabet` into two parts, `p` and `q`, which are now directly
-available in the {% tooltip label="subject" href="/glossary/subject"
-/%}. We call the modulus operation `mod` to make sure that the point at
-which we split our `tape` is a valid point inside of `my-alphabet` even
-if `my-steps` is greater than `length`, the length of `my-alphabet`. Try
-trim in the dojo:
+available in the [subject](/glossary/subject). We call the modulus
+operation `mod` to make sure that the point at which we split our `tape`
+is a valid point inside of `my-alphabet` even if `my-steps` is greater
+than `length`, the length of `my-alphabet`. Try trim in the dojo:
 
 ```hoon
 > (trim 2 "abcdefg")
@@ -1097,13 +1055,13 @@ trim in the dojo:
 [p="your" q="beard"]
 ```
 
-`(weld q p)` uses {% tooltip label="++weld"
-href="/language/hoon/reference/stdlib/2b#weld" /%}, which combines two
-strings into one. Remember that `trim` has given us a split version of
-`my-alphabet` with `p` being the front half that was split off of
-`my-alphabet` and `q` being the back half. Here we are welding the two
-parts back together, but in reverse order: the second part `q` is welded
-to the front, and the first part `p` is welded to the back.
+`(weld q p)` uses [++weld](/language/hoon/reference/stdlib/2b#weld),
+which combines two strings into one. Remember that `trim` has given us a
+split version of `my-alphabet` with `p` being the front half that was
+split off of `my-alphabet` and `q` being the back half. Here we are
+welding the two parts back together, but in reverse order: the second
+part `q` is welded to the front, and the first part `p` is welded to the
+back.
 
 ```hoon {% copy=true %}
 ++  map-maker
@@ -1119,11 +1077,11 @@ to the front, and the first part `p` is welded to the back.
 ```
 
 The `++map-maker` arm, as the name implies, takes two tapes and creates
-a {% tooltip label="map" href="/language/hoon/reference/stdlib/2o#map"
-/%} out of them. A `map` is a type equivalent to a dictionary in other
-languages: it's a data structure that associates a key with a value. If,
-for example, we wanted to have an association between `a` and 1 and `b`
-and 2, we could use a `map`.
+a [map](/language/hoon/reference/stdlib/2o#map) out of them. A `map` is
+a type equivalent to a dictionary in other languages: it's a data
+structure that associates a key with a value. If, for example, we wanted
+to have an association between `a` and 1 and `b` and 2, we could use a
+`map`.
 
 `|= [a=tape b=tape]` builds a gate that takes two tapes, `a` and `b`, as
 its sample.
@@ -1134,47 +1092,44 @@ and a `cord` value.
 You might wonder, if our gate in this arm takes `tape`s, why then are we
 producing a map of `cord` keys and values?
 
-As we discussed earlier, a {% tooltip label="tape" href="/glossary/tape"
-/%} is a list of `cord`s. In this case what we are going to do is map a
-single element of a `tape` (either our alphabet or shifted-alphabet) to
-an element of a different `tape` (either our shifted-alphabet or our
-alphabet). This pair will therefore be a pair of `cord`s. When we go to
-use this `map` to convert our incoming `msg`, we will take each element
-(`cord`) of our `msg` `tape`, use it as a `key` when accessing our `map`
-and get the corresponding `value` from that position in the `map`. This
-is how we're going to encode or decode our `msg` `tape`.
+As we discussed earlier, a [tape](/glossary/tape) is a list of `cord`s.
+In this case what we are going to do is map a single element of a `tape`
+(either our alphabet or shifted-alphabet) to an element of a different
+`tape` (either our shifted-alphabet or our alphabet). This pair will
+therefore be a pair of `cord`s. When we go to use this `map` to convert
+our incoming `msg`, we will take each element (`cord`) of our `msg`
+`tape`, use it as a `key` when accessing our `map` and get the
+corresponding `value` from that position in the `map`. This is how we're
+going to encode or decode our `msg` `tape`.
 
-`=| chart=(map @t @t)` adds a {% tooltip label="noun"
-href="/glossary/noun" /%} to the subject with the default value of the
-`(map @t @t)` type, and gives that noun the face `chart`.
+`=| chart=(map @t @t)` adds a [noun](/glossary/noun) to the subject with
+the default value of the `(map @t @t)` type, and gives that noun the
+face `chart`.
 
 `?. =((lent key-position) (lent value-result))` checks if the two
 `tape`s are the same length. If not, the program crashes with an error
 message of `%uneven-lengths`, using `~| %uneven-lengths !!`.
 
 If the two `tape`s are of the same length, we continue on to create a
-trap. `|-` {% tooltip label="barhep"
-href="/language/hoon/reference/rune/bar#--barhep" /%} creates a {%
-tooltip label="trap" href="/glossary/trap" /%}, a gate with no arguments
-that is called immediately.
+trap. `|-` [barhep](/language/hoon/reference/rune/bar#--barhep) creates
+a [trap](/glossary/trap), a gate with no arguments that is called
+immediately.
 
 `?: |(?=(~ key-position) ?=(~ value-result))` checks if either `tape` is
 empty. If this is true, the `map-maker` arm is finished and can return
-`chart`, the {% tooltip label="map"
-href="/language/hoon/reference/stdlib/2o#map" /%} that we have been
-creating.
+`chart`, the [map](/language/hoon/reference/stdlib/2o#map) that we have
+been creating.
 
 If the above test finds that the `tape`s are not empty, we trigger a
 recursion that constructs our `map`: `$(chart (~(put by chart) i.a i.b),
 a t.a, b t.b)`. This code recursively adds an entry in our `map` where
 the head of the `tape` `a` maps to the value of the head of `tape` `b`
-with `~(put by chart)`, our calling of the {% tooltip label="put"
-href="/language/hoon/reference/stdlib/2i#putby" /%} arm of the {%
-tooltip label="by" href="/language/hoon/reference/stdlib/2i#by" /%}
-map-engine {% tooltip label="core" href="/glossary/core" /%} (note that
-`~(<wing> <door> <sample>`) is a shorthand for `%~ <wing> <door>
-<sample>` (see the `%~` {% tooltip label="censig"
-href="/language/hoon/reference/rune/cen#-censig" /%} documentation for
+with `~(put by chart)`, our calling of the
+[put](/language/hoon/reference/stdlib/2i#putby) arm of the
+[by](/language/hoon/reference/stdlib/2i#by) map-engine
+[core](/glossary/core) (note that `~(<wing> <door> <sample>`) is a
+shorthand for `%~ <wing> <door> <sample>` (see the `%~`
+[censig](/language/hoon/reference/rune/cen#-censig) documentation for
 more information). The recursion also "consumes" those heads with every
 iteration by changing `a` and `b` to their tails using `a t.a, b t.b`.
 
@@ -1192,17 +1147,14 @@ we'll look at it first.
 `|= [key-position=tape value-result=tape]` creates a gate that takes two
 `tapes`.
 
-We use the {% tooltip label="put"
-href="/language/hoon/reference/stdlib/2i#putby" /%} arm of the {%
-tooltip label="by" href="/language/hoon/reference/stdlib/2i#by" /%} core
-on the next line, giving it a {% tooltip label="map"
-href="/language/hoon/reference/stdlib/2o#map" /%} produced by the
-`map-maker` arm that we created before as its {% tooltip label="sample"
-href="/glossary/sample" /%}. This adds an entry to the map where the
+We use the [put](/language/hoon/reference/stdlib/2i#putby) arm of the
+[by](/language/hoon/reference/stdlib/2i#by) core on the next line,
+giving it a [map](/language/hoon/reference/stdlib/2o#map) produced by
+the `map-maker` arm that we created before as its
+[sample](/glossary/sample). This adds an entry to the map where the
 space character (called `ace`) simply maps to itself. This is done to
-simplify the handling of spaces in {% tooltip label="tapes"
-href="/glossary/tape" /%} we want to encode, since we don't want to
-shift them.
+simplify the handling of spaces in [tapes](/glossary/tape) we want to
+encode, since we don't want to shift them.
 
 ```hoon {% copy=true %}
 ++  encoder
@@ -1218,7 +1170,7 @@ shift them.
 ```
 
 `++encoder` and `++decoder` utilize the `rotation` and `space-adder`
-arms. These {% tooltip label="gates" href="/glossary/gate" /%} are
+arms. These [gates](/glossary/gate) are
 essentially identical, with the arguments passed to `space-adder`
 reversed. They simplify the two common transactions you want to do in
 this program: producing `maps` that we can use to encode and decode
@@ -1227,11 +1179,10 @@ messages.
 In both cases, we create a gate that accepts a `@ud` named `steps`.
 
 In `encoder`: `=/ value-tape=tape (rotation alpha steps)` creates a
-`value-tape` {% tooltip label="noun" href="/glossary/noun" /%} by
+`value-tape` [noun](/glossary/noun) by
 calling `rotation` on `alpha`. `alpha` is our arm which contains a
 `tape` of the entire alphabet. The `value-tape` will be the list of
-`value`s in our {% tooltip label="map"
-href="/language/hoon/reference/stdlib/2o#map" /%}.
+`value`s in our [map](/language/hoon/reference/stdlib/2o#map).
 
 In `decoder`: `=/ key-tape (rotation alpha steps)` does the same work,
 but when passed to `space-adder` it will be the list of `key`s in our
@@ -1270,8 +1221,8 @@ positions of the alphabet by which we want to shift our message.
 shift-steps))`, and `++unshift` makes that call with `(operate message
 (decoder shift-steps))`. These both produce the final output of the
 core, to be called in the form of `(shift msg steps)` and `(unshift msg
-steps)` in the {% tooltip label="cell" href="/glossary/cell" /%} being
-created at the beginning of our code.
+steps)` in the [cell](/glossary/cell) being created at the beginning of
+our code.
 
 ```hoon {% copy=true %}
 ++  operate
@@ -1282,24 +1233,21 @@ created at the beginning of our code.
   (~(got by shift-map) a)
 ```
 
-`++operate` produces a `tape`. The `%+` {% tooltip label="cenlus"
-href="/language/hoon/reference/rune/cen#-cenlus" /%} rune allows us to
-pull an arm with a pair sample. The arm we are going to pull is {%
-tooltip label="turn" href="/language/hoon/reference/stdlib/2b#turn" /%}.
-This arm takes two arguments, a {% tooltip label="list"
-href="/glossary/list" /%} and a {% tooltip label="gate"
-href="/glossary/gate" /%} to apply to each element of the `list`.
+`++operate` produces a `tape`. The `%+`
+[cenlus](/language/hoon/reference/rune/cen#-cenlus) rune allows us to
+pull an arm with a pair sample. The arm we are going to pull is
+[turn](/language/hoon/reference/stdlib/2b#turn). This arm takes two
+arguments, a [list](/glossary/list) and a [gate](/glossary/gate) to
+apply to each element of the `list`.
 
-In this case, the `gate` we are applying to our `message` uses the {%
-tooltip label="got" href="/language/hoon/reference/stdlib/2i#gotby" /%}
-arm of the {% tooltip label="by"
-href="/language/hoon/reference/stdlib/2i#by" /%} door with our
-`shift-map` as the {% tooltip label="sample" href="/glossary/sample" /%}
-(which is either the standard alphabet for keys, and the shifted
-alphabet for values, or the other way, depending on whether we are
-encoding or decoding) to look up each `cord` in our `message`, one by
-one and replace it with the `value` from our `map` (either the encoded
-or decoded version).
+In this case, the `gate` we are applying to our `message` uses the
+[got](/language/hoon/reference/stdlib/2i#gotby) arm of the
+[by](/language/hoon/reference/stdlib/2i#by) door with our `shift-map` as
+the [sample](/glossary/sample) (which is either the standard alphabet
+for keys, and the shifted alphabet for values, or the other way,
+depending on whether we are encoding or decoding) to look up each `cord`
+in our `message`, one by one and replace it with the `value` from our
+`map` (either the encoded or decoded version).
 
 Let's give our arm Caesar's famous statement (translated into English!)
 and get our left-cipher and right-cipher.
@@ -1322,9 +1270,8 @@ key and look for the legible result.
 
 ##### Further Exercise
 
-1.  Take the example {% tooltip label="generator"
-    href="/glossary/generator" /%} and modify it to add a second layer
-    of shifts.
+1.  Take the example [generator](/glossary/generator) and modify it to
+    add a second layer of shifts.
 2.  Extend the example generator to allow for use of characters other
     than a-z. Make it shift the new characters independently of the
     alpha characters, such that punctuation is only encoded as other
@@ -1336,15 +1283,14 @@ key and look for the legible result.
 
 ##  A Bit More on Cores
 
-The `|^` {% tooltip label="barket"
-href="/language/hoon/reference/rune/bar#-barket" /%} rune is an example
-of what we can call a _convenience rune_, similar to the idea of sugar
-syntax (irregular syntax to make writing certain things out in a more
-expressive manner).  `|^` {% tooltip label="barket"
-href="/language/hoon/reference/rune/bar#-barket" /%} produces a core
-with _at least_ a `$` buc arm and computes it immediately, called a
-_cork_.  (So a cork is like a trap in the regard of computing
-immediately, but it has more arms than just `$` buc.)
+The `|^` [barket](/language/hoon/reference/rune/bar#-barket) rune is an
+example of what we can call a _convenience rune_, similar to the idea of
+sugar syntax (irregular syntax to make writing certain things out in a
+more expressive manner).  `|^`
+[barket](/language/hoon/reference/rune/bar#-barket) produces a core with
+_at least_ a `$` buc arm and computes it immediately, called a _cork_.
+(So a cork is like a trap in the regard of computing immediately, but it
+has more arms than just `$` buc.)
 
 This code calculates the volume of a cylinder, _A=πr²h_.
 
@@ -1360,18 +1306,18 @@ This code calculates the volume of a cylinder, _A=πr²h_.
 ```
 
 Since all of the values either have to be pinned ahead of time or made
-available as arms, a `|^` {% tooltip label="barket"
-href="/language/hoon/reference/rune/bar#-barket" /%} would probably be
-used inside of a gate.  Of course, since it is a {% tooltip label="core"
-href="/glossary/core" /%} with a `$` buc arm, one could also use it
-recursively to calculate values like the factorial.
+available as arms, a `|^`
+[barket](/language/hoon/reference/rune/bar#-barket) would probably be
+used inside of a gate.  Of course, since it is a [core](/glossary/core)
+with a `$` buc arm, one could also use it recursively to calculate
+values like the factorial.
 
-If you read the docs, you'll find that a `|-` {% tooltip label="barhep"
-href="/language/hoon/reference/rune/bar#--barhep" /%} rune “produces a
-{% tooltip label="trap" href="/glossary/trap" /%} (a core with one arm
-`$`) and evaluates it.”  So a trap actually evaluates to a `|%` {%
-tooltip label="barcen" href="/language/hoon/reference/rune/bar#-barcen"
-/%} core with an arm `$`:
+If you read the docs, you'll find that a `|-`
+[barhep](/language/hoon/reference/rune/bar#--barhep) rune “produces a
+[trap](/glossary/trap) (a core with one arm `$`) and evaluates it.”  So
+a trap actually evaluates to a `|%`
+[barcen](/language/hoon/reference/rune/bar#-barcen) core with an arm
+`$`:
 
 ```hoon {% copy=true %}
 :: count to five
@@ -1396,10 +1342,10 @@ actually translates to
 --
 ```
 
-You can also create a trap for later use with the `|.` {% tooltip
-label="bardot" href="/language/hoon/reference/rune/bar#-bardot" /%}
-rune.  It's quite similar, but without the `=<($...` part then it
-doesn't get evaluated immediately.
+You can also create a trap for later use with the `|.`
+[bardot](/language/hoon/reference/rune/bar#-bardot) rune.  It's quite
+similar, but without the `=<($...` part then it doesn't get evaluated
+immediately.
 
 ```hoon
 > =forty-two |.(42)
@@ -1409,21 +1355,19 @@ doesn't get evaluated immediately.
 42
 ```
 
-What is a {% tooltip label="gate" href="/glossary/gate" /%}?  It is a {%
-tooltip label="door" href="/glossary/door" /%} with only one arm `$`
-buc, and whenever you invoke it then that default arm's expression is
-referred to and evaluated.
+What is a [gate](/glossary/gate)?  It is a [door](/glossary/door) with
+only one arm `$` buc, and whenever you invoke it then that default arm's
+expression is referred to and evaluated.
 
-A _gate_ and a _trap_ are actually very similar:  a gate simply has a {%
-tooltip label="sample" href="/glossary/sample" /%} (and can actively
-change when evaluated or via a `%=` {% tooltip label="centis"
-href="/language/hoon/reference/rune/cen#-centis" /%}), whereas a trap
-does not (and can _only_ be passively changed via something like `%=`
-centis).
+A _gate_ and a _trap_ are actually very similar:  a gate simply has a
+[sample](/glossary/sample) (and can actively change when evaluated or
+via a `%=` [centis](/language/hoon/reference/rune/cen#-centis)), whereas
+a trap does not (and can _only_ be passively changed via something like
+`%=` centis).
 
 #### Example:  Hoon Workbook
 
-Other examples demonstrating {% tooltip label="++map"
-href="/language/hoon/reference/stdlib/2o#map" /%} are available in the
+Other examples demonstrating
+[++map](/language/hoon/reference/stdlib/2o#map) are available in the
 [Hoon Workbook](/language/hoon/examples), such as Solution #2 in the
 [Rhonda Numbers](/language/hoon/examples/rhonda) tutorial.

--- a/content/courses/hoon-school/L-struct.md
+++ b/content/courses/hoon-school/L-struct.md
@@ -6,23 +6,22 @@ objectives = ["Identify units, sets, maps, and compound structures like jars and
 +++
 
 _This module will introduce you to several useful data structures built
-on the {% tooltip label="door" href="/glossary/door" /%}, then discuss
-how the compiler handles types and the {% tooltip label="sample"
-href="/glossary/sample" /%}._
+on the [door](/glossary/door), then discuss how the compiler handles
+types and the [sample](/glossary/sample)._
 
 
 ##  Key Data Structures and Molds
 
-{% tooltip label="++maps" href="/language/hoon/reference/stdlib/2o#map" /%} are
-a versatile way to store and access data, but they are far from
-the only useful pattern.  `++map`s were documented in [the previous
+[++maps](/language/hoon/reference/stdlib/2o#map) are a versatile way to
+store and access data, but they are far from the only useful pattern.
+`++map`s were documented in [the previous
 module](/courses/hoon-school/K-doors).
 
 ### `tree`
 
-We use {% tooltip label="tree"
-href="/language/hoon/reference/stdlib/1c#tree" /%} to make a binary tree
-data structure in Hoon, e.g., `(tree @)` for a binary tree of atoms.
+We use [tree](/language/hoon/reference/stdlib/1c#tree) to make a binary
+tree data structure in Hoon, e.g., `(tree @)` for a binary tree of
+atoms.
 
 There are two kinds of `tree` in Hoon:
 
@@ -32,11 +31,10 @@ There are two kinds of `tree` in Hoon:
     2. The left child of the node.
     3. The right child of the node.
     
-    Each child is itself a tree.  The node value has the {% tooltip
-    label="face" href="/glossary/face" /%} `n`, the left child has the
-    face `l`, and the right child has the face `r`. The following
-    diagram provides an illustration of a `(tree @)` (without the
-    faces):
+    Each child is itself a tree.  The node value has the
+    [face](/glossary/face) `n`, the left child has the face `l`, and the
+    right child has the face `r`. The following diagram provides an
+    illustration of a `(tree @)` (without the faces):
 
 ```
           12
@@ -58,10 +56,9 @@ in the diagram above in the dojo, casting it accordingly:
 ```
 
 Notice that we don't have to insert the faces manually; by casting the
-{% tooltip label="noun" href="/glossary/noun" /%} above to a `(tree @)`
-Hoon inserts the faces for us.  Let's put this noun in the dojo {%
-tooltip label="subject" href="/glossary/subject" /%} with the face `b`
-and pull out the tree at the left child of the `12` node:
+[noun](/glossary/noun) above to a `(tree @)` Hoon inserts the faces for
+us.  Let's put this noun in the dojo [subject](/glossary/subject) with
+the face `b` and pull out the tree at the left child of the `12` node:
 
 ```hoon
 > =b `(tree @)`[12 [8 [4 ~ ~] ~] [14 ~ [16 ~ ~]]]
@@ -76,9 +73,8 @@ find-fork
 
 This didn't work because we haven't first proved to Hoon that `b` is a
 non-null tree.  A null tree has no `l` in it, after all.  Let's try
-again, using `?~` {% tooltip label="wutsig"
-href="/language/hoon/reference/rune/wut#-wutsig" /%} to prove that `b`
-isn't null.  We can also look at `r` and `n`:
+again, using `?~` [wutsig](/language/hoon/reference/rune/wut#-wutsig) to
+prove that `b` isn't null.  We can also look at `r` and `n`:
 
 ```hoon
 > ?~(b ~ l.b)
@@ -123,45 +119,43 @@ new atom with which to replace `nedl`.  Save this as
 
 ### `set`
 
-A {% tooltip label="set" href="/language/hoon/reference/stdlib/2o#set"
-/%} is rather like a {% tooltip label="list" href="/glossary/list" /%}
-except that each entry can only be represented once.  As with a {%
-tooltip label="map" href="/language/hoon/reference/stdlib/2o#map" /%}, a
-`set` is typically associated with a particular type, such as `(set
-@ud)` for a collection of decimal values.  (`set`s also don't have an
-order, so they're basically a bag of unique values.)
+A [set](/language/hoon/reference/stdlib/2o#set) is rather like a
+[list](/glossary/list) except that each entry can only be represented
+once.  As with a [map](/language/hoon/reference/stdlib/2o#map), a `set`
+is typically associated with a particular type, such as `(set @ud)` for
+a collection of decimal values.  (`set`s also don't have an order, so
+they're basically a bag of unique values.)
 
-`set` operations are provided by {% tooltip label="++in"
-href="/language/hoon/reference/stdlib/2h#in" /%}.  Most names are
-similar to `map`/{% tooltip label="++by"
-href="/language/hoon/reference/stdlib/2i#by" /%} operations when
+`set` operations are provided by
+[++in](/language/hoon/reference/stdlib/2h#in).  Most names are similar
+to `map`/[++by](/language/hoon/reference/stdlib/2i#by) operations when
 applicable.
 
-{% tooltip label="++silt" href="/language/hoon/reference/stdlib/2l#silt" /%} produces
-a `set` from a `list`:
+[++silt](/language/hoon/reference/stdlib/2l#silt) produces a `set` from
+a `list`:
 
 ```hoon {% copy=true %}
 =primes (silt ~[2 3 5 7 11 13])
 ```
 
-{% tooltip label="++put:in" href="/language/hoon/reference/stdlib/2h#putin" /%} adds
-a value to a `set` (and null-ops when the value is already present):
+[++put:in](/language/hoon/reference/stdlib/2h#putin) adds a value to a
+`set` (and null-ops when the value is already present):
 
 ```hoon {% copy=true %}
 =primes (~(put in primes) 17)
 =primes (~(put in primes) 13)
 ```
 
-{% tooltip label="++del:in" href="/language/hoon/reference/stdlib/2h#delin" /%} removes
-a value from a `set`:
+[++del:in](/language/hoon/reference/stdlib/2h#delin) removes a value
+from a `set`:
 
 ```hoon {% copy=true %}
 =primes (~(put in primes) 18)
 =primes (~(del in primes) 18)
 ```
 
-{% tooltip label="++has:in" href="/language/hoon/reference/stdlib/2h#hasin" /%} checks
-for existence:
+[++has:in](/language/hoon/reference/stdlib/2h#hasin) checks for
+existence:
 
 ```hoon
 > (~(has in primes) 15)
@@ -171,8 +165,8 @@ for existence:
 %.y
 ```
 
-{% tooltip label="++tap:in" href="/language/hoon/reference/stdlib/2h#tapin" /%} yields
-a `list` of the values:
+[++tap:in](/language/hoon/reference/stdlib/2h#tapin) yields a `list` of
+the values:
 
 ```hoon
 > ~(tap in primes)
@@ -182,8 +176,8 @@ a `list` of the values:
 ~[2 3 5 7 11 13 17]
 ```
 
-{% tooltip label="++run:in" href="/language/hoon/reference/stdlib/2h#runin" /%} applies
-a function across all values:
+[++run:in](/language/hoon/reference/stdlib/2h#runin) applies a function
+across all values:
 
 ```hoon
 > (~(run in primes) dec)
@@ -192,12 +186,12 @@ a function across all values:
 
 #### Example:  Cartesian Product
 
-Here's a program that takes two {% tooltip label="sets"
-href="/language/hoon/reference/stdlib/2o#set" /%} of atoms and returns
-the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product)
-of those sets.  A Cartesian product of two sets `a` and `b` is a set of
-all the cells whose head is a member of `a` and whose tail is a member
-of `b`.
+Here's a program that takes two
+[sets](/language/hoon/reference/stdlib/2o#set) of atoms and returns the
+[Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product) of
+those sets.  A Cartesian product of two sets `a` and `b` is a set of all
+the cells whose head is a member of `a` and whose tail is a member of
+`b`.
 
 ```hoon {% copy=true %}
 |=  [a=(set @) b=(set @)]
@@ -216,8 +210,8 @@ of `b`.
 ==
 ```
 
-Save this as `cartesian.hoon` in your urbit's {% tooltip label="pier"
-href="/glossary/pier" /%} and run in the dojo:
+Save this as `cartesian.hoon` in your urbit's [pier](/glossary/pier) and
+run in the dojo:
 
 ```hoon
 > =c `(set @)`(sy ~[1 2 3])
@@ -236,15 +230,15 @@ href="/glossary/pier" /%} and run in the dojo:
 
 ### `unit` Redux (and `vase`)
 
-We encountered the {% tooltip label="unit"
-href="/language/hoon/reference/stdlib/1c#unit" /%} briefly as a tool for
-distinguishing null results from actual zeroes:  using a `unit` allows
-you to specify something that may not be there.  For this reason,
-`unit`s are commonly used for operations that sometimes fail, such as
-search functions, database lookups, remote data requests, etc.
+We encountered the [unit](/language/hoon/reference/stdlib/1c#unit)
+briefly as a tool for distinguishing null results from actual zeroes:
+using a `unit` allows you to specify something that may not be there.
+For this reason, `unit`s are commonly used for operations that sometimes
+fail, such as search functions, database lookups, remote data requests,
+etc.
 
-You can build a `unit` using the tic special notation or {% tooltip
-label="++some" href="/language/hoon/reference/stdlib/2a#some" /%}:
+You can build a `unit` using the tic special notation or
+[++some](/language/hoon/reference/stdlib/2a#some):
 
 ```hoon
 > `%mars
@@ -254,15 +248,13 @@ label="++some" href="/language/hoon/reference/stdlib/2a#some" /%}:
 [~ u=%mars]
 ```
 
-While {% tooltip label="++got:by"
-href="/language/hoon/reference/stdlib/2i#gotby" /%} is one way to get a
-value back without wrapping it in a `unit`, it's better practice to use
-the [`unit` logic](/language/hoon/reference/stdlib/2a) gates to
+While [++got:by](/language/hoon/reference/stdlib/2i#gotby) is one way to
+get a value back without wrapping it in a `unit`, it's better practice
+to use the [`unit` logic](/language/hoon/reference/stdlib/2a) gates to
 manipulate gates to work correctly with `unit`s.
 
-For example, use {% tooltip label="++need"
-href="/language/hoon/reference/stdlib/2a#need" /%} to unwrap a `unit`,
-or crash if the `unit` is `~` null.
+For example, use [++need](/language/hoon/reference/stdlib/2a#need) to
+unwrap a `unit`, or crash if the `unit` is `~` null.
 
 ```hoon
 > =colors (malt `(list (pair @tas @ux))`~[[%red 0xed.0a3f] [%yellow 0xfb.e870] [%green 0x1.a638] [%blue 0x66ff]])
@@ -280,14 +272,12 @@ or crash if the `unit` is `~` null.
 dojo: hoon expression failed
 ```
 
-Rather than unwrap a {% tooltip label="unit"
-href="/language/hoon/reference/stdlib/1c#unit" /%}, one can modify gates
-to work with `unit`s directly even if they're not natively set up that
-way.  For instance, one cannot decrement a `unit` because {% tooltip
-label="++dec" href="/language/hoon/reference/stdlib/1a#dec" /%} doesn't
-accept a `unit`. {% tooltip label="++bind"
-href="/language/hoon/reference/stdlib/2a#bind" /%} can bind a non-`unit`
-function—another gate-building gate!.
+Rather than unwrap a [unit](/language/hoon/reference/stdlib/1c#unit),
+one can modify gates to work with `unit`s directly even if they're not
+natively set up that way.  For instance, one cannot decrement a `unit`
+because [++dec](/language/hoon/reference/stdlib/1a#dec) doesn't accept a
+`unit`. [++bind](/language/hoon/reference/stdlib/2a#bind) can bind a
+non-`unit` function—another gate-building gate!.
 
 ```hoon
 > (bind ((unit @ud) [~ 2]) dec)  
@@ -301,37 +291,32 @@ function—another gate-building gate!.
 page](/language/hoon/reference/stdlib/2a) which may be potentially
 useful to you.)
 
-A {% tooltip label="vase" href="/glossary/vase" /%} is a pair of type
-and value, such as that returned by `!>` {% tooltip label="zapgar"
-href="/language/hoon/reference/rune/zap#-zapgar" /%}.  A `vase` is
-useful when transmitting data in a way that may lose its type
+A [vase](/glossary/vase) is a pair of type and value, such as that
+returned by `!>` [zapgar](/language/hoon/reference/rune/zap#-zapgar).  A
+`vase` is useful when transmitting data in a way that may lose its type
 information.
 
 ### Containers of Containers
 
-{% tooltip label="maps" href="/language/hoon/reference/stdlib/2o#map" /%} and
-{% tooltip label="sets" href="/language/hoon/reference/stdlib/2o#set" /%} are
-frequently used in the standard library and in the extended ecosystem.
-There are other common patterns which recur often enough that
-they have their own names:
+[maps](/language/hoon/reference/stdlib/2o#map) and
+[sets](/language/hoon/reference/stdlib/2o#set) are frequently used in
+the standard library and in the extended ecosystem. There are other
+common patterns which recur often enough that they have their own names:
 
-- {% tooltip label="++jar" href="/language/hoon/reference/stdlib/2o#jar" /%} is
-  a mold for a `map` of `list`s.  `++jar` uses the {% tooltip
-  label="++ja" href="/language/hoon/reference/stdlib/2j#ja" /%} core.
-  (Mnemonic: jars hold solid ordered things, like a {% tooltip
-  label="list" href="/glossary/list" /%}.)
+- [++jar](/language/hoon/reference/stdlib/2o#jar) is a mold for a `map`
+  of `list`s.  `++jar` uses the
+  [++ja](/language/hoon/reference/stdlib/2j#ja) core. (Mnemonic: jars
+  hold solid ordered things, like a [list](/glossary/list).)
 
-- {% tooltip label="++jug" href="/language/hoon/reference/stdlib/2o#jug" /%} is
-  a {% tooltip label="mold" href="/glossary/mold" /%} for a `map`
-  of `set`s.  `++jug` uses the {% tooltip label="++ju"
-  href="/language/hoon/reference/stdlib/2j#ju" /%} core.  (Mnemonic:
-  jugs hold liquids, evoking the unordered nature of a {% tooltip
-  label="set" href="/language/hoon/reference/stdlib/2o#set" /%}.)
+- [++jug](/language/hoon/reference/stdlib/2o#jug) is a
+  [mold](/glossary/mold) for a `map` of `set`s.  `++jug` uses the
+  [++ju](/language/hoon/reference/stdlib/2j#ju) core.  (Mnemonic: jugs
+  hold liquids, evoking the unordered nature of a
+  [set](/language/hoon/reference/stdlib/2o#set).)
 
-- {% tooltip label="++mip" href="/language/hoon/reference/mip#mip" /%} is
-  a mold for a map of maps.  `++mip` lives in the `%landscape` desk in
-  `/lib/mip.hoon`.  Affordances are still few but a short example
-  follows:
+- [++mip](/language/hoon/reference/mip#mip) is a mold for a map of maps.
+  `++mip` lives in the `%landscape` desk in `/lib/mip.hoon`.
+  Affordances are still few but a short example follows:
 
     ```hoon
     > =mip -build-file /=landscape=/lib/mip/hoon
@@ -359,30 +344,24 @@ they have their own names:
     > (~(got bi:mip my-mip) %cool %green)
     0x1.a638
 
-    > ~(tap bi:mip my-mip)
-    ~[
-      [x=%warm y=%yellow v=0xfb.e870]
-      [x=%warm y=%red v=0xed.0a3f]
-      [x=%cool y=%green v=0x1.a638]
-      [x=%cool y=%blue v=0x66ff]
-    ]
-    ```
+    > ~(tap bi:mip my-mip) ~[ [x=%warm y=%yellow v=0xfb.e870] [x=%warm
+    y=%red v=0xed.0a3f] [x=%cool y=%green v=0x1.a638] [x=%cool y=%blue
+    v=0x66ff] ] ```
 
     `mip`s are unjetted and quite slow but serve as a proof of concept.
 
-- {% tooltip label="++mop" href="/language/hoon/reference/zuse/2m#mop" /%} ordered
-  maps are discussed in [the App School guides](/courses/app-school).
+- [++mop](/language/hoon/reference/zuse/2m#mop) ordered maps are
+  discussed in [the App School guides](/courses/app-school).
 
 
 ##  Molds and Samples
 
 ### Modifying Gate Behavior
 
-Sometimes you need to modify parts of a {% tooltip label="core"
-href="/glossary/core" /%} (like a {% tooltip label="gate"
-href="/glossary/gate" /%}) on-the-fly to get the desired behavior.  For
-instance, if you are using {% tooltip label="++roll"
-href="/language/hoon/reference/stdlib/2b#roll" /%} to calculate the
+Sometimes you need to modify parts of a [core](/glossary/core) (like a
+[gate](/glossary/gate)) on-the-fly to get the desired behavior.  For
+instance, if you are using
+[++roll](/language/hoon/reference/stdlib/2b#roll) to calculate the
 multiplicative product of the elements of a list, this “just works”:
 
 ```hoon
@@ -400,28 +379,24 @@ fail:
 ```
 
 Why is this?  Let's peek inside the gates and see.  Since we know a core
-is a cell of `[battery payload]`, let's take a look at the {% tooltip
-label="payload" href="/glossary/payload" /%}:
+is a cell of `[battery payload]`, let's take a look at the
+[payload](/glossary/payload):
 
-```hoon
-> +:mul
-[[a=1 b=1] <33.uof 1.pnw %138>]
+```hoon > +:mul [[a=1 b=1] <33.uof 1.pnw %138>]
 
-> +:mul:rs
-[[a=.0 b=.0] <21.ezj [r=?(%d %n %u %z) <51.njr 139.oyl 33.uof 1.pnw %138>]>]
-```
+> +:mul:rs [[a=.0 b=.0] <21.ezj [r=?(%d %n %u %z) <51.njr 139.oyl 33.uof
+1.pnw %138>]>] ```
 
-The correct behavior for {% tooltip label="++mul:rs"
-href="/language/hoon/reference/stdlib/3b#mulrs" /%} is really to
-multiply starting from one, not zero, so that {% tooltip label="++roll"
-href="/language/hoon/reference/stdlib/2b#roll" /%} doesn't wipe out
-the entire product.
+The correct behavior for
+[++mul:rs](/language/hoon/reference/stdlib/3b#mulrs) is really to
+multiply starting from one, not zero, so that
+[++roll](/language/hoon/reference/stdlib/2b#roll) doesn't wipe out the
+entire product.
 
 ### Custom Samples
 
-In an earlier exercise we created a {% tooltip label="door"
-href="/glossary/door" /%} with {% tooltip label="sample"
-href="/glossary/sample" /%} `[a=@ud b=@ud c=@ud]`.  If we investigated,
+In an earlier exercise we created a [door](/glossary/door) with
+[sample](/glossary/sample) `[a=@ud b=@ud c=@ud]`.  If we investigated,
 we would find that the initial value of each is `0`, the bunt value of
 `@ud`.
 
@@ -431,11 +406,10 @@ we would find that the initial value of each is `0`, the bunt value of
 ```
 
 What if we wish to define a door with a chosen sample value directly? We
-can make use of the `$_` {% tooltip label="buccab"
-href="/language/hoon/reference/rune/buc#_-buccab" /%} rune, whose
+can make use of the `$_`
+[buccab](/language/hoon/reference/rune/buc#_-buccab) rune, whose
 irregular form is simply `_`. To create the door `poly` with the sample
-set to have certain values in the {% tooltip label="Dojo"
-href="/glossary/dojo" /%}, we would write
+set to have certain values in the [Dojo](/glossary/dojo), we would write
 
 ```hoon
 > =poly |_  [a=_5 b=_4 c=_3]
@@ -448,11 +422,10 @@ href="/glossary/dojo" /%}, we would write
 31
 ```
 
-For our earlier example with {% tooltip label="++roll"
-href="/language/hoon/reference/stdlib/2b#roll" /%}, if we wanted to set
-the default sample to have a different value than the {% tooltip
-label="bunt" href="/glossary/bunt" /%} of the type, we could use `_`
-cab:
+For our earlier example with
+[++roll](/language/hoon/reference/stdlib/2b#roll), if we wanted to set
+the default sample to have a different value than the
+[bunt](/glossary/bunt) of the type, we could use `_` cab:
 
 ```hoon
 > =mmul |=([a=_.1 b=_.1] (mul:rs a b))
@@ -463,32 +436,30 @@ cab:
 
 ### Named Tuples
 
-A named tuple is a structured collection of values with {% tooltip
-label="faces" href="/glossary/face" /%}.  The `$:` {% tooltip
-label="buccol" href="/language/hoon/reference/rune/buc#-buccol" /%} rune
-forms a named tuple.  We use these implicitly in an irregular form when
-we specify the sample of a gate, as `|=([a=@ b=@] (add a b))` expands to
-a `$:` {% tooltip label="buccol"
-href="/language/hoon/reference/rune/buc#-buccol" /%} expression for
-`[a=@ b=@]`.  Otherwise, we only need these if we are building a special
-type like a vector (e.g. with two components like an _x_ and a _y_).
+A named tuple is a structured collection of values with
+[faces](/glossary/face).  The `$:`
+[buccol](/language/hoon/reference/rune/buc#-buccol) rune forms a named
+tuple.  We use these implicitly in an irregular form when we specify the
+sample of a gate, as `|=([a=@ b=@] (add a b))` expands to a `$:`
+[buccol](/language/hoon/reference/rune/buc#-buccol) expression for `[a=@
+b=@]`.  Otherwise, we only need these if we are building a special type
+like a vector (e.g. with two components like an _x_ and a _y_).
 
 ### Structure Mode
 
 Most Hoon expressions evaluate normally (that's what “normal” means),
 what we'll call _noun mode_ (or _normal mode_).  However, sample
-definitions and `+$` {% tooltip label="lusbuc"
-href="/language/hoon/reference/rune/lus#-lusbuc" /%} mold specification
-arms evaluate in what is called _structure mode_.  (You may occasionally
-see this the older term “spec mode”.)  Structure mode expressions use a
-similar syntax to regular Hoon expressions but create structure
-definitions instead.
+definitions and `+$` [lusbuc](/language/hoon/reference/rune/lus#-lusbuc)
+mold specification arms evaluate in what is called _structure mode_.
+(You may occasionally see this the older term “spec mode”.)  Structure
+mode expressions use a similar syntax to regular Hoon expressions but
+create structure definitions instead.
 
 For instance, in eval mode if you use the irregular form `p=1` this is
-an irregular form of the `^=` {% tooltip label="kettis"
-href="/language/hoon/reference/rune/ket#-kettis" /%} rune.  This is one
-way to define a variable using a `=+` {% tooltip label="tislus"
-href="/language/hoon/reference/rune/tis#-tislus" /%}; these are
+an irregular form of the `^=`
+[kettis](/language/hoon/reference/rune/ket#-kettis) rune.  This is one
+way to define a variable using a `=+`
+[tislus](/language/hoon/reference/rune/tis#-tislus); these are
 equivalent statements:
 
 ```hoon
@@ -499,12 +470,12 @@ equivalent statements:
 1
 ```
 
-(Normally we have preferred `=/` {% tooltip label="tisfas"
-href="/language/hoon/reference/rune/tis#-tisfas" /%} in the Hoon School
+(Normally we have preferred `=/`
+[tisfas](/language/hoon/reference/rune/tis#-tisfas) in the Hoon School
 docs, but that is just for consistency.)
 
-In a {% tooltip label="sample" href="/glossary/sample" /%} definition,
-such as in a {% tooltip label="gate" href="/glossary/gate" /%}, the
+In a [sample](/glossary/sample) definition,
+such as in a [gate](/glossary/gate), the
 statement is evaluated in structure mode; these are equivalent
 statements:
 

--- a/content/courses/hoon-school/M-typecheck.md
+++ b/content/courses/hoon-school/M-typecheck.md
@@ -16,13 +16,12 @@ mean with a given data structure.  As you get in the habit of casting
 your data structures, it will not only help anyone reading your code,
 but it will help you in hunting down bugs in your code.
 
-{% tooltip label="++list" href="/language/hoon/reference/stdlib/1c#list" /%} is
-a mold builder that is used to produce a {% tooltip label="mold"
-href="/glossary/mold" /%}, i.e. a list of a particular type (like `(list
-@)` for a list of atoms).  A list can be thought of as an ordered
-arrangement of zero or more elements terminated by a `~` (null).  There
-is a difference to Hoon, however, between something explicitly tagged as
-a `list` of some kind and a null-terminated tuple.
+[++list](/language/hoon/reference/stdlib/1c#list) is a mold builder that
+is used to produce a [mold](/glossary/mold), i.e. a list of a particular
+type (like `(list @)` for a list of atoms).  A list can be thought of as
+an ordered arrangement of zero or more elements terminated by a `~`
+(null).  There is a difference to Hoon, however, between something
+explicitly tagged as a `list` of some kind and a null-terminated tuple.
 
 ```hoon
 > -:!>(~[1 2 3])
@@ -37,8 +36,7 @@ presents.  By marking the type explicitly as a `(list @)` for the
 compiler, we achieve some stronger guarantees that many of the `list`
 operators require.
 
-However, we still don't get the {% tooltip label="faces"
-href="/glossary/face" /%} for free:
+However, we still don't get the [faces](/glossary/face) for free:
 
 ```hoon
 > =a `(list @)`~[1 2 3]
@@ -49,12 +47,11 @@ find-fork
 dojo: hoon expression failed
 ```
 
-What's going on?  Formally, a {% tooltip label="list"
-href="/glossary/list" /%} can be either null or non-null.  When the list
-contains only `~` and no items, it's the null list.  Most lists are,
-however, non-null lists, which have items preceding the `~`. Non-null
-lists, called _lests_, are {% tooltip label="cells"
-href="/glossary/cell" /%} in which the head is the first list item, and
+What's going on?  Formally, a [list](/glossary/list) can be either null
+or non-null.  When the list contains only `~` and no items, it's the
+null list.  Most lists are, however, non-null lists, which have items
+preceding the `~`. Non-null lists, called _lests_, are
+[cells](/glossary/cell) in which the head is the first list item, and
 the tail is the rest of the list.  The tail is itself a list, and if
 such a list is also non-null, the head of this sublist is the second
 item in the greater list, and so on.  To illustrate, let's look at a
@@ -66,13 +63,12 @@ list `[1 2 3 4 ~]` with the cell-delineating brackets left in:
 
 It's easy to see where the heads are and where the nesting tails are.
 The head of the above list is the atom `1` and the tail is the list `[2
-[3 [4 ~]]]`, (or `[2 3 4 ~]`).  Recall that whenever {% tooltip
-label="cell" href="/glossary/cell" /%} brackets are omitted so that
-visually there appears to be more than two child {% tooltip
-label="nouns" href="/glossary/noun" /%}, it is implicitly understood
-that the right-most nouns constitute a cell.
+[3 [4 ~]]]`, (or `[2 3 4 ~]`).  Recall that whenever
+[cell](/glossary/cell) brackets are omitted so that visually there
+appears to be more than two child [nouns](/glossary/noun), it is
+implicitly understood that the right-most nouns constitute a cell.
 
-You can construct {% tooltip label="lists" href="/glossary/list" /%} of
+You can construct [lists](/glossary/list) of
 any type. `(list @)` indicates a list of atoms, `(list ^)` indicates a
 list of cells, `(list [@ ?])` indicates a list of cells whose head is an
 atom and whose tail is a flag, etc.
@@ -118,7 +114,7 @@ suddenly we can use the faces:
 ```
 
 It's important to note that performing tests like this will actually
-transform a {% tooltip label="list" href="/glossary/list" /%} into a
+transform a [list](/glossary/list) into a
 `lest`, a non-null list.  Because `lest` is a different type than
 `list`, performing such tests can come back to bite you later in
 non-obvious ways when you try to use some standard library functions
@@ -130,25 +126,24 @@ meant for lists.
 As the Hoon compiler compiles your Hoon code, it does a type check on
 certain expressions to make sure they are guaranteed to produce a value
 of the correct type.  If it cannot be proved that the output value is
-correctly typed, the compile will fail with a {% tooltip
-label="nest-fail" href="/language/hoon/reference/hoon-errors#nest-fail"
-/%} crash.  In order to figure out what type of value is produced by a
-given expression, the compiler uses type inference on that code.
+correctly typed, the compile will fail with a
+[nest-fail](/language/hoon/reference/hoon-errors#nest-fail) crash.  In
+order to figure out what type of value is produced by a given
+expression, the compiler uses type inference on that code.
 
 Let's enumerate the most common cases where a type check is called for
 in Hoon.
 
-The most obvious case is when there is a casting `^` {% tooltip
-label="ket" href="/language/hoon/reference/rune/ket" /%} rune in your
-code.  These runes don't directly have any effect on the compiled result
-of your code; they simply indicate that a type check should be performed
-on a piece of code at compile-time.
+The most obvious case is when there is a casting `^`
+[ket](/language/hoon/reference/rune/ket) rune in your code.  These runes
+don't directly have any effect on the compiled result of your code; they
+simply indicate that a type check should be performed on a piece of code
+at compile-time.
 
 #### `^-` kethep Cast with a Type
 
 You've already seen one rune that calls for a type check:
-`^-` {% tooltip label="kethep"
-href="/language/hoon/reference/rune/ket#--kethep" /%}:
+`^-` [kethep](/language/hoon/reference/rune/ket#--kethep):
 
 ```hoon
 > ^-(@ 12)
@@ -178,11 +173,10 @@ nest-fail
 
 #### `^+` ketlus Cast with an Example Value
 
-The rune `^+` {% tooltip label="ketlus"
-href="/language/hoon/reference/rune/ket#-ketlus" /%} is like `^-` {%
-tooltip label="kethep" href="/language/hoon/reference/rune/ket#--kethep"
-/%}, except that instead of using a type name for the cast, it uses an
-example value of the type in question.  E.g.:
+The rune `^+` [ketlus](/language/hoon/reference/rune/ket#-ketlus) is
+like `^-` [kethep](/language/hoon/reference/rune/ket#--kethep), except
+that instead of using a type name for the cast, it uses an example value
+of the type in question.  E.g.:
 
 ```hoon
 > ^+(7 12)
@@ -195,8 +189,7 @@ example value of the type in question.  E.g.:
 nest-fail
 ```
 
-The `^+` {% tooltip label="ketlus"
-href="/language/hoon/reference/rune/ket#-ketlus" /%} rune takes two
+The `^+` [ketlus](/language/hoon/reference/rune/ket#-ketlus) rune takes two
 subexpressions.  The first subexpression is evaluated and its type is
 inferred.  The second subexpression is evaluated and its inferred type
 is compared against the type of the first.  If the type of the second
@@ -224,29 +217,24 @@ nest-fail
 
 ### Arm Checks
 
-Whenever an {% tooltip label="arm" href="/glossary/arm" /%} is evaluated
-in Hoon it expects to have some version of its parent {% tooltip
-label="core" href="/glossary/core" /%} as the {% tooltip label="subject"
-href="/glossary/subject" /%}.  Specifically, a type check is performed
+Whenever an [arm](/glossary/arm) is evaluated in Hoon it expects to have
+some version of its parent [core](/glossary/core) as the
+[subject](/glossary/subject).  Specifically, a type check is performed
 to see whether the arm subject is of the appropriate type.  We see this
-in action whenever a {% tooltip label="gate" href="/glossary/gate" /%}
-or a multi-arm {% tooltip label="door" href="/glossary/door" /%} is
-called.
+in action whenever a [gate](/glossary/gate) or a multi-arm
+[door](/glossary/door) is called.
 
-A gate is a one-armed core with a {% tooltip label="sample"
-href="/glossary/sample" /%}.  When it is called, its `$` buc arm is
-evaluated with (a mutated copy of) the gate as the {% tooltip
-label="subject" href="/glossary/subject" /%}. The only part of the core
-that might change is the {% tooltip label="payload"
-href="/glossary/payload" /%}, including the sample. Of course, we want
-the sample to be able to change.  The sample is where the argument(s) of
-the function call are placed.  For example, when we call {% tooltip
-label="add" href="/language/hoon/reference/stdlib/1a#add" /%} the `$`
-buc arm expects two {% tooltip label="atoms" href="/glossary/atom" /%}
-for the sample, i.e., the two numbers to be added.  When the type check
-occurs, the payload must be of the appropriate type.  If it isn't, the
-result is a {% tooltip label="nest-fail"
-href="/language/hoon/reference/hoon-errors#nest-fail" /%} crash.
+A gate is a one-armed core with a [sample](/glossary/sample).  When it
+is called, its `$` buc arm is evaluated with (a mutated copy of) the
+gate as the [subject](/glossary/subject). The only part of the core that
+might change is the [payload](/glossary/payload), including the sample.
+Of course, we want the sample to be able to change.  The sample is where
+the argument(s) of the function call are placed.  For example, when we
+call [add](/language/hoon/reference/stdlib/1a#add) the `$` buc arm
+expects two [atoms](/glossary/atom) for the sample, i.e., the two
+numbers to be added.  When the type check occurs, the payload must be of
+the appropriate type.  If it isn't, the result is a
+[nest-fail](/language/hoon/reference/hoon-errors#nest-fail) crash.
 
 ```hoon
 > (add 22 33)
@@ -270,10 +258,9 @@ can occur at arm evaluation [when we discuss type
 polymorphism](/courses/hoon-school/R-metals).
 
 This isn't a comprehensive list of the type checks in Hoon:  for
-instance, some other runes that include a type check are `=.` {% tooltip
-label="tisdot" href="/language/hoon/reference/rune/tis#-tisdot" /%} and
-`%_` {% tooltip label="cencab"
-href="/language/hoon/reference/rune/cen#_-cencab" /%}.
+instance, some other runes that include a type check are `=.`
+[tisdot](/language/hoon/reference/rune/tis#-tisdot) and `%_`
+[cencab](/language/hoon/reference/rune/cen#_-cencab).
 
 
 ##  Type Inference
@@ -286,13 +273,11 @@ definitions, conditional expressions, and more.
 ### Literals
 
 [Literals](https://en.wikipedia.org/wiki/Literal_%28computer_programming%29)
-are expressions that represent fixed values.  {% tooltip label="Atom"
-href="/glossary/atom" /%} and {% tooltip label="cell"
-href="/glossary/cell" /%} literals are supported in Hoon, and every
-supported {% tooltip label="aura" href="/glossary/aura" /%} has an
-unambiguous representation that allows the parser to directly infer the
-type from the form.  Here are a few examples of auras and associated
-literal formats:
+are expressions that represent fixed values.  [Atom](/glossary/atom) and
+[cell](/glossary/cell) literals are supported in Hoon, and every
+supported [aura](/glossary/aura) has an unambiguous representation that
+allows the parser to directly infer the type from the form.  Here are a
+few examples of auras and associated literal formats:
 
 | Type | Literal |
 | ---- | ------- |
@@ -304,12 +289,11 @@ literal formats:
 
 ### Casts
 
-Casting with `^` {% tooltip label="ket"
-href="/language/hoon/reference/rune/ket" /%} runes also shape how Hoon
-understands an expression type, as outlined above.  The inferred type of
-a cast expression is just the type being cast for.  It can be inferred
-that, if the cast didn't result in a {% tooltip label="nest-fail"
-href="/language/hoon/reference/hoon-errors#nest-fail" /%}, the value
+Casting with `^` [ket](/language/hoon/reference/rune/ket) runes also
+shape how Hoon understands an expression type, as outlined above.  The
+inferred type of a cast expression is just the type being cast for.  It
+can be inferred that, if the cast didn't result in a
+[nest-fail](/language/hoon/reference/hoon-errors#nest-fail), the value
 produced must be of the cast type. Here are some examples of cast
 expressions with the inferred output type on the right:
 
@@ -326,43 +310,38 @@ expressions with the inferred output type on the right:
 | `[@ux @ub]` | `^+([0x1b 0b11] [0x123 0b101])` |
 
 You can also use the irregular `` ` `` syntax for casting in the same
-way as `^-` {% tooltip label="kethep"
-href="/language/hoon/reference/rune/ket#--kethep" /%}; e.g., `` `@`123
-`` for `^-(@ 123)`.
+way as `^-` [kethep](/language/hoon/reference/rune/ket#--kethep); e.g.,
+`` `@`123 `` for `^-(@ 123)`.
 
 Since casts can throw away type information, if the cast type is more
 general, then the more specific type information is lost.  Consider the
 literal `[12 14]`.  The inferred type of this expression is `[@ @]`,
-i.e., a {% tooltip label="cell" href="/glossary/cell" /%} of two {%
-tooltip label="atoms" href="/glossary/atom" /%}.  If we cast over `[12
-14]` with `^-(^ [12 14])` then the inferred type is just `^`, the set of
-all cells.  The information about what kind of cell it is has been
-thrown away.  If we cast over `[12 14]` with `^-(* [12 14])` then the
-inferred type is `*`, the set of all {% tooltip label="nouns"
-href="/glossary/noun" /%}.  All interesting type information is thrown
-away on the latter cast.
+i.e., a [cell](/glossary/cell) of two [atoms](/glossary/atom).  If we
+cast over `[12 14]` with `^-(^ [12 14])` then the inferred type is just
+`^`, the set of all cells.  The information about what kind of cell it
+is has been thrown away.  If we cast over `[12 14]` with `^-(* [12 14])`
+then the inferred type is `*`, the set of all [nouns](/glossary/noun).
+All interesting type information is thrown away on the latter cast.
 
-It's important to remember to include a cast {% tooltip label="rune"
-href="/glossary/rune" /%} with each {% tooltip label="gate"
-href="/glossary/gate" /%} and {% tooltip label="trap"
-href="/glossary/trap" /%} expression.  That way it's clear what the
-inferred product type will be for calls to that core.
+It's important to remember to include a cast [rune](/glossary/rune) with
+each [gate](/glossary/gate) and [trap](/glossary/trap) expression.  That
+way it's clear what the inferred product type will be for calls to that
+core.
 
 ### (Dry) Gate Sample Definitions
 
-By now you've used the `|=` {% tooltip label="bartis"
-href="/language/hoon/reference/rune/bar#-bartis" /%} rune to define
-several {% tooltip label="gates" href="/glossary/gate" /%}.  This rune
-is used to produce a _dry gate_, which has different type-checking and
-type-inference properties than a _wet gate_ does.  We won't explain the
-distinction until [a later module](/courses/hoon-school/R-metals)—for
-now, just keep in mind that we're only dealing with one kind of gate
-(albeit the more common kind).
+By now you've used the `|=`
+[bartis](/language/hoon/reference/rune/bar#-bartis) rune to define
+several [gates](/glossary/gate).  This rune is used to produce a _dry
+gate_, which has different type-checking and type-inference properties
+than a _wet gate_ does.  We won't explain the distinction until [a later
+module](/courses/hoon-school/R-metals)—for now, just keep in mind that
+we're only dealing with one kind of gate (albeit the more common kind).
 
-The first subexpression after the `|=` defines the {% tooltip
-label="sample" href="/glossary/sample" /%} type.  Any faces used in this
-definition have the type declared for it in this definition.  Consider
-an addition generator `/gen/sum.hoon`:
+The first subexpression after the `|=` defines the
+[sample](/glossary/sample) type.  Any faces used in this definition have
+the type declared for it in this definition.  Consider an addition
+generator `/gen/sum.hoon`:
 
 ```hoon {% copy=true %}
 |=  [a=@ b=@]
@@ -372,7 +351,7 @@ an addition generator `/gen/sum.hoon`:
 $(a +(a), b (dec b))
 ```
 
-We run it in the {% tooltip label="Dojo" href="/glossary/dojo" /%} using
+We run it in the [Dojo](/glossary/dojo) using
 a cell to pass the two arguments:
 
 ```hoon
@@ -385,46 +364,39 @@ nest-fail
 -have.@ud
 ```
 
-If you try to call this gate with the wrong kind of argument, you get
-a {% tooltip label="nest-fail"
-href="/language/hoon/reference/hoon-errors#nest-fail" /%}.  If the call
-succeeds, then the argument takes on the type of the {% tooltip
-label="sample" href="/glossary/sample" /%} definition: `[a=@ b=@]`.
-Accordingly, the inferred type of `a` is `@`, and the inferred type of
-`b` is `@`.  In this case some type information has been thrown away;
-the inferred type of `[12 14]` is `[@ud @ud]`, but the addition program
-takes all atoms, regardless of {% tooltip label="aura"
-href="/glossary/aura" /%}.
+If you try to call this gate with the wrong kind of argument, you get a
+[nest-fail](/language/hoon/reference/hoon-errors#nest-fail).  If the
+call succeeds, then the argument takes on the type of the
+[sample](/glossary/sample) definition: `[a=@ b=@]`. Accordingly, the
+inferred type of `a` is `@`, and the inferred type of `b` is `@`.  In
+this case some type information has been thrown away; the inferred type
+of `[12 14]` is `[@ud @ud]`, but the addition program takes all atoms,
+regardless of [aura](/glossary/aura).
 
 ### Inferring Type (`?` wut Runes)
 
 #### Using Conditionals for Inference by Branch
 
-You have learned about a few conditional runes (e.g., `?:` {% tooltip
-label="wutcol" href="/language/hoon/reference/rune/wut#-wutcol" /%} and
-`?.` {% tooltip label="wutdot"
-href="/language/hoon/reference/rune/wut#-wutdot" /%}), but other runes
-of the `?` family are used for branch-specialized type inference.  The
-`?@` {% tooltip label="wutpat"
-href="/language/hoon/reference/rune/wut#-wutpat" /%}, `?^` {% tooltip
-label="wutket" href="/language/hoon/reference/rune/wut#-wutket" /%}, and
-`?~` {% tooltip label="wutsig"
-href="/language/hoon/reference/rune/wut#-wutsig" /%} conditionals each
+You have learned about a few conditional runes (e.g., `?:`
+[wutcol](/language/hoon/reference/rune/wut#-wutcol) and `?.`
+[wutdot](/language/hoon/reference/rune/wut#-wutdot)), but other runes of
+the `?` family are used for branch-specialized type inference.  The `?@`
+[wutpat](/language/hoon/reference/rune/wut#-wutpat), `?^`
+[wutket](/language/hoon/reference/rune/wut#-wutket), and `?~`
+[wutsig](/language/hoon/reference/rune/wut#-wutsig) conditionals each
 take three subexpressions, which play the same basic role as the
 corresponding subexpressions of `?:` wutcol—the first is the test
 condition, which evaluates to a flag `?`.  If the test condition is
 true, the second subexpression is evaluated; otherwise the third.  These
 second and third subexpressions are the ‘branches’ of the conditional.
 
-There is also a `?=` {% tooltip label="wuttis"
-href="/language/hoon/reference/rune/wut#-wuttis" /%} rune for
+There is also a `?=` [wuttis](/language/hoon/reference/rune/wut#-wuttis) rune for
 pattern-matching expressions by type, returning `%.y` for a match and
 `%.n` otherwise.
 
 ##### `?=` wuttis Non-recursive Type Match Test
 
-The `?=` {% tooltip label="wuttis"
-href="/language/hoon/reference/rune/wut#-wuttis" /%} rune takes two
+The `?=` [wuttis](/language/hoon/reference/rune/wut#-wuttis) rune takes two
 subexpressions.  The first subexpression should be a type.  The second
 subexpression is evaluated and the resulting value is compared to the
 first type.  If the value is an instance of the type, `%.y` is produced.
@@ -450,9 +422,8 @@ Otherwise, `%.n`.  Examples:
 %.n
 ```
 
-`?=` {% tooltip label="wuttis"
-href="/language/hoon/reference/rune/wut#-wuttis" /%} expressions ignore
-{% tooltip label="aura" href="/glossary/aura" /%} information:
+`?=` [wuttis](/language/hoon/reference/rune/wut#-wuttis) expressions
+ignore [aura](/glossary/aura) information:
 
 ```hoon
 > ?=(@ud 0x12)
@@ -472,19 +443,17 @@ every list type qualifies as such, and hence should not be used with
 fish-loop
 ```
 
-Using these non-basic constructed types with the `?=` {% tooltip
-label="wuttis" href="/language/hoon/reference/rune/wut#-wuttis" /%} rune
-results in a `fish-loop` error.
+Using these non-basic constructed types with the `?=`
+[wuttis](/language/hoon/reference/rune/wut#-wuttis) rune results in a
+`fish-loop` error.
 
-The `?=` {% tooltip label="wuttis"
-href="/language/hoon/reference/rune/wut#-wuttis" /%} rune is
-particularly useful when used with the `?:` {% tooltip label="wutcol"
-href="/language/hoon/reference/rune/wut#-wutcol" /%} rune, because in
+The `?=` [wuttis](/language/hoon/reference/rune/wut#-wuttis) rune is
+particularly useful when used with the `?:`
+[wutcol](/language/hoon/reference/rune/wut#-wutcol) rune, because in
 these cases Hoon uses the result of the `?=` wuttis evaluation to infer
-type information.  To see how this works lets use `=/` {% tooltip
-label="tisfas" href="/language/hoon/reference/rune/tis#-tisfas" /%} to
-define a {% tooltip label="face" href="/glossary/face" /%}, `b`, as a
-generic noun:
+type information.  To see how this works lets use `=/`
+[tisfas](/language/hoon/reference/rune/tis#-tisfas) to define a
+[face](/glossary/face), `b`, as a generic noun:
 
 ```hoon
 > =/(b=* 12 b)
@@ -504,10 +473,10 @@ the product type:
 (Remember that `?` isn't part of Hoon -- it's a Dojo-specific
 instruction.)
 
-Let's replace that last `b` with a `?:` {% tooltip label="wutcol"
-href="/language/hoon/reference/rune/wut#-wutcol" /%} expression whose
-condition subexpression is a `?=` {% tooltip label="wuttis"
-href="/language/hoon/reference/rune/wut#-wuttis" /%} test.  If `b` is an
+Let's replace that last `b` with a `?:`
+[wutcol](/language/hoon/reference/rune/wut#-wutcol) expression whose
+condition subexpression is a `?=`
+[wuttis](/language/hoon/reference/rune/wut#-wuttis) test.  If `b` is an
 `@`, it'll produce `[& b]`; otherwise `[| b]`:
 
 ```hoon
@@ -517,9 +486,9 @@ href="/language/hoon/reference/rune/wut#-wuttis" /%} test.  If `b` is an
 
 You can't see it here, but the inferred type of `b` in `[& b]` is `@`.
 That subexpression is only evaluated if `?=(@ b)` evaluates as true;
-hence, Hoon can safely infer that `b` must be an {% tooltip label="atom"
-href="/glossary/atom" /%} in that subexpression.  Let's set `b` to a
-different initial value but leave everything else the same:
+hence, Hoon can safely infer that `b` must be an [atom](/glossary/atom)
+in that subexpression.  Let's set `b` to a different initial value but
+leave everything else the same:
 
 ```hoon
 > =/(b=* [12 14] ?:(?=(@ b) [& b] [| b]))
@@ -528,20 +497,18 @@ different initial value but leave everything else the same:
 
 You can't see it here either, but the inferred type of `b` in `[| b]` is
 `^`.  That subexpression is only evaluated if `?=(@ b)` evaluates as
-false, so `b` can't be an atom there.  It follows that it must be
-a {% tooltip label="cell" href="/glossary/cell" /%}.
+false, so `b` can't be an atom there.  It follows that it must be a
+[cell](/glossary/cell).
 
 ##### The Type Spear
 
 What if you want to see the inferred type of `b` for yourself for each
 conditional branch?  One way to do this is with the _type spear_.  The
-`!>` {% tooltip label="zapgar"
-href="/language/hoon/reference/rune/zap#-zapgar" /%} rune takes one
-subexpression and constructs a {% tooltip label="cell"
-href="/glossary/cell" /%} from it.  The subexpression is evaluated and
-becomes the tail of the product cell, with a `q` {% tooltip label="face"
-href="/glossary/face" /%} attached.  The head of the product cell is the
-inferred type of the subexpression.
+`!>` [zapgar](/language/hoon/reference/rune/zap#-zapgar) rune takes one
+subexpression and constructs a [cell](/glossary/cell) from it.  The
+subexpression is evaluated and becomes the tail of the product cell,
+with a `q` [face](/glossary/face) attached.  The head of the product
+cell is the inferred type of the subexpression.
 
 ```hoon
 > !>(15)
@@ -571,11 +538,11 @@ spear, `-:!>`.
 #t/@
 ```
 
-Now let's try using `?=` {% tooltip label="wuttis"
-href="/language/hoon/reference/rune/wut#-wuttis" /%} with `?:` {%
-tooltip label="wutcol" href="/language/hoon/reference/rune/wut#-wutcol"
-/%} again.  But this time we'll replace `[& b]` with `[& -:!>(b)]` and
-`[| b]` with `[| -:!>(b)]`. With `b` as `12`:
+Now let's try using `?=`
+[wuttis](/language/hoon/reference/rune/wut#-wuttis) with `?:`
+[wutcol](/language/hoon/reference/rune/wut#-wutcol) again.  But this
+time we'll replace `[& b]` with `[& -:!>(b)]` and `[| b]` with `[|
+-:!>(b)]`. With `b` as `12`:
 
 ```hoon
 > =/(b=* 12 ?:(?=(@ b) [& -:!>(b)] [| -:!>(b)]))
@@ -589,12 +556,11 @@ tooltip label="wutcol" href="/language/hoon/reference/rune/wut#-wutcol"
 [%.n #t/[* *]]
 ```
 
-In both cases, `b` is defined initially as a generic {% tooltip
-label="noun" href="/glossary/noun" /%}, `*`.  But when using `?:` with
-`?=(@ b)` as the test condition, `b` is inferred to be an {% tooltip
-label="atom" href="/glossary/atom" /%}, `@`, when the condition is true;
-otherwise `b` is inferred to be a {% tooltip label="cell"
-href="/glossary/cell" /%}, `^` (identical to `[* *]`).
+In both cases, `b` is defined initially as a generic
+[noun](/glossary/noun), `*`.  But when using `?:` with `?=(@ b)` as the
+test condition, `b` is inferred to be an [atom](/glossary/atom), `@`,
+when the condition is true; otherwise `b` is inferred to be a
+[cell](/glossary/cell), `^` (identical to `[* *]`).
 
 ###### `mint-vain`
 
@@ -606,10 +572,10 @@ information Hoon already has.
 
 For example, if you have a wing expression (e.g., `b`) that is already
 known to be an atom, `@`, and you use `?=(@ b)` to test whether `b` is
-an atom, you'll get a {% tooltip label="mint-vain"
-href="/language/hoon/reference/hoon-errors#mint-vain-and-mint-lost" /%}
-crash.  The same thing happens if `b` is initially defined to be a {%
-tooltip label="cell" href="/glossary/cell" /%} `^`:
+an atom, you'll get a
+[mint-vain](/language/hoon/reference/hoon-errors#mint-vain-and-mint-lost)
+crash.  The same thing happens if `b` is initially defined to be a
+[cell](/glossary/cell) `^`:
 
 ```hoon
 > =/(b=@ 12 ?:(?=(@ b) [& b] [| b]))
@@ -627,11 +593,10 @@ of the branches will never be taken.
 
 #### `?@` wutpat Atom Match Tests
 
-The `?@` {% tooltip label="wutpat"
-href="/language/hoon/reference/rune/wut#-wutpat" /%} rune takes three
-subexpressions.  The first is evaluated, and if its value is an instance
-of `@`, the second subexpression is evaluated.  Otherwise, the third
-subexpression is evaluated.
+The `?@` [wutpat](/language/hoon/reference/rune/wut#-wutpat) rune takes
+three subexpressions.  The first is evaluated, and if its value is an
+instance of `@`, the second subexpression is evaluated.  Otherwise, the
+third subexpression is evaluated.
 
 ```hoon
 > =/(b=* 12 ?@(b %atom %cell))
@@ -641,12 +606,10 @@ subexpression is evaluated.
 %cell
 ```
 
-If the second `?@` {% tooltip label="wutpat"
-href="/language/hoon/reference/rune/wut#-wutpat" /%} subexpression is
-evaluated, Hoon correctly infers that `b` is an {% tooltip label="atom"
-href="/glossary/atom" /%}.  if the third subexpression is evaluated,
-Hoon correctly infers that `b` is a {% tooltip label="cell"
-href="/glossary/cell" /%}.
+If the second `?@` [wutpat](/language/hoon/reference/rune/wut#-wutpat)
+subexpression is evaluated, Hoon correctly infers that `b` is an
+[atom](/glossary/atom).  if the third subexpression is evaluated, Hoon
+correctly infers that `b` is a [cell](/glossary/cell).
 
 ```hoon
 > =/(b=* 12 ?@(b [%atom -:!>(b)] [%cell -:!>(b)]))
@@ -656,12 +619,11 @@ href="/glossary/cell" /%}.
 [%cell #t/[* *]]
 ```
 
-If the inferred type of the first `?@` {% tooltip label="wutpat"
-href="/language/hoon/reference/rune/wut#-wutpat" /%} subexpression nests
+If the inferred type of the first `?@`
+[wutpat](/language/hoon/reference/rune/wut#-wutpat) subexpression nests
 under `@` then one of the conditional branches provably never runs.
-Attempting to evaluate the expression results in a {% tooltip
-label="mint-vain"
-href="/language/hoon/reference/hoon-errors#mint-vain-and-mint-lost" /%}:
+Attempting to evaluate the expression results in a
+[mint-vain](/language/hoon/reference/hoon-errors#mint-vain-and-mint-lost):
 
 ```hoon
 > ?@(12 %an-atom %not-an-atom)
@@ -677,17 +639,14 @@ mint-vain
 mint-vain
 ```
 
-`?@` {% tooltip label="wutpat"
-href="/language/hoon/reference/rune/wut#-wutpat" /%} should only be used
+`?@` [wutpat](/language/hoon/reference/rune/wut#-wutpat) should only be used
 when it allows for Hoon to infer new type information; it shouldn't be
 used to confirm type information Hoon already knows.
 
 #### `?^` wutket Cell Match Tests
 
-The `?^` {% tooltip label="wutket"
-href="/language/hoon/reference/rune/wut#-wutket" /%} rune is just like
-`?@` {% tooltip label="wutpat"
-href="/language/hoon/reference/rune/wut#-wutpat" /%} except it tests for
+The `?^` [wutket](/language/hoon/reference/rune/wut#-wutket) rune is just like
+`?@` [wutpat](/language/hoon/reference/rune/wut#-wutpat) except it tests for
 a cell match instead of for an atom match.  The first subexpression is
 evaluated, and if the resulting value is an instance of `^` the second
 subexpression is evaluated. Otherwise, the third is run.
@@ -703,8 +662,7 @@ subexpression is evaluated. Otherwise, the third is run.
 Again, if the second subexpression is evaluated Hoon infers that `b` is
 a cell; if the third, Hoon infers that `b` is an atom.  If one of the
 conditional branches is provably never evaluated, the expression crashes
-with a {% tooltip label="mint-vain"
-href="/language/hoon/reference/hoon-errors#mint-vain-and-mint-lost" /%}:
+with a [mint-vain](/language/hoon/reference/hoon-errors#mint-vain-and-mint-lost):
 
 ```hoon
 > =/(b=@ 12 ?^(b %cell %atom))
@@ -716,11 +674,10 @@ nest-fail
 
 #### Tutorial:  Leaf Counting
 
-{% tooltip label="Nouns" href="/glossary/noun" /%} can be understood as
-binary trees in which each 'leaf' of the tree is an {% tooltip
-label="atom" href="/glossary/atom" /%}.  Let's look at a program that
-takes a noun and returns the number of leaves in it, i.e., the number of
-atoms.
+[Nouns](/glossary/noun) can be understood as binary trees in which each
+'leaf' of the tree is an [atom](/glossary/atom).  Let's look at a
+program that takes a noun and returns the number of leaves in it, i.e.,
+the number of atoms.
 
 ```hoon {% copy=true %}
 |=  a=*
@@ -730,9 +687,8 @@ atoms.
 (add $(a -.a) $(a +.a))
 ```
 
-Save this as `/gen/leafcount.hoon` in your fakeship's {% tooltip
-label="pier" href="/glossary/pier" /%} and run it from the {% tooltip
-label="Dojo" href="/glossary/dojo" /%}:
+Save this as `/gen/leafcount.hoon` in your fakeship's
+[pier](/glossary/pier) and run it from the [Dojo](/glossary/dojo):
 
 ```hoon
 > +leafcount 12
@@ -750,7 +706,7 @@ tree of one leaf; return `1`.  Otherwise, the number of leaves in `a` is
 the sum of the leaves in the head, `-.a`, and the tail, `+.a`.
 
 We have been careful to use `-.a` and `+.a` only on a branch for which
-`a` is proved to be a {% tooltip label="cell" href="/glossary/cell" /%}
+`a` is proved to be a [cell](/glossary/cell)
 -- then it's safe to treat `a` as having a head and a tail.
 
 #### Tutorial:  Cell Counting
@@ -792,13 +748,12 @@ Save this as `/gen/cellcount.hoon` and run it from the Dojo:
 ```
 
 This code is a little more tricky.  The basic idea, however, is simple.
-We have a counter value, `c`, whose initial value is `0` (`=|` {%
-tooltip label="tisbar" href="/language/hoon/reference/rune/tis#-tisbar"
-/%} pins the {% tooltip label="bunt" href="/glossary/bunt" /%} of the
-value with the given {% tooltip label="face" href="/glossary/face"
-/%}).  We trace through the noun `a`, adding `1` to `c` every time we
-come across a cell.  For any part of the noun that is just an atom, `c`
-is returned unchanged.
+We have a counter value, `c`, whose initial value is `0` (`=|`
+[tisbar](/language/hoon/reference/rune/tis#-tisbar) pins the
+[bunt](/glossary/bunt) of the value with the given
+[face](/glossary/face)).  We trace through the noun `a`, adding `1` to
+`c` every time we come across a cell.  For any part of the noun that is
+just an atom, `c` is returned unchanged.
 
 What makes this program is little harder to follow is that it recurses
 within a recursion call.  The first recursion expression on line 6 makes
@@ -807,7 +762,7 @@ The new value for `c` defined in the line `$(c +(c), a -.a)` is another
 recursion call (this time in irregular syntax).  The new value for `c`
 is to be the result of running the same function on the the head of `a`,
 `-.a`, and with `1` added to `c`.  We add `1` because we know that `a`
-must be a {% tooltip label="cell" href="/glossary/cell" /%}.  Otherwise,
+must be a [cell](/glossary/cell).  Otherwise,
 we're asking for the number of cells in the rest of `-.a`.
 
 Once that new value for `c` is computed from the head of `a`, we're
@@ -817,13 +772,13 @@ want from `-.a`, so we throw that away and replace `a` with `+.a`.
 ### Lists
 
 You learned about lists earlier in the chapter, but we left out a little
-bit of information about the way Hoon understands {% tooltip
-label="list" href="/glossary/list" /%} types.
+bit of information about the way Hoon understands [list](/glossary/list)
+types.
 
 A non-null list is a cell.  If `b` is a non-null list then the head of
 `b` is the first item of `b` _with an `i` face on it_.  The tail of `b`
 is the rest of the list.  The 'rest of the list' is itself another list
-_with a `t` {% tooltip label="face" href="/glossary/face" /%} on it_.
+_with a `t` [face](/glossary/face) on it_.
 We can (and should) use these `i` and `t` faces in list functions.
 
 To illustrate: let's say that `b` is the list of the atoms `11`, `22`,
@@ -856,11 +811,10 @@ atoms from `a` to `b`:
 
 This program is very simple.  It takes two `@` as input, `a` and `b`,
 and returns a `(list @)`, i.e., a list of `@`.  If `a` is greater than
-`b` the {% tooltip label="list" href="/glossary/list" /%} is finished:
-return the null list `~`.  Otherwise, return a non-null list: a pair in
-which the head is `a` with an `i` {% tooltip label="face"
-href="/glossary/face" /%} on it, and in which the tail is another list
-with the `t` face on it.  This embedded list is the product of a
+`b` the [list](/glossary/list) is finished: return the null list `~`.
+Otherwise, return a non-null list: a pair in which the head is `a` with
+an `i` [face](/glossary/face) on it, and in which the tail is another
+list with the `t` face on it.  This embedded list is the product of a
 recursion call: add `1` to `a` and run the function again.
 
 Save this code as `/gen/gulf.hoon` and run it from the Dojo:
@@ -892,14 +846,14 @@ itself:
 ```
 
 Because there is a cast to a `(list @)` on line 2, Hoon will silently
-include `i` and `t` faces for the appropriate places of the {% tooltip
-label="noun" href="/glossary/noun" /%}. Remember that {% tooltip
-label="faces" href="/glossary/face" /%} are recorded in the type
-information of the noun in question, not as part of the noun itself.
+include `i` and `t` faces for the appropriate places of the
+[noun](/glossary/noun). Remember that [faces](/glossary/face) are
+recorded in the type information of the noun in question, not as part of
+the noun itself.
 
-We called this program `gulf.hoon` because it replicates the {% tooltip
-label="gulf" href="/language/hoon/reference/stdlib/2b#gulf" /%} function
-in the Hoon standard library:
+We called this program `gulf.hoon` because it replicates the
+[gulf](/language/hoon/reference/stdlib/2b#gulf) function in the Hoon
+standard library:
 
 ```hoon
 > (gulf 1 10)
@@ -911,14 +865,12 @@ in the Hoon standard library:
 
 #### `?~` wutsig Null Match Test
 
-The `?~` {% tooltip label="wutsig"
-href="/language/hoon/reference/rune/wut#-wutsig" /%} rune is a lot like
-`?@` {% tooltip label="wutpat"
-href="/language/hoon/reference/rune/wut#-wutpat" /%} and `?^` {% tooltip
-label="wutket" href="/language/hoon/reference/rune/wut#-wutket" /%}.  It
-takes three subexpressions, the first of which is evaluated to see
-whether the result is `~` null. If so, the second subexpression is
-evaluated.  Otherwise, the third one is evaluated.
+The `?~` [wutsig](/language/hoon/reference/rune/wut#-wutsig) rune is a
+lot like `?@` [wutpat](/language/hoon/reference/rune/wut#-wutpat) and
+`?^` [wutket](/language/hoon/reference/rune/wut#-wutket).  It takes
+three subexpressions, the first of which is evaluated to see whether the
+result is `~` null. If so, the second subexpression is evaluated.
+Otherwise, the third one is evaluated.
 
 ```hoon
 > =/(b=* ~ ?~(b %null %not-null))
@@ -929,9 +881,8 @@ evaluated.  Otherwise, the third one is evaluated.
 ```
 
 The inferred type of `b` must not already be known to be null or
-non-null; otherwise, the expression will crash with a {% tooltip
-label="mint-vain"
-href="/language/hoon/reference/hoon-errors#mint-vain-and-mint-lost" /%}:
+non-null; otherwise, the expression will crash with a
+[mint-vain](/language/hoon/reference/hoon-errors#mint-vain-and-mint-lost):
 
 ```hoon
 > =/(b=~ ~ ?~(b %null %not-null))
@@ -949,16 +900,14 @@ branch is evaluated after the test.
 
 ##### Using `?~` wutsig With Lists
 
-`?~` {% tooltip label="wutsig"
-href="/language/hoon/reference/rune/wut#-wutsig" /%} is especially
+`?~` [wutsig](/language/hoon/reference/rune/wut#-wutsig) is especially
 useful for working with lists.  Is a list null, or not?  You probably
-want to do different things based on the answer to that question.
-Above, we used a pattern of `?:` {% tooltip label="wutcol"
-href="/language/hoon/reference/rune/wut#-wutcol" /%} and `?=` {% tooltip
-label="wuttis" href="/language/hoon/reference/rune/wut#-wuttis" /%} to
-answer the question, but `?~` wutsig will let us know in one step.
-Here's a program using `?~` wutsig to calculate the number of items in a
-list of atoms:
+want to do different things based on the answer to that question. Above,
+we used a pattern of `?:`
+[wutcol](/language/hoon/reference/rune/wut#-wutcol) and `?=`
+[wuttis](/language/hoon/reference/rune/wut#-wuttis) to answer the
+question, but `?~` wutsig will let us know in one step. Here's a program
+using `?~` wutsig to calculate the number of items in a list of atoms:
 
 ```hoon {% copy=true %}
 |=  a=(list @)
@@ -972,9 +921,9 @@ $(c +(c), a t.a)
 This function takes a list of `@` and returns an `@`.  It uses `c` as a
 counter value, initially set at `0` on line 2.  If `a` is `~` (i.e., a
 null list) then the computation is finished; return `c`.  Otherwise `a`
-must be a non-null {% tooltip label="list" href="/glossary/list" /%}, in
-which case there is a recursion to the `|-` {% tooltip label="barhep"
-href="/language/hoon/reference/rune/bar#--barhep" /%} on line 3, but with
+must be a non-null [list](/glossary/list), in which case there is a
+recursion to the `|-`
+[barhep](/language/hoon/reference/rune/bar#--barhep) on line 3, but with
 `c` incremented, and with the head of the list `a` thrown away.
 
 It's important to note that if `a` is a list, you can only use `i.a` and
@@ -1000,9 +949,8 @@ Save the above code as `/gen/lent.hoon` and run it from the Dojo:
 
 #### Tutorial:  Converting a Noun to a List of its Leaves
 
-Here's a program that takes a noun and returns a {% tooltip label="list"
-href="/glossary/list" /%} of its 'leaves' (atoms) in order of their
-appearance:
+Here's a program that takes a noun and returns a [list](/glossary/list)
+of its 'leaves' (atoms) in order of their appearance:
 
 ```hoon {% copy=true %}
 |=  a=*
@@ -1042,28 +990,25 @@ So far you've learned about four kinds of type inference:
 4.  branch specialization using runes in the `?` family
 
 There are several other ways that Hoon infers type.  Any rune expression
-that evaluates to a `?` flag, e.g., `.=` {% tooltip label="dottis"
-href="/language/hoon/reference/rune/dot#-dottis" /%}, will be inferred
-from accordingly.  The `.+` {% tooltip label="dotlus"
-href="/language/hoon/reference/rune/dot#-dotlus" /%} rune always
+that evaluates to a `?` flag, e.g., `.=`
+[dottis](/language/hoon/reference/rune/dot#-dottis), will be inferred
+from accordingly.  The `.+`
+[dotlus](/language/hoon/reference/rune/dot#-dotlus) rune always
 evaluates to an `@`, and Hoon knows that too.  The cell constructor
-runes, `:-` {% tooltip label="colhep"
-href="/language/hoon/reference/rune/col#--colhep" /%}, `:+` {% tooltip
-label="collus" href="/language/hoon/reference/rune/col#-collus" /%},
-`:^` {% tooltip label="colket"
-href="/language/hoon/reference/rune/col#-colket" /%}, and `:*` {%
-tooltip label="coltar" href="/language/hoon/reference/rune/col#-coltar"
-/%} are all known to produce cells.
+runes, `:-` [colhep](/language/hoon/reference/rune/col#--colhep), `:+`
+[collus](/language/hoon/reference/rune/col#-collus), `:^`
+[colket](/language/hoon/reference/rune/col#-colket), and `:*`
+[coltar](/language/hoon/reference/rune/col#-coltar) are all known to
+produce cells.
 
-More subtly, the `=+` {% tooltip label="tislus"
-href="/language/hoon/reference/rune/tis#-tislus" /%}, `=/` {% tooltip
-label="tisfas" href="/language/hoon/reference/rune/tis#-tisfas" /%}, and
-`=|` {% tooltip label="tisbar"
-href="/language/hoon/reference/rune/tis#-tisbar" /%} runes modify the {%
-tooltip label="subject" href="/glossary/subject" /%} by pinning values
-to the head.  Hoon infers from this that the subject has a new type:  a
-cell whose head is the type of the pinned value and whose tail is the
-type of the (old) subject.
+More subtly, the `=+`
+[tislus](/language/hoon/reference/rune/tis#-tislus), `=/`
+[tisfas](/language/hoon/reference/rune/tis#-tisfas), and `=|`
+[tisbar](/language/hoon/reference/rune/tis#-tisbar) runes modify the
+[subject](/glossary/subject) by pinning values to the head.  Hoon infers
+from this that the subject has a new type:  a cell whose head is the
+type of the pinned value and whose tail is the type of the (old)
+subject.
 
 In general, anything that modifies the subject modifies the type of the
 subject.  Type inference can work in subtle ways for various
@@ -1074,11 +1019,11 @@ majority of ordinary use cases.
 
 ## Auras as 'Soft' Types
 
-It's important to understand that Hoon's type system doesn't enforce {%
-tooltip label="auras" href="/glossary/aura" /%} as strictly as it does
-other types. Auras are 'soft' type information. To see how this works,
-we'll take you through the process of converting the aura of an {%
-tooltip label="atom" href="/glossary/atom" /%} to another aura.
+It's important to understand that Hoon's type system doesn't enforce
+[auras](/glossary/aura) as strictly as it does other types. Auras are
+'soft' type information. To see how this works, we'll take you through
+the process of converting the aura of an [atom](/glossary/atom) to
+another aura.
 
 Hoon makes an effort to enforce that the correct aura is produced by an
 expression:
@@ -1133,9 +1078,9 @@ In fact, you can cast any atom all the way to the most general case `@`:
 2
 ```
 
-Anything of the general {% tooltip label="aura" href="/glossary/aura"
-/%} `@` can, in turn, be cast to more specific auras. We can show this
-by embedding a cast expression inside another cast:
+Anything of the general [aura](/glossary/aura) `@` can, in turn, be cast
+to more specific auras. We can show this by embedding a cast expression
+inside another cast:
 
 ```hoon
 > ^-(@ud ^-(@ 0x10))
@@ -1158,9 +1103,8 @@ Hoon uses the outermost cast to infer the type:
 
 As you can see, an atom with one aura can be converted to another aura.
 For a convenient shorthand, you can do this conversion with irregular
-cast syntax, e.g. `` `@ud` ``, rather than using the `^-` {% tooltip
-label="kethep" href="/language/hoon/reference/rune/ket#--kethep" /%}
-rune twice:
+cast syntax, e.g. `` `@ud` ``, rather than using the `^-`
+[kethep](/language/hoon/reference/rune/ket#--kethep) rune twice:
 
 ```hoon
 > `@ud`0x10
@@ -1190,18 +1134,16 @@ has been performed on `b`.  For an illustration of the bug, let's set
 ~[11 22 33 44]
 ```
 
-Now let's use `?~` {% tooltip label="wutsig"
-href="/language/hoon/reference/rune/wut#-wutsig" /%} to prove that `b`
-isn't null, and then try to snag it:
+Now let's use `?~` [wutsig](/language/hoon/reference/rune/wut#-wutsig)
+to prove that `b` isn't null, and then try to snag it:
 
 ```hoon
 > ?~(b ~ (snag 0 b))
 nest-fail
 ```
 
-The problem is that {% tooltip label="++snag"
-href="/language/hoon/reference/stdlib/2b#snag" /%} is expecting a raw
-list, not a list that is known to be non-null.
+The problem is that [++snag](/language/hoon/reference/stdlib/2b#snag) is
+expecting a raw list, not a list that is known to be non-null.
 
 You can cast `b` back to `(list)` to work around this:
 
@@ -1213,31 +1155,24 @@ You can cast `b` back to `(list)` to work around this:
 ### Pattern Matching and Assertions
 
 To summarize, as values get passed around and checked at various points,
-the Hoon compiler tracks what the possible data structure or {% tooltip
-label="mold" href="/glossary/mold" /%} looks like.  The following runes
-are particularly helpful when inducing the compiler to infer what it
-needs to know:
+the Hoon compiler tracks what the possible data structure or
+[mold](/glossary/mold) looks like.  The following runes are particularly
+helpful when inducing the compiler to infer what it needs to know:
 
-- `?~` {% tooltip label="wutsig"
-  href="/language/hoon/reference/rune/wut#-wutsig" /%} asserts non-null.
-- `?^` {% tooltip label="wutket"
-  href="/language/hoon/reference/rune/wut#-wutket" /%} asserts cell.
-- `?@` {% tooltip label="wutpat"
-  href="/language/hoon/reference/rune/wut#-wutpat" /%} asserts atom.
-- `?=` {% tooltip label="wuttis"
-  href="/language/hoon/reference/rune/wut#-wuttis" /%} tests for a
+- `?~` [wutsig](/language/hoon/reference/rune/wut#-wutsig) asserts non-null.
+- `?^` [wutket](/language/hoon/reference/rune/wut#-wutket) asserts cell.
+- `?@` [wutpat](/language/hoon/reference/rune/wut#-wutpat) asserts atom.
+- `?=` [wuttis](/language/hoon/reference/rune/wut#-wuttis) tests for a
   pattern match in type.
 
 There are two additional assertions which can be used with the type
 system:
 
-- `?>` {% tooltip label="wutgar"
-  href="/language/hoon/reference/rune/wut#-wutgar" /%} is a positive
+- `?>` [wutgar](/language/hoon/reference/rune/wut#-wutgar) is a positive
   assertion (`%.y` or crash).
-- `?<` {% tooltip label="wutgal"
-  href="/language/hoon/reference/rune/wut#-wutgal" /%} is a negative
+- `?<` [wutgal](/language/hoon/reference/rune/wut#-wutgal) is a negative
   assertion (`%.n` or crash).
 
 If you are running into `find-fork` errors in more complicated data
-structures (like {% tooltip label="marks" href="/glossary/mark" /%} or
-JSONs), consider using these assertions to guide the typechecker.
+structures (like [marks](/glossary/mark) or JSONs), consider using these
+assertions to guide the typechecker.

--- a/content/courses/hoon-school/N-logic.md
+++ b/content/courses/hoon-school/N-logic.md
@@ -7,10 +7,10 @@ objectives = ["Produce loobean expressions.", "Reorder conditional arms.", "Swit
 
 {% video src="https://media.urbit.org/docs/hoon-school-videos/HS184 - Logical Operations.mp4" /%}
 
-_Although you've been using various of the `?` {% tooltip label="wut"
-href="/language/hoon/reference/rune/wut" /%} runes for a while now,
-let's wrap up some loose ends.  This module will cover the nature of
-loobean logic and the rest of the `?` wut runes._
+_Although you've been using various of the `?`
+[wut](/language/hoon/reference/rune/wut) runes for a while now, let's
+wrap up some loose ends.  This module will cover the nature of loobean
+logic and the rest of the `?` wut runes._
 
 
 ##  Loobean Logic
@@ -39,11 +39,10 @@ very uncommon for you to need to unpack them.
 
 ##  Noun Equality
 
-The most fundamental comparison in Hoon is provided by `.=` {% tooltip
-label="dottis" href="/language/hoon/reference/rune/dot#-dottis" /%}, a
-test for equality of two {% tooltip label="nouns" href="/glossary/noun"
-/%} using Nock 5.  This is almost always used in its irregular form of
-`=` tis.
+The most fundamental comparison in Hoon is provided by `.=`
+[dottis](/language/hoon/reference/rune/dot#-dottis), a test for equality
+of two [nouns](/glossary/noun) using Nock 5.  This is almost always used
+in its irregular form of `=` tis.
 
 ```hoon
 > =(0 0)
@@ -53,11 +52,10 @@ test for equality of two {% tooltip label="nouns" href="/glossary/noun"
 %.n
 ```
 
-Since {% tooltip label="Nock" href="/glossary/nock" /%} is unaware of
-the Hoon metadata type system, only bare {% tooltip label="atoms"
-href="/glossary/atom" /%} in the nouns are compared.  If you need to
-compare include type information, create vases with `!>` {% tooltip
-label="zapgar" href="/language/hoon/reference/rune/zap#-zapgar" /%}.
+Since [Nock](/glossary/nock) is unaware of the Hoon metadata type
+system, only bare [atoms](/glossary/atom) in the nouns are compared.  If
+you need to compare include type information, create vases with `!>`
+[zapgar](/language/hoon/reference/rune/zap#-zapgar).
 
 ```hoon
 > =('a' 97)
@@ -80,35 +78,33 @@ or `%.n` false (in which case we do another).  Some basic expressions
 are mathematical, but we also check for existence, for equality of two
 values, etc.
 
-- {% tooltip label="++gth" href="/language/hoon/reference/stdlib/1a#gth" /%} (greater than `>`)
-- {% tooltip label="++lth" href="/language/hoon/reference/stdlib/1a#lth" /%} (less than `<`)  
-- {% tooltip label="++gte" href="/language/hoon/reference/stdlib/1a#gte" /%} (greater than or equal to `≥`)
-- {% tooltip label="++lte" href="/language/hoon/reference/stdlib/1a#lte" /%} (less than or equal to `≤`)
-- `.=` {% tooltip label="dottis" href="/language/hoon/reference/rune/dot#-dottis" /%}, irregularly `=()` (check for equality)
+- [++gth](/language/hoon/reference/stdlib/1a#gth) (greater than `>`)
+- [++lth](/language/hoon/reference/stdlib/1a#lth) (less than `<`)  
+- [++gte](/language/hoon/reference/stdlib/1a#gte) (greater than or equal to `≥`)
+- [++lte](/language/hoon/reference/stdlib/1a#lte) (less than or equal to `≤`)
+- `.=` [dottis](/language/hoon/reference/rune/dot#-dottis), irregularly
+  `=()` (check for equality)
 
-The key conditional decision-making rune is `?:` {% tooltip
-label="wutcol" href="/language/hoon/reference/rune/wut#-wutcol" /%},
-which lets you branch between an `expression-if-true` and an
-`expression-if-false`. `?.` {% tooltip label="wutdot"
-href="/language/hoon/reference/rune/wut#-wutdot" /%} inverts the order
-of `?:`.  Good Hoon style prescribes that the heavier branch of a
+The key conditional decision-making rune is `?:`
+[wutcol](/language/hoon/reference/rune/wut#-wutcol), which lets you
+branch between an `expression-if-true` and an `expression-if-false`.
+`?.` [wutdot](/language/hoon/reference/rune/wut#-wutdot) inverts the
+order of `?:`.  Good Hoon style prescribes that the heavier branch of a
 logical expression should be lower in the file.
 
 There are also two long-form decision-making runes, which we will call
 [_switch statements_](https://en.wikipedia.org/wiki/Switch_statement) by
 analogy with languages like C.
 
-- `?-` {% tooltip label="wuthep"
-  href="/language/hoon/reference/rune/wut#--wuthep" /%} lets you choose
-  between several possibilities, as with a type union.  Every case must
-  be handled and no case can be unreachable.
+- `?-` [wuthep](/language/hoon/reference/rune/wut#--wuthep) lets you
+  choose between several possibilities, as with a type union.  Every
+  case must be handled and no case can be unreachable.
 
     Since `@tas` terms are constants first, and not `@tas` unless marked
-    as such, `?-` {% tooltip label="wuthep"
-    href="/language/hoon/reference/rune/wut#--wuthep" /%} switches over
-    term unions can make it look like the expression is branching on the
-    value.  It's actually branching on the _type_.  These are almost
-    exclusively used with term type unions.
+    as such, `?-` [wuthep](/language/hoon/reference/rune/wut#--wuthep)
+    switches over term unions can make it look like the expression is
+    branching on the value.  It's actually branching on the _type_.
+    These are almost exclusively used with term type unions.
 
     ```hoon {% copy=true %}
     |=  p=?(%1 %2 %3)
@@ -119,11 +115,10 @@ analogy with languages like C.
     ==
     ```
 
-- `?+` {% tooltip label="wutlus"
-  href="/language/hoon/reference/rune/wut#-wutlus" /%} is similar to
+- `?+` [wutlus](/language/hoon/reference/rune/wut#-wutlus) is similar to
   `?-` but allows a default value in case no branch is taken.  Otherwise
-  these are similar to `?-` {% tooltip label="wuthep"
-  href="/language/hoon/reference/rune/wut#--wuthep"/%} switch
+  these are similar to `?-`
+  [wuthep](/language/hoon/reference/rune/wut#--wuthep) switch
   statements.
 
     ```hoon {% copy=true %}
@@ -142,8 +137,7 @@ other propositions.  In computer science, we use this functionality to
 determine which part of an expression is evaluated.  We can combine
 logical statements pairwise:
 
-- `?&` {% tooltip label="wutpam"
-  href="/language/hoon/reference/rune/wut#-wutpam" /%}, irregularly
+- `?&` [wutpam](/language/hoon/reference/rune/wut#-wutpam), irregularly
   `&()`, is a logical `AND` (i.e. _p_ ∧ _q_) over loobean values, e.g.
   both terms must be true.
 
@@ -160,8 +154,7 @@ logical statements pairwise:
     %.y
     ```
 
-- `?|` {% tooltip label="wutbar"
-  href="/language/hoon/reference/rune/wut#-wutbar" /%}, irregularly
+- `?|` [wutbar](/language/hoon/reference/rune/wut#-wutbar), irregularly
   `|()`, is a logical `OR` (i.e. _p_ ∨ _q_)  over loobean values, e.g.
   either term may be true.
 
@@ -178,9 +171,8 @@ logical statements pairwise:
     %.y
     ```
 
-- `?!` {% tooltip label="wutzap"
-  href="/language/hoon/reference/rune/wut#-wutzap" /%}, irregularly `!`,
-  is a logical `NOT` (i.e. ¬*p*).  Sometimes it can be difficult to
+- `?!` [wutzap](/language/hoon/reference/rune/wut#-wutzap), irregularly
+  `!`, is a logical `NOT` (i.e. ¬*p*).  Sometimes it can be difficult to
   parse code including `!` because it operates without parentheses.
 
     |                              | `NOT` |
@@ -212,7 +204,7 @@ calculated by (_p_ ∧ ¬*q*) ∨ (¬*p* ∧ _q_).
 | `%.y`{% class="font-bold" %} | `%.n` | `%.y` |
 | `%.n`{% class="font-bold" %} | `%.y` | `%.n` |
 
-- Implement `XOR` as a {% tooltip label="gate" href="/glossary/gate" /%}
+- Implement `XOR` as a [gate](/glossary/gate)
   in Hoon.
 
     ```hoon {% copy=true %}
@@ -250,9 +242,8 @@ operands are false.  `NOR` can be calculated by ¬(_p_ ∨ _q_).
 The boxcar function is a piecewise mathematical function which is equal
 to zero for inputs less than zero and one for inputs greater than or
 equal to zero.  We implemented the similar Heaviside function
-[previously](/courses/hoon-school/B-syntax) using the `?:` {% tooltip
-label="wutcol" href="/language/hoon/reference/rune/wut#-wutcol" /%}
-rune.
+[previously](/courses/hoon-school/B-syntax) using the `?:`
+[wutcol](/language/hoon/reference/rune/wut#-wutcol) rune.
 
 - Compose a gate which implements the boxcar function,
 

--- a/content/courses/hoon-school/O-subject.md
+++ b/content/courses/hoon-school/O-subject.md
@@ -7,11 +7,10 @@ objectives = ["Review subject-oriented programming as a design paradigm.", "Disc
 
 _This module discusses how Urbit's subject-oriented programming paradigm
 structures how cores and values are used and maintain state, as well as
-how deferred computations and remote value lookups ({% tooltip
-label="\"scrying\"" href="/glossary/scry" /%}) are handled.  This
-module does not cover {% tooltip label="core" href="/glossary/core" /%}
-genericity and variance, which will be explained in [a later
-module](/courses/hoon-school/R-metals)._
+how deferred computations and remote value lookups
+(["scrying"](/glossary/scry)) are handled.  This module does not cover
+[core](/glossary/core) genericity and variance, which will be explained
+in [a later module](/courses/hoon-school/R-metals)._
 
 
 ##  The Subject
@@ -19,39 +18,33 @@ module](/courses/hoon-school/R-metals)._
 As we've said before:
 
 > The Urbit operating system hews to a conceptual model wherein each
-> expression takes place in a certain context (the {% tooltip
-> label="subject" href="/glossary/subject" /%}).  While
-> sharing a lot of practicality with other programming paradigms and
-> platforms, Urbit's model is mathematically well-defined and
-> unambiguously specified.  Every expression of Hoon is evaluated relative
-> to its subject, a piece of data that represents the environment, or the
-> context, of an expression.
+> expression takes place in a certain context (the
+> [subject](/glossary/subject)).  While sharing a lot of practicality with
+> other programming paradigms and platforms, Urbit's model is
+> mathematically well-defined and unambiguously specified.  Every
+> expression of Hoon is evaluated relative to its subject, a piece of data
+> that represents the environment, or the context, of an expression.
 
 Subject-oriented programming means that every expression is evaluated
-with respect to some {% tooltip label="subject" href="/glossary/subject"
-/%}.  Every {% tooltip label="arm" href="/glossary/arm" /%} of a {%
-tooltip label="core" href="/glossary/core" /%} is evaluated with its
+with respect to some [subject](/glossary/subject).  Every
+[arm](/glossary/arm) of a [core](/glossary/core) is evaluated with its
 parent core as the subject.
 
-You have also seen how wings work as search paths to identify {% tooltip
-label="nouns" href="/glossary/noun" /%} in the {% tooltip
-label="subject" href="/glossary/subject" /%}, and you have learned three
-ways to access values by address:  numeric addressing, lark notation,
-and wing search expressions.
+You have also seen how wings work as search paths to identify
+[nouns](/glossary/noun) in the [subject](/glossary/subject), and you
+have learned three ways to access values by address:  numeric
+addressing, lark notation, and wing search expressions.
 
-Generally speaking, the following {% tooltip label="rune"
-href="/glossary/rune" /%} families allow you to do certain things to
-the {% tooltip label="subject" href="/glossary/subject" /%}:
+Generally speaking, the following [rune](/glossary/rune) families allow
+you to do certain things to the [subject](/glossary/subject):
 
-- `|` {% tooltip label="bar" href="/language/hoon/reference/rune/bar"
-  /%} runes create {% tooltip label="cores" href="/glossary/core" /%},
-  i.e. largely self-contained expressions
-- `^` {% tooltip label="ket" href="/language/hoon/reference/rune/ket"
-  /%} runes transform cores, i.e. change core properties
-- `%` {% tooltip label="cen" href="/language/hoon/reference/rune/cen"
-  /%} runes pull arms in cores
-- `=` {% tooltip label="tis" href="/language/hoon/reference/rune/tis"
-  /%} runes modify the subject by introducing or replacing values
+- `|` [bar](/language/hoon/reference/rune/bar) runes create
+  [cores](/glossary/core), i.e. largely self-contained expressions
+- `^` [ket](/language/hoon/reference/rune/ket) runes transform cores,
+  i.e. change core properties
+- `%` [cen](/language/hoon/reference/rune/cen) runes pull arms in cores
+- `=` [tis](/language/hoon/reference/rune/tis) runes modify the subject
+  by introducing or replacing values
 
 Different kinds of cores can expose or conceal functionality (such as
 their sample) based on their variance model.  We don't need to be
@@ -63,29 +56,27 @@ to read [that module](/courses/hoon-school/R-metals) as well.
 
 Usually the subject of a Hoon expression isn't shown explicitly.  In
 fact, only when using `:`/`.` wing lookup expressions have we made the
-{% tooltip label="subject" href="/glossary/subject" /%} explicit.
+[subject](/glossary/subject) explicit.
 
 An arm is always evaluated with its parent core as its subject.  We've
 briefly mentioned that one can use helper cores (e.g. for generators) by
-composing the cores side-by-side using `=<` {% tooltip label="tisgal"
-href="/language/hoon/reference/rune/tis#-tisgal" /%} and `=>` {% tooltip
-label="tisgar" href="/language/hoon/reference/rune/tis#-tisgar" /%}.
-This way we can make sure that the arms fall within each other's subject
-horizon.
+composing the cores side-by-side using `=<`
+[tisgal](/language/hoon/reference/rune/tis#-tisgal) and `=>`
+[tisgar](/language/hoon/reference/rune/tis#-tisgar). This way we can
+make sure that the arms fall within each other's subject horizon.
 
-Why must an {% tooltip label="arm" href="/glossary/arm" /%} have its
-parent core as the subject, when it's computed? As stated previously,
-the {% tooltip label="payload" href="/glossary/payload" /%} of a core
-contains all the data needed for computing the arms of that core.  Arms
-can only access data in the subject.  By requiring that the parent core
-be the subject we guarantee that each arm has the appropriate data
-available to it.  The tail of its subject contains the `payload` and
-thus all the values therein.  The head of the subject is the {% tooltip
-label="battery" href="/glossary/battery" /%}, which allows for making
-reference to sibling arms of that same core.
+Why must an [arm](/glossary/arm) have its parent core as the subject,
+when it's computed? As stated previously, the
+[payload](/glossary/payload) of a core contains all the data needed for
+computing the arms of that core.  Arms can only access data in the
+subject.  By requiring that the parent core be the subject we guarantee
+that each arm has the appropriate data available to it.  The tail of its
+subject contains the `payload` and thus all the values therein.  The
+head of the subject is the [battery](/glossary/battery), which allows
+for making reference to sibling arms of that same core.
 
-In the Dojo, if you use `+1` by itself, you can see the current {%
-tooltip label="subject" href="/glossary/subject" /%}.
+In the Dojo, if you use `+1` by itself, you can see the current
+[subject](/glossary/subject).
 
 ```hoon
 > +1
@@ -100,20 +91,19 @@ tooltip label="subject" href="/glossary/subject" /%}.
 
 `.` does the same thing:  it always refers to the current subject.
 
-If `.` is the subject, then `..arm` is the subject of a given {% tooltip
-label="arm" href="/glossary/arm" /%} (the second `.` dot being the wing
-resolution operator).  You can check the details of the parent {%
-tooltip label="core" href="/glossary/core" /%} using something like
-`..add`.  This trick is used when producing agents that have highly
-nested operations (search `..` in the `/app` directory), or when
-composing
+If `.` is the subject, then `..arm` is the subject of a given
+[arm](/glossary/arm) (the second `.` dot being the wing resolution
+operator).  You can check the details of the parent
+[core](/glossary/core) using something like `..add`.  This trick is used
+when producing agents that have highly nested operations (search `..` in
+the `/app` directory), or when composing
 [jets](/system/runtime/guides/jetting#edit-the-hoon-source-code), for
 instance.
 
 Another use case for the `..arm` syntax is when there is a core in the
-subject without a {% tooltip label="face" href="/glossary/face" /%}
+subject without a [face](/glossary/face)
 bound to it; i.e., the core might be nameless. In that case you can use
-an arm name in that {% tooltip label="core" href="/glossary/core" /%} to
+an arm name in that [core](/glossary/core) to
 refer to the whole core.
 
 ```hoon
@@ -123,17 +113,15 @@ refer to the whole core.
 
 #### Tutorial:  The Core Structure of `hoon.hoon`
 
-Let's take a deeper look at how cores can be combined with `=>` {%
-tooltip label="tisgar" href="/language/hoon/reference/rune/tis#-tisgar"
-/%} to build up larger structures.  `=>  p=hoon  q=hoon` yields the
-product of `q` with the product of `p` taken as the subject; i.e. it
-composes Hoon statements, like {% tooltip label="cores"
-href="/glossary/core" /%}.
+Let's take a deeper look at how cores can be combined with `=>`
+[tisgar](/language/hoon/reference/rune/tis#-tisgar) to build up larger
+structures.  `=>  p=hoon  q=hoon` yields the product of `q` with the
+product of `p` taken as the subject; i.e. it composes Hoon statements,
+like [cores](/glossary/core).
 
-We use this to set the context of cores.  Recall that the {% tooltip
-label="payload" href="/glossary/payload" /%} of a {% tooltip
-label="gate" href="/glossary/gate" /%} is a cell of `[sample context]`.
-For example:
+We use this to set the context of cores.  Recall that the
+[payload](/glossary/payload) of a [gate](/glossary/gate) is a cell of
+`[sample context]`. For example:
 
 ```hoon
 > =foo =>([1 2] |=(@ 15))
@@ -147,10 +135,10 @@ Here we have created a gate with `[1 2]` as its context that takes in an
 [1 2]]`.  Here `0` is the default value of `@` and is the sample, while
 `[1 2]` is the context that was given to `foo`.
 
-`=>` {% tooltip label="tisgar"
-href="/language/hoon/reference/rune/tis#-tisgar" /%} (and its reversed
-version `=<` {% tooltip label="tisgal" href="/language/hoon/reference/rune/tis#-tisgal"
-/%}) are used extensively to put cores into the context of other cores.
+`=>` [tisgar](/language/hoon/reference/rune/tis#-tisgar) (and its
+reversed version `=<`
+[tisgal](/language/hoon/reference/rune/tis#-tisgal)) are used
+extensively to put cores into the context of other cores.
 
 ```hoon {% copy=true %}
 =>
@@ -166,18 +154,17 @@ version `=<` {% tooltip label="tisgal" href="/language/hoon/reference/rune/tis#-
 --
 ```
 
-At the level of {% tooltip label="arms" href="/glossary/arm" /%},
-`++foo` is in the {% tooltip label="subject" href="/glossary/subject"
-/%} of `++bar`, and so `++bar` is able to call `++foo`. On the other
-hand, `+bar` is not in the subject of `++foo`, so `++foo` cannot call
-`++bar` - you will get a `-find.bar` error.
+At the level of [arms](/glossary/arm), `++foo` is in the
+[subject](/glossary/subject) of `++bar`, and so `++bar` is able to call
+`++foo`. On the other hand, `+bar` is not in the subject of `++foo`, so
+`++foo` cannot call `++bar` - you will get a `-find.bar` error.
 
 At the level of cores, the `=>` sets the context of the core containing
 `++bar` to be the core containing `++foo`.  Recall that arms are
-evaluated with the parent {% tooltip label="core" href="/glossary/core"
-/%} as the subject.  Thus `++bar` is evaluated with the core containing
-it as the subject, which has the core containing `++foo` in its context.
-This is why `++foo` is in the scope of `++bar` but not vice versa.
+evaluated with the parent [core](/glossary/core) as the subject.  Thus
+`++bar` is evaluated with the core containing it as the subject, which
+has the core containing `++foo` in its context. This is why `++foo` is
+in the scope of `++bar` but not vice versa.
 
 Let's look inside `/sys/hoon.hoon`, where the standard library is
 located, to see how this can be used.
@@ -191,8 +178,7 @@ The first core listed here has just one arm.
 --
 ```
 
-This is reflected in the {% tooltip label="subject"
-href="/glossary/subject" /%} of `hoon-version`.
+This is reflected in the [subject](/glossary/subject) of `hoon-version`.
 
 ```hoon
 > ..hoon-version
@@ -246,8 +232,8 @@ of `add`.
 <33.uof 1.pnw %138>
 ```
 
-Here we see that core containing `hoon-version` is in the {% tooltip
-label="subject" href="/glossary/subject" /%} of the section 1 core.
+Here we see that core containing `hoon-version` is in the
+[subject](/glossary/subject) of the section 1 core.
 
 Next, [section 2](/language/hoon/reference/stdlib/2a) starts:
 
@@ -282,10 +268,8 @@ arms. This is also reflected in the dojo:
 and we also see the section 1 core and the core containing
 `hoon-version` in the subject.
 
-We can also confirm that {% tooltip label="++add"
-href="/language/hoon/reference/stdlib/1a#add" /%} is in the subject
-of {% tooltip label="++biff" href="/language/hoon/reference/stdlib/2a#biff"
-/%}
+We can also confirm that [++add](/language/hoon/reference/stdlib/1a#add)
+is in the subject of [++biff](/language/hoon/reference/stdlib/2a#biff)
 
 ```hoon
 > add:biff
@@ -308,26 +292,25 @@ May 2024):
 ```
 
 This confirms for us, then, that `hoon.hoon` consists of six nested
-cores, with one inside the {% tooltip label="payload"
-href="/glossary/payload" /%} of the next, with the `hoon-version` core
-most deeply nested.
+cores, with one inside the [payload](/glossary/payload) of the next,
+with the `hoon-version` core most deeply nested.
 
 ### Exercise:  Explore `hoon.hoon`
 
 - Pick a couple of arms in `hoon.hoon` and check to make sure that they
-  are only referenced in its parent {% tooltip label="core"
-  href="/glossary/core" /%} or core(s) that have the parent core put in
-  its context via the `=>` or `=<` runes.
+  are only referenced in its parent [core](/glossary/core) or core(s)
+  that have the parent core put in its context via the `=>` or `=<`
+  runes.
 
 
 ### Axes of the Subject
 
-The core {% tooltip label="Arvo" href="/glossary/arvo" /%} subject
+The core [Arvo](/glossary/arvo) subject
 exposes several axes (plural of `+$axis` which is the tree address) in
-the {% tooltip label="subject" href="/glossary/subject" /%}.  You've
+the [subject](/glossary/subject).  You've
 encountered these before:
 
-- `our` is the {% tooltip label="ship's" href="/glossary/ship" /%}
+- `our` is the [ship's](/glossary/ship)
   identity.
 
     ```hoon
@@ -347,11 +330,10 @@ encountered these before:
   [CSPRNG](https://en.wikipedia.org/wiki/Cryptographically-secure_pseudorandom_number_generator)
   and hash-iterated using
   [`++shax`](/language/hoon/reference/stdlib/3d#shax).  (`eny` is shared
-  between {% tooltip label="vanes" href="/glossary/vane" /%} during an
-  event, so there are currently limits on how much it should be relied
-  on until the Urbit kernel is security-hardened, but it is unique
-  within each {% tooltip label="Gall" href="/glossary/gall" /%} agent
-  activation.)
+  between [vanes](/glossary/vane) during an event, so there are
+  currently limits on how much it should be relied on until the Urbit
+  kernel is security-hardened, but it is unique within each
+  [Gall](/glossary/gall) agent activation.)
 
     ```hoon
     > ->+..
@@ -367,66 +349,58 @@ really make reference to any other transactions or events in the system.
 They don't preserve the results of previous calculations beyond their
 own transient existence.
 
-However, clearly regular applications, such as Gall {% tooltip
-label="agents" href="/glossary/agent" /%}, are stateful, meaning that
-they modify their own {% tooltip label="subject"
-href="/glossary/subject" /%} regularly.
+However, clearly regular applications, such as Gall
+[agents](/glossary/agent), are stateful, meaning that they modify their
+own [subject](/glossary/subject) regularly.
 
-There are several ways to manage state.  One approach, including `%=` {%
-tooltip label="centis" href="/language/hoon/reference/rune/cen#-centis"
-/%}, directly modifies the subject using a {% tooltip label="rune"
-href="/glossary/rune" /%}.  Another method is to use the other runes to
-compose or sequence changes together (e.g. as a pipe of {% tooltip
-label="gates" href="/glossary/gate" /%}).  By and large the `=` {%
-tooltip label="tis" href="/language/hoon/reference/rune/tis" /%} runes
-are responsible for modifying the subject, and the `;` {% tooltip
-label="mic" href="/language/hoon/reference/rune/mic" /%} runes permit
-chaining deferred computations together.
+There are several ways to manage state.  One approach, including `%=`
+[centis](/language/hoon/reference/rune/cen#-centis), directly modifies
+the subject using a [rune](/glossary/rune).  Another method is to use
+the other runes to compose or sequence changes together (e.g. as a pipe
+of [gates](/glossary/gate)).  By and large the `=`
+[tis](/language/hoon/reference/rune/tis) runes are responsible for
+modifying the subject, and the `;`
+[mic](/language/hoon/reference/rune/mic) runes permit chaining deferred
+computations together.
 
 To act in a stateful manner, a core must mutate itself and then pin the
 mutated copy in its place.  Most of the time this is handled by Arvo's
-Gall {% tooltip label="vane" href="/glossary/vane" /%}, by the {%
-tooltip label="Dojo" href="/glossary/dojo" /%}, or another system
-service, but we need to explicit modify and manage state for cores as we
-work within these kinds of applications.
+Gall [vane](/glossary/vane), by the [Dojo](/glossary/dojo), or another
+system service, but we need to explicit modify and manage state for
+cores as we work within these kinds of applications.
 
-We will use `%say` {% tooltip label="generators"
-href="/glossary/generator" /%} as a bridge concept.  We will produce
-some short applications that maintain state while carrying out a
-calculation; they still result in a single return value, but gesture at
-the big-picture approach to maintaining state in persistent {% tooltip
-label="agents" href="/glossary/agent" /%}.
+We will use `%say` [generators](/glossary/generator) as a bridge
+concept.  We will produce some short applications that maintain state
+while carrying out a calculation; they still result in a single return
+value, but gesture at the big-picture approach to maintaining state in
+persistent [agents](/glossary/agent).
 
 [As you may recall](/courses/hoon-school/J-stdlib-text), a `%say`
-generator is like a naked generator except rather than being simply a {%
-tooltip label="gate" href="/glossary/gate" /%}, it is a {% tooltip
-label="cell" href="/glossary/cell" /%} of `%say` (as a tag) and a gate.
-This gate can receive more information as gate arguments as part of its
-`sample`, such as a timestamp `now`, some entropy `eny`, and a file
-system beak `bec`. These allow us to think about how a core can modify
-and maintain state. Although a `%say` generator, like all generators,
-ultimately simply terminates, a Gall agent will be a persistent core
-with state that can continue to be used.
+generator is like a naked generator except rather than being simply a
+[gate](/glossary/gate), it is a [cell](/glossary/cell) of `%say` (as a
+tag) and a gate. This gate can receive more information as gate
+arguments as part of its `sample`, such as a timestamp `now`, some
+entropy `eny`, and a file system beak `bec`. These allow us to think
+about how a core can modify and maintain state. Although a `%say`
+generator, like all generators, ultimately simply terminates, a Gall
+agent will be a persistent core with state that can continue to be used.
 
 Here are a couple of new runes for modifying the subject and chaining
-computations together, aside from `%=` {% tooltip label="centis"
-href="/language/hoon/reference/rune/cen#-centis" /%} which you've
-already seen:
+computations together, aside from `%=`
+[centis](/language/hoon/reference/rune/cen#-centis) which you've already
+seen:
 
-- `=.` {% tooltip label="tisdot"
-  href="/language/hoon/reference/rune/tis#-tisdot" /%} is used to change
-  a leg in the {% tooltip label="subject" href="/glossary/subject" /%}.
-- `=~` {% tooltip label="tissig"
-  href="/language/hoon/reference/rune/tis#-tissig" /%} composes many
+- `=.` [tisdot](/language/hoon/reference/rune/tis#-tisdot) is used to change
+  a leg in the [subject](/glossary/subject).
+- `=~` [tissig](/language/hoon/reference/rune/tis#-tissig) composes many
   expressions together serially.
 
 #### Tutorial:  Bank Account
 
-In this section, we will write a {% tooltip label="door"
-href="/glossary/door" /%} that can act as a bank account with the
-ability to withdraw, deposit, and check the account's balance. This door
-replaces the sample of the door with the new values as each transaction
-proceeds.
+In this section, we will write a [door](/glossary/door) that can act as
+a bank account with the ability to withdraw, deposit, and check the
+account's balance. This door replaces the sample of the door with the
+new values as each transaction proceeds.
 
 ```hoon {% copy=true mode="collapse" %}
 :-  %say
@@ -452,7 +426,7 @@ proceeds.
 ```
 
 We start with the three boilerplate lines we have in every
-`%say` {% tooltip label="generator" href="/glossary/generator" /%}:
+`%say` [generator](/glossary/generator):
 
 ```hoon {% copy=true %}
 :-  %say
@@ -460,13 +434,11 @@ We start with the three boilerplate lines we have in every
 :-  %noun
 ```
 
-In the above code chunk, we're creating a {% tooltip label="cell"
-href="/glossary/cell" /%}.  The head of this cell is `%say`.  The tail
-is a {% tooltip label="gate" href="/glossary/gate" /%} (`|=  *`) that
-produces another cell (`:- %noun`) with a head of the {% tooltip
-label="mark" href="/glossary/mark" /%} of a the kind of data we are
-going to produce, a `%noun`; the tail of the second cell is the rest of
-the program.
+In the above code chunk, we're creating a [cell](/glossary/cell).  The
+head of this cell is `%say`.  The tail is a [gate](/glossary/gate) (`|=
+*`) that produces another cell (`:- %noun`) with a head of the
+[mark](/glossary/mark) of a the kind of data we are going to produce, a
+`%noun`; the tail of the second cell is the rest of the program.
 
 ```hoon {% copy=true %}
 =<  =~  new-account
@@ -481,16 +453,14 @@ In this code above, we're going to compose two runes using `=<`, which
 has inverted arguments. We use this rune to keep the heaviest twig to
 the bottom of the code.
 
-The `=~` {% tooltip label="tissig"
-href="/language/hoon/reference/rune/tis#-tissig" /%} rune composes
+The `=~` [tissig](/language/hoon/reference/rune/tis#-tissig) rune composes
 multiple expressions together; we use it here to make the code more
 readable.  We take `new-account` and use that as the subject for the
 call to `deposit`.  `deposit` and `withdraw` both produce a new version
-of the {% tooltip label="door" href="/glossary/door" /%} that's used in
+of the [door](/glossary/door) that's used in
 subsequent calls, which is why we are able to chain them in this
 fashion.  The final reference is to `balance`, which is the account
-balance contained in the {% tooltip label="core" href="/glossary/core"
-/%} that we examine below.
+balance contained in the [core](/glossary/core) that we examine below.
 
 ```hoon {% copy=true %}
 |%
@@ -506,17 +476,15 @@ balance contained in the {% tooltip label="core" href="/glossary/core"
 --
 ```
 
-We've chosen here to wrap our {% tooltip label="door"
-href="/glossary/door" /%} in its own core to emulate the style of
-programming that is used when creating libraries.  `++new-account` is
-the name of our door.  A door is a core with one or more arms that has a
-sample.  Here, our door has a sample of one `@ud` with the face
-`balance` and two {% tooltip label="arms" href="/glossary/arm" /%}
-`++deposit` and `++withdraw`.
+We've chosen here to wrap our [door](/glossary/door) in its own core to
+emulate the style of programming that is used when creating libraries.
+`++new-account` is the name of our door.  A door is a core with one or
+more arms that has a sample.  Here, our door has a sample of one `@ud`
+with the face `balance` and two [arms](/glossary/arm) `++deposit` and
+`++withdraw`.
 
-Each of these arms produces a {% tooltip label="gate"
-href="/glossary/gate" /%} which takes an `@ud` argument.  Each of these
-gates has a similar bit of code inside:
+Each of these arms produces a [gate](/glossary/gate) which takes an
+`@ud` argument.  Each of these gates has a similar bit of code inside:
 
 ```hoon {% copy=true %}
 +>.$(balance (add balance amount))
@@ -524,7 +492,7 @@ gates has a similar bit of code inside:
 
 `+>` is a kind of wing syntax, lark notation.  This particular wing
 construction looks for the tail of the tail (the third element) in `$`
-buc, the {% tooltip label="subject" href="/glossary/subject" /%} of the
+buc, the [subject](/glossary/subject) of the
 gate we are in.  The `++withdraw` and `++deposit` arms create gates with
 the entire `new-account` door as the context in their cores' `[battery
 sample context]`, in the "tail of the tail" slot.  We change `balance`
@@ -533,26 +501,25 @@ as the result.  `++withdraw` functions the same way only doing
 subtraction instead of addition.
 
 It's important to notice that the sample, `balance`, is stored as part
-of the {% tooltip label="door" href="/glossary/door" /%} rather than
+of the [door](/glossary/door) rather than
 existing outside of it.
 
 ### Exercise:  Bank Account
 
-- Modify the `%say` {% tooltip label="generator"
-  href="/glossary/generator" /%} above to accept a `@ud` unsigned
-  decimal dollar amount and a `?(%deposit %withdraw)` term and returns
-  the result of only that operation on the starting balance of the bank
-  account.  (Note that this will only work once on the {% tooltip
-  label="door" href="/glossary/door" /%}, and the state will not persist
-  between generator calls.)
+- Modify the `%say` [generator](/glossary/generator) above to accept a
+  `@ud` unsigned decimal dollar amount and a `?(%deposit %withdraw)`
+  term and returns the result of only that operation on the starting
+  balance of the bank account.  (Note that this will only work once on
+  the [door](/glossary/door), and the state will not persist between
+  generator calls.)
 
 ### Deferred Computations
 
-_Deferred computation_ means that parts of the {% tooltip
-label="subject" href="/glossary/subject" /%} have changes that may be
-underdetermined at first.  These must be calculated later using the
-appropriate {% tooltip label="runes" href="/glossary/rune" /%} as new or
-asynchronous information becomes available.
+_Deferred computation_ means that parts of the
+[subject](/glossary/subject) have changes that may be underdetermined at
+first.  These must be calculated later using the appropriate
+[runes](/glossary/rune) as new or asynchronous information becomes
+available.
 
 For instance, a network service call may take a while or may fail.  How
 should the calculation deal with these outcomes?  In addition, the
@@ -560,30 +527,23 @@ successful result of the network data is unpredictable in content (but
 should not be unpredictable in format!).
 
 We have some more tools available for managing deferred or chained
-computations, in addition to `=~` {% tooltip label="tissig"
-href="/language/hoon/reference/rune/tis#-tissig" /%} and `=*` {% tooltip
-label="tistar" href="/language/hoon/reference/rune/tis#-tistar" /%}:
+computations, in addition to `=~`
+[tissig](/language/hoon/reference/rune/tis#-tissig) and `=*`
+[tistar](/language/hoon/reference/rune/tis#-tistar):
 
-- `=^` {% tooltip label="tisket"
-  href="/language/hoon/reference/rune/tis#-tisket" /%} is used to change
-  a leg in the tail of the {% tooltip label="subject"
-  href="/glossary/subject" /%} then evaluate against it.  This is
-  commonly used for events that need to be ordered in their resolution
-  e.g. with a `%=` {% tooltip label="centis"
-  href="/language/hoon/reference/rune/cen#-centis" /%}.  (Used in {%
-  tooltip label="Gall" href="/glossary/gall" /%} agents frequently.)
-- `=*` {% tooltip label="tistar"
-  href="/language/hoon/reference/rune/tis#-tistar" /%} defers an
+- `=^` [tisket](/language/hoon/reference/rune/tis#-tisket) is used to
+  change a leg in the tail of the [subject](/glossary/subject) then
+  evaluate against it.  This is commonly used for events that need to be
+  ordered in their resolution e.g. with a `%=`
+  [centis](/language/hoon/reference/rune/cen#-centis).  (Used in
+  [Gall](/glossary/gall) agents frequently.)
+- `=*` [tistar](/language/hoon/reference/rune/tis#-tistar) defers an
   expression (rather like a macro).
-- `;<` {% tooltip label="micgal"
-  href="/language/hoon/reference/rune/mic#-micgal" /%} sequences two
+- `;<` [micgal](/language/hoon/reference/rune/mic#-micgal) sequences two
   computations, particularly for an asynchronous event like a remote
-  system call.  (Used in {% tooltip label="threads"
-  href="/glossary/thread" /%}.)
-- `;~` {% tooltip label="micsig"
-  href="/language/hoon/reference/rune/mic#-micsig" /%} produces a
-  pipeline, a way of piping the output of one {% tooltip label="gate"
-  href="/glossary/gate" /%} into another in a chain.  (This is
+  system call.  (Used in [threads](/glossary/thread).)
+- `;~` [micsig](/language/hoon/reference/rune/mic#-micsig) produces a
+  pipeline, a way of piping the output of one [gate](/glossary/gate) into another in a chain.  (This is
   particularly helpful when parsing text.)
 
 ### `++og` Randomness
@@ -608,14 +568,13 @@ it will reproduce the same sequence of numbers.
 While RNGs don't work like our _π_-based example, a given seed will
 reliably produce the same result every time it is run.
 
-The basic RNG core in Hoon is {% tooltip label="++og"
-href="/language/hoon/reference/stdlib/3d#og" /%}.  `++og` is a door
-whose sample is its seed.  We need to use `eny` to seed it
-non-deterministically, but we can also pin the state using `=^` {%
-tooltip label="tisket" href="/language/hoon/reference/rune/tis#-tisket"
-/%}. {% tooltip label="++rads:rng"
-href="/language/hoon/reference/stdlib/3d#radsog" /%} produces a cell of
-a random whole number in a given range and a new modified core to
+The basic RNG core in Hoon is
+[++og](/language/hoon/reference/stdlib/3d#og).  `++og` is a door whose
+sample is its seed.  We need to use `eny` to seed it
+non-deterministically, but we can also pin the state using `=^`
+[tisket](/language/hoon/reference/rune/tis#-tisket).
+[++rads:rng](/language/hoon/reference/stdlib/3d#radsog) produces a cell
+of a random whole number in a given range and a new modified core to
 continue the random sequence.
 
 ```hoon
@@ -626,10 +585,9 @@ continue the random sequence.
 
 Since the `rng` starts from the same seed value every single time, both
 of the numbers will always be the same.  What we have to do is pin the
-updated version of the RNG (the tail of `++rads:og`'s return {% tooltip
-label="cell" href="/glossary/cell" /%}) to the subject using `=^` {%
-tooltip label="tisket" href="/language/hoon/reference/rune/tis#-tisket"
-/%}, e.g.,
+updated version of the RNG (the tail of `++rads:og`'s return
+[cell](/glossary/cell)) to the subject using `=^`
+[tisket](/language/hoon/reference/rune/tis#-tisket), e.g.,
 
 ```hoon
 > =/  rng  ~(. og eny)
@@ -689,12 +647,10 @@ current entropy.  A [random number
 generator](https://en.wikipedia.org/wiki/Random_number_generation) is a
 stateful mathematical function that produces an unpredictable result
 (unless you know the algorithm AND the starting value, or seed).  Here
-we pull the subject of {% tooltip label="++og"
-href="/language/hoon/reference/stdlib/3d#og" /%}, the randomness {%
-tooltip label="core" href="/glossary/core" /%} in Hoon, to start the
-RNG.  An RNG like `++og` maintains its own state, but we will find that
-we have to preserve state changes to continue to produce novel random
-numbers.
+we pull the subject of [++og](/language/hoon/reference/stdlib/3d#og),
+the randomness [core](/glossary/core) in Hoon, to start the RNG.  An RNG
+like `++og` maintains its own state, but we will find that we have to
+preserve state changes to continue to produce novel random numbers.
 
 We slam the `++rad:rng` gate which returns a random number from 0 to
 _n_-1 inclusive.  This gives us a random value from the list of possible
@@ -708,8 +664,8 @@ answers.
 ##  Tutorial:  Dice Roll
 
 Let's look at an example that uses all three parts. Save the code below
-in a file called `dice.hoon` in the `/gen` directory of your
-`%base` {% tooltip label="desk" href="/glossary/desk" /%}.
+in a file called `dice.hoon` in the `/gen` directory of your `%base`
+[desk](/glossary/desk).
 
 ```hoon {% copy=true %}
 :-  %say
@@ -719,14 +675,12 @@ in a file called `dice.hoon` in the `/gen` directory of your
 ```
 
 This is a very simple dice program with an optional betting
-functionality. In the code, our sample specifies {% tooltip
-label="faces" href="/glossary/face" /%} on all of the {% tooltip
-label="Arvo" href="/glossary/arvo" /%} data, meaning that we can easily
+functionality. In the code, our sample specifies [faces](/glossary/face)
+on all of the [Arvo](/glossary/arvo) data, meaning that we can easily
 access them. We also require the argument `[n=@ud ~]`, and allow the
 _optional_ argument `[bet=@ud ~]`.
 
-We can run this {% tooltip label="generator" href="/glossary/generator"
-/%} like so:
+We can run this [generator](/glossary/generator) like so:
 
 ```hoon
 > +dice 6, =bet 2
@@ -751,36 +705,31 @@ ability to choose to not use the second argument.
 
 ##  Scrying (In Brief)
 
-A _peek_ or a {% tooltip label="scry" href="/glossary/scry" /%} is a
-request to Arvo to tell you something about the state of part of the
-Urbit OS.  Scries are used to determine the state of an agent or a vane.
-The `.^` {% tooltip label="dotket"
-href="/language/hoon/reference/rune/dot#-dotket" /%} rune sends the scry
+A _peek_ or a [scry](/glossary/scry) is a request to Arvo to tell you
+something about the state of part of the Urbit OS.  Scries are used to
+determine the state of an agent or a vane. The `.^`
+[dotket](/language/hoon/reference/rune/dot#-dotket) rune sends the scry
 request to a particular vane with a certain _care_ or type of scry.  The
-request is then routed to a particular path in that {% tooltip
-label="vane" href="/glossary/vane" /%}. Scries are discused in detail in
-[App School](/courses/app-school/10-scry).  We will only briefly
-introduce them here as we can use them later to find out about Arvo's
-system state, such as file contents and {% tooltip label="agent"
-href="/glossary/agent" /%} state.
+request is then routed to a particular path in that
+[vane](/glossary/vane). Scries are discused in detail in [App
+School](/courses/app-school/10-scry).  We will only briefly introduce
+them here as we can use them later to find out about Arvo's system
+state, such as file contents and [agent](/glossary/agent) state.
 
 ### `%c` Clay
 
-The {% tooltip label="Clay" href="/glossary/clay" /%} filesystem stores
-nouns persistently at hierarchical path addresses.  These {% tooltip
-label="nouns" href="/glossary/noun" /%} can be accessed using {% tooltip
-label="marks" href="/glossary/mark" /%}, which are rules for structuring
+The [Clay](/glossary/clay) filesystem stores nouns persistently at
+hierarchical path addresses.  These [nouns](/glossary/noun) can be
+accessed using [marks](/glossary/mark), which are rules for structuring
 the data.  We call the nouns “files” and the path addresses “folders”.
 
 If we want to retrieve the contents of a file or folder, we can directly
-ask Clay for the data using a {% tooltip label="scry"
-href="/glossary/scry" /%} with an appropriate {% tooltip label="care"
-href="/system/kernel/clay/reference/data-types#care" /%}.
+ask Clay for the data using a [scry](/glossary/scry) with an appropriate
+[care](/system/kernel/clay/reference/data-types#care).
 
-For instance, the `%x` care to the `%c` Clay {% tooltip label="vane"
-href="/glossary/vane" /%} returns the {% tooltip label="noun"
-href="/glossary/noun" /%} at a given address as a `@` {% tooltip
-label="atom" href="/glossary/atom" /%}.
+For instance, the `%x` care to the `%c` Clay [vane](/glossary/vane)
+returns the [noun](/glossary/noun) at a given address as a `@`
+[atom](/glossary/atom).
 
 ```hoon
 > .^(@ %cx /===/gen/hood/hi/hoon)
@@ -822,9 +771,9 @@ Similarly, you can request the contents at a particular directory path:
 ```
 
 There are many more options with Clay than just accessing file and
-folder data.  For instance, we can also scry all of the {% tooltip
-label="desks" href="/glossary/desk" /%} on our current ship with the
-`%d` care of `%c` Clay:
+folder data.  For instance, we can also scry all of the
+[desks](/glossary/desk) on our current ship with the `%d` care of `%c`
+Clay:
 
 ```hoon
 > .^((set desk) %cd /=//=)

--- a/content/courses/hoon-school/P-stdlib-io.md
+++ b/content/courses/hoon-school/P-stdlib-io.md
@@ -6,36 +6,33 @@ objectives = ["Identify tanks, tangs, wains, walls, and similar formatted printi
 +++
 
 _This module will elaborate on text representation in Hoon, including
-formatted text and `%ask` {% tooltip label="generators"
-href="/glossary/generator" /%}.  It may be considered optional and
-skipped if you are speedrunning Hoon School._
+formatted text and `%ask` [generators](/glossary/generator).  It may be
+considered optional and skipped if you are speedrunning Hoon School._
 
 
 ##  Text Conversions
 
 We frequently need to convert from text to data, and between different
-text-based representations.  Let's examine some specific {% tooltip
-label="arms" href="/glossary/arm" /%}:
+text-based representations.  Let's examine some specific
+[arms](/glossary/arm):
 
 - How do we convert text into all lower-case?
-    - {% tooltip label="++cass" href="/language/hoon/reference/stdlib/4b#cass" /%}
+    - [++cass](/language/hoon/reference/stdlib/4b#cass)
 
-- How do we turn a `cord` into a {% tooltip label="tape"
-  href="/glossary/tape" /%}?
-    - {% tooltip label="++trip" href="/language/hoon/reference/stdlib/4b#trip" /%}
+- How do we turn a `cord` into a [tape](/glossary/tape)?
+    - [++trip](/language/hoon/reference/stdlib/4b#trip)
 
-- How can we make a {% tooltip label="list" href="/glossary/list" /%} of
+- How can we make a [list](/glossary/list) of
   a null-terminated tuple?
-    - {% tooltip label="++le:nl" href="/language/hoon/reference/stdlib/2m#lenl" /%}
+    - [++le:nl](/language/hoon/reference/stdlib/2m#lenl)
 
-- How can we evaluate {% tooltip label="Nock" href="/glossary/nock" /%} expressions?
-    - {% tooltip label="++mink" href="/language/hoon/reference/stdlib/4n#mink" /%}
+- How can we evaluate [Nock](/glossary/nock) expressions?
+    - [++mink](/language/hoon/reference/stdlib/4n#mink)
 
-(If you see a `|*` {% tooltip label="bartar"
-href="/language/hoon/reference/rune/bar#-bartar" /%} rune in the code,
-it's similar to a `|=` {% tooltip label="bartis"
-href="/language/hoon/reference/rune/bar#-bartis" /%}, but produces
-what's called a [_wet gate_](/courses/hoon-school/R-metals).)
+(If you see a `|*` [bartar](/language/hoon/reference/rune/bar#-bartar)
+rune in the code, it's similar to a `|=`
+[bartis](/language/hoon/reference/rune/bar#-bartis), but produces what's
+called a [_wet gate_](/courses/hoon-school/R-metals).)
 
 The `++html` core of the standard libary contains some additional
 important tools for working with web-based data, such as [MIME
@@ -67,11 +64,10 @@ strings](https://en.wikipedia.org/wiki/JSON).
 
 ##  Formatted Text
 
-Hoon produces messages at the {% tooltip label="Dojo"
-href="/glossary/dojo" /%} (or otherwise) using an internal formatted
-text system, called `tank`s.  A `+$tank` is a formatted print tree.
-Error messages and the like are built of `tank`s.  `tank`s are defined
-in `hoon.hoon`:
+Hoon produces messages at the [Dojo](/glossary/dojo) (or otherwise)
+using an internal formatted text system, called `tank`s.  A `+$tank` is
+a formatted print tree. Error messages and the like are built of
+`tank`s.  `tank`s are defined in `hoon.hoon`:
 
 ```hoon
 ::  $tank: formatted print tree
@@ -93,10 +89,8 @@ in `hoon.hoon`:
 +$ tang (list tank) :: bottom-first error
 ```
 
-The {% tooltip label="++ram:re"
-href="/language/hoon/reference/stdlib/4c#ramre" /%} arm is used to
-convert these to actual formatted output as a {% tooltip label="tape"
-href="/glossary/tape" /%}, e.g.
+The [++ram:re](/language/hoon/reference/stdlib/4c#ramre) arm is used to
+convert these to actual formatted output as a [tape](/glossary/tape), e.g.
 
 ```hoon
 > ~(ram re leaf+"foo")
@@ -107,9 +101,8 @@ href="/glossary/tape" /%}, e.g.
 "[foo bar baz]"
 ```
 
-Many {% tooltip label="generators" href="/glossary/generator" /%} build
-sophisticated output using `tank`s and the short-format {% tooltip
-label="cell" href="/glossary/cell" /%} builder `+`, e.g. in
+Many [generators](/glossary/generator) build sophisticated output using
+`tank`s and the short-format [cell](/glossary/cell) builder `+`, e.g. in
 `/gen/azimuth-block/hoon`:
 
 ```hoon {% copy=true %}
@@ -128,9 +121,8 @@ you delve into the Urbit codebase.
 
 #### Tutorial:  Deep Dive into `ls.hoon`
 
-The {% tooltip label="+ls" href="/manual/os/dojo-tools#ls" /%} generator
-shows the contents at a particular path in {% tooltip label="Clay"
-href="/glossary/clay" /%}:
+The [+ls](/manual/os/dojo-tools#ls) generator shows the contents at a
+particular path in [Clay](/glossary/clay):
 
 ```hoon
 > +cat /===/gen/ls/hoon
@@ -175,40 +167,34 @@ A separator `%` is printed.
 :-  %say
 ```
 
-A `%say` {% tooltip label="generator" href="/glossary/generator" /%} is
-a cell with a metadata tag `%say` as the head and the {% tooltip
-label="gate" href="/glossary/gate" /%} as the tail.
+A `%say` [generator](/glossary/generator) is a cell with a metadata tag
+`%say` as the head and the [gate](/glossary/gate) as the tail.
 
 ```hoon
 |=  [^ [arg=path ~] vane=?(%g %c)]
 ```
 
 This generator requires a path argument in its sample and optionally
-accepts a {% tooltip label="vane" href="/glossary/vane" /%} tag (`%g` {%
-tooltip label="Gall" href="/glossary/gall" /%} or `%c` {% tooltip
-label="Clay" href="/glossary/clay" /%}).  Most of the time, {% tooltip
-label="+cat" href="/manual/os/dojo-tools#cat" /%} is used with Clay, so
-`%c` as the last entry in the type union serves as the {% tooltip
-label="bunt" href="/glossary/bunt" /%} value.
+accepts a [vane](/glossary/vane) tag (`%g` [Gall](/glossary/gall) or
+`%c` [Clay](/glossary/clay)).  Most of the time,
+[+cat](/manual/os/dojo-tools#cat) is used with Clay, so `%c` as the last
+entry in the type union serves as the [bunt](/glossary/bunt) value.
 
 ```hoon
 =+  lon=.^(arch (cat 3 vane %y) arg)
 ```
 
-We saw `.^` {% tooltip label="dotket"
-href="/language/hoon/reference/rune/dot#-dotket" /%} for the first time
-in [the previous module](/courses/hoon-school/O-subject), where we
-learned that it performs a _peek_ or {% tooltip label="scry"
-href="/glossary/scry" /%} into the state of an Arvo {% tooltip
-label="vane" href="/glossary/vane" /%}.  Most of the time this
-functionality is used to ask `%c` {% tooltip label="Clay"
-href="/glossary/clay" /%} or `%g` {% tooltip label="Gall"
-href="/glossary/gall" /%} for information about a path, {% tooltip
-label="desk" href="/glossary/desk" /%}, {% tooltip label="agent"
-href="/glossary/agent" /%}, etc.  In this case, `(cat 3 %c %y)` is a
-fancy way of collocating the two `@tas` terms into `%cy`, a Clay file or
-directory lookup.  The type of this lookup is `+$arch`, and the location
-of the file or directory is given by `arg` from the sample.
+We saw `.^` [dotket](/language/hoon/reference/rune/dot#-dotket) for the
+first time in [the previous module](/courses/hoon-school/O-subject),
+where we learned that it performs a _peek_ or [scry](/glossary/scry)
+into the state of an Arvo [vane](/glossary/vane).  Most of the time this
+functionality is used to ask `%c` [Clay](/glossary/clay) or `%g`
+[Gall](/glossary/gall) for information about a path,
+[desk](/glossary/desk), [agent](/glossary/agent), etc.  In this case,
+`(cat 3 %c %y)` is a fancy way of collocating the two `@tas` terms into
+`%cy`, a Clay file or directory lookup.  The type of this lookup is
+`+$arch`, and the location of the file or directory is given by `arg`
+from the sample.
 
 ```hoon
 tang+[?~(dir.lon leaf+"~" (show-dir vane arg dir.lon))]~
@@ -220,9 +206,8 @@ depending on whether the request was `~` null or not.
 
 #### Tutorial:  Deep Dive into `cat.hoon`
 
-For instance, how does {% tooltip label="+cat"
-href="/manual/os/dojo-tools#cat" /%} work?  Let's look at the structure
-of `/gen/cat/hoon`:
+For instance, how does [+cat](/manual/os/dojo-tools#cat) work?  Let's
+look at the structure of `/gen/cat/hoon`:
 
 ```hoon {% copy=true mode="collapse" %}
 ::  ConCATenate file listings
@@ -260,28 +245,23 @@ of `/gen/cat/hoon`:
 ==
 ```
 
-- What is the top-level structure of the {% tooltip label="generator"
-  href="/glossary/generator" /%}?  (A {% tooltip label="cell"
-  href="/glossary/cell" /%} of `%say` and the {% tooltip label="gate"
-  href="/glossary/gate" /%}, what Dojo recognizes as a `%say`
+- What is the top-level structure of the
+  [generator](/glossary/generator)?  (A [cell](/glossary/cell) of `%say`
+  and the [gate](/glossary/gate), what Dojo recognizes as a `%say`
   generator.)
 
 - Some points of interest include:
-  - `/?` faswut pins the expected Arvo {% tooltip label="kelvin version"
-    href="/glossary/kelvin" /%}; right now it doesn't do anything.
-  - `.^` {% tooltip label="dotket"
-    href="/language/hoon/reference/rune/dot#-dotket" /%} loads a value
-    from Arvo (called a {% tooltip label="\"scry\""
-    href="/glossary/scry" /%}).
-  - {% tooltip label="++smyt" href="/language/hoon/reference/stdlib/4m#smyt" /%}
-    pretty-prints a path.
-  - `=-` {% tooltip label="tishep"
-    href="/language/hoon/reference/rune/tis#--tishep" /%} combines a {%
-    tooltip label="faced" href="/glossary/face" /%} noun with the {%
-    tooltip label="subject" href="/glossary/subject" /%}, inverted
-    relative to `=+` {% tooltip label="tislus"
-    href="/language/hoon/reference/rune/tis#-tislus" /%}/`=/` {% tooltip
-    label="tisfas" href="/language/hoon/reference/rune/tis#-tisfas" /%}.
+  - `/?` faswut pins the expected Arvo [kelvin
+    version](/glossary/kelvin); right now it doesn't do anything.
+  - `.^` [dotket](/language/hoon/reference/rune/dot#-dotket) loads a
+    value from Arvo (called a ["scry"](/glossary/scry)).
+  - [++smyt](/language/hoon/reference/stdlib/4m#smyt) pretty-prints a
+    path.
+  - `=-` [tishep](/language/hoon/reference/rune/tis#--tishep) combines a
+    [faced](/glossary/face) noun with the [subject](/glossary/subject),
+    inverted relative to `=+`
+    [tislus](/language/hoon/reference/rune/tis#-tislus)/`=/`
+    [tisfas](/language/hoon/reference/rune/tis#-tisfas).
 
 You can see how much of the generator is concerned with formatting the
 content of the file into a formatted text `tank` by prepending `%rose`
@@ -292,21 +272,20 @@ tags and so forth.
 
 ### Producing Error Messages
 
-Formal error messages in Urbit are built of tanks.  “A `tang` is a {%
-tooltip label="list" href="/glossary/list" /%} of `tank`s, and a `tank`
-is a structure for printing data.  There are three types of `tank`:
-`leaf`, `palm`, and `rose`.  A `leaf` is for printing a single noun, a
-`rose` is for printing rows of data, and a `palm` is for printing
-backstep-indented lists.”
+Formal error messages in Urbit are built of tanks.  “A `tang` is a
+[list](/glossary/list) of `tank`s, and a `tank` is a structure for
+printing data.  There are three types of `tank`: `leaf`, `palm`, and
+`rose`.  A `leaf` is for printing a single noun, a `rose` is for
+printing rows of data, and a `palm` is for printing backstep-indented
+lists.”
 
-One way to include an error message in your code is the `~_` {% tooltip
-label="sigcab" href="/language/hoon/reference/rune/sig#_-sigcab" /%}
-rune, described as a “user-formatted tracing printf”, or the `~|` {%
-tooltip label="sigbar" href="/language/hoon/reference/rune/sig#-sigbar"
-/%} rune, a “tracing printf”.  What this means is that these print to
-the stack trace if something fails, so you can use either {% tooltip
-label="rune" href="/glossary/rune" /%} to contribute to the error
-description:
+One way to include an error message in your code is the `~_`
+[sigcab](/language/hoon/reference/rune/sig#_-sigcab) rune, described as
+a “user-formatted tracing printf”, or the `~|`
+[sigbar](/language/hoon/reference/rune/sig#-sigbar) rune, a “tracing
+printf”.  What this means is that these print to the stack trace if
+something fails, so you can use either [rune](/glossary/rune) to
+contribute to the error description:
 
 ```hoon {% copy=true %}
 |=  a=@ud
@@ -320,11 +299,11 @@ messages for likely failure points.
 
 ##  `%ask` Generators
 
-Previously, we introduced the concept of a `%say` {% tooltip
-label="generator" href="/glossary/generator" /%} to produce a more
-versatile form of standalone single computation than a simple naked
-generator ({% tooltip label="gate" href="/glossary/gate" /%}) allowed.
-Another elaboration, the `%ask` generator, takes things further.
+Previously, we introduced the concept of a `%say`
+[generator](/glossary/generator) to produce a more versatile form of
+standalone single computation than a simple naked generator
+([gate](/glossary/gate)) allowed. Another elaboration, the `%ask`
+generator, takes things further.
 
 We use an `%ask` generator when we want to create an interactive program
 that prompts for inputs as it runs, rather than expecting arguments to
@@ -340,12 +319,10 @@ of relevant input/output issues.
 
 ##### Tutorial:  `%ask` Generator
 
-The code below is an `%ask` {% tooltip label="generator"
-href="/glossary/generator" /%} that checks if the user inputs `"blue"`
-when prompted [per a classic Monty Python
+The code below is an `%ask` [generator](/glossary/generator) that checks
+if the user inputs `"blue"` when prompted [per a classic Monty Python
 scene](https://www.youtube.com/watch?v=L0vlQHxJTp0).  Save it as
-`/gen/axe.hoon` in your `%base` {% tooltip label="desk"
-href="/glossary/desk" /%}.
+`/gen/axe.hoon` in your `%base` [desk](/glossary/desk).
 
 ```hoon {% copy=true mode="collapse" %}
 /-  sole
@@ -367,8 +344,7 @@ href="/glossary/desk" /%}.
 ==
 ```
 
-Run the generator from the {% tooltip label="Dojo" href="/glossary/dojo"
-/%}:
+Run the generator from the [Dojo](/glossary/dojo):
 
 ```hoon
 > +axe
@@ -396,20 +372,17 @@ Let's go over what exactly is happening in this code.
 ```
 
 Here we bring in some of the types we are going to need from `/sur/sole`
-and gates we will use from `/lib/generators`. We use some special {%
-tooltip label="runes" href="/glossary/rune" /%} for this.
+and gates we will use from `/lib/generators`. We use some special
+[runes](/glossary/rune) for this.
 
-- `/-` {% tooltip label="fashep"
-  href="/language/hoon/reference/rune/fas#--fashep" /%} is a Ford rune
+- `/-` [fashep](/language/hoon/reference/rune/fas#--fashep) is a Ford rune
   used to import types from `/sur`.
-- `/+` {% tooltip label="faslus"
-  href="/language/hoon/reference/rune/fas#-faslus" /%} is a Ford rune
+- `/+` [faslus](/language/hoon/reference/rune/fas#-faslus) is a Ford rune
   used to import libraries from `/lib`.
-- `=,` {% tooltip label="tiscom"
-  href="/language/hoon/reference/rune/tis#-tiscol" /%} is a rune that
-  allows us to expose a namespace. We do this to avoid having to write
-  `sole-result:sole` instead of `sole-result` or `print:generators`
-  instead of `print`.
+- `=,` [tiscom](/language/hoon/reference/rune/tis#-tiscol) is a rune
+  that allows us to expose a namespace. We do this to avoid having to
+  write `sole-result:sole` instead of `sole-result` or
+  `print:generators` instead of `print`.
 
 ```hoon
 :-  %ask
@@ -420,29 +393,26 @@ This code might be familiar. Just as with their `%say` cousins, `%ask`
 generators need to produce a `cell`, the head of which specifies what
 kind of generator we are running.
 
-With `|= *`, we create a {% tooltip label="gate" href="/glossary/gate"
-/%} and ignore the standard arguments we are given, because we're not
-using them.
+With `|= *`, we create a [gate](/glossary/gate) and ignore the standard
+arguments we are given, because we're not using them.
 
 ```hoon
 ^-  (sole-result (cask tang))
 ```
 
-`%ask` {% tooltip label="generators" href="/glossary/generator" /%} need
-to have the second half of the {% tooltip label="cell"
-href="/glossary/cell" /%} be a gate that produces a `sole-result`, one
-that in this case contains a `cask` of `tang`.  We use the `^-` {%
-tooltip label="kethep" href="/language/hoon/reference/rune/ket#--kethep"
-/%} rune to constrain the generator's output to such a `sole-result`.
+`%ask` [generators](/glossary/generator) need to have the second half of
+the [cell](/glossary/cell) be a gate that produces a `sole-result`, one
+that in this case contains a `cask` of `tang`.  We use the `^-`
+[kethep](/language/hoon/reference/rune/ket#--kethep) rune to constrain
+the generator's output to such a `sole-result`.
 
-A `cask` is a pair of a {% tooltip label="mark" href="/glossary/mark"
-/%} name and a {% tooltip label="noun" href="/glossary/noun" /%}.  We
-previously described a `mark` as a kind of complicated {% tooltip
-label="mold" href="/glossary/mold" /%}; here we add that a `mark` can be
+A `cask` is a pair of a [mark](/glossary/mark) name and a
+[noun](/glossary/noun).  We previously described a `mark` as a kind of
+complicated [mold](/glossary/mold); here we add that a `mark` can be
 thought of as an Arvo-level [MIME](https://en.wikipedia.org/wiki/MIME)
 type for data.
 
-A `tang` is a {% tooltip label="list" href="/glossary/list" /%} of
+A `tang` is a [list](/glossary/list) of
 `tank`, and a `tank` is a structure for printing data, as described
 above.  There are three types of `tank`: `leaf`, `palm`, and `rose`.  A
 `leaf` is for printing a single noun, a `rose` is for printing rows of
@@ -455,14 +425,14 @@ data, and a `palm` is for printing backstep-indented lists.
 %+  produce  %tang
 ```
 
-Because we imported {% tooltip label="generators"
-href="/glossary/generator" /%}, we can access its contained gates, three
-of which we use in `axe.hoon`: `++print`, `++prompt`, and `++produce`.
+Because we imported [generators](/glossary/generator), we can access its
+contained gates, three of which we use in `axe.hoon`: `++print`,
+`++prompt`, and `++produce`.
 
 - `print` is used for printing a `tank` to the console.
 
-    In our example, `%+` {% tooltip label="cenlus"
-    href="/language/hoon/reference/rune/cen#-cenlus" /%} is used to call
+    In our example, `%+`
+    [cenlus](/language/hoon/reference/rune/cen#-cenlus) is used to call
     the gate `++print`, with two arguments. The first argument is a
     `tank` to print.  The `+` here is syntactic sugar for `[%leaf "What
     is your favorite color?"]` that just makes it easier to write. The
@@ -482,9 +452,9 @@ of which we use in `axe.hoon`: `++print`, `++prompt`, and `++produce`.
     information for use in creating autocomplete options for the prompt.
     This functionality is not yet implemented.
 
-    The third element of the `++prompt` sample is the {% tooltip
-    label="tape" href="/glossary/tape" /%} that we would like to use to
-    prompt the user. In the case of our example, we use `"color: "`.
+    The third element of the `++prompt` sample is the
+    [tape](/glossary/tape) that we would like to use to prompt the user.
+    In the case of our example, we use `"color: "`.
 
 - `produce` is used to construct the output of the generator. In our
   example, we produce a `tang`.
@@ -504,5 +474,5 @@ reverse order from how it is created.  The reason for this is that
 `tang` was originally created to display stack trace information, which
 should be produced in reverse order.  This leads to an annoyance: we
 either have to specify our messages backwards or construct them in the
-order we want and then {% tooltip label="++flop"
-href="/language/hoon/reference/stdlib/2b#flop" /%} the `list`.
+order we want and then [++flop](/language/hoon/reference/stdlib/2b#flop)
+the `list`.

--- a/content/courses/hoon-school/Q-func.md
+++ b/content/courses/hoon-school/Q-func.md
@@ -9,7 +9,7 @@ _This module will discuss some gates-that-work-on-gates and other
 assorted operators that are commonly recognized as functional
 programming tools._
 
-Given a {% tooltip label="gate" href="/glossary/gate" /%}, you can
+Given a [gate](/glossary/gate), you can
 manipulate it to accept a different number of values than its sample
 formally requires, or otherwise modify its behavior.  These techniques
 mirror some of the common tasks used in other [functional programming
@@ -22,16 +22,14 @@ behavior.  It works as a formal system of symbolic expressions
 manipulated according to given rules and properties.  FP was derived
 from the [lambda
 calculus](https://en.wikipedia.org/wiki/Lambda_calculus), a cousin of
-combinator calculi like {% tooltip label="Nock" href="/glossary/nock"
-/%}.  (See also
+combinator calculi like [Nock](/glossary/nock).  (See also
 [APL](https://en.wikipedia.org/wiki/APL_%28programming_language%29).)
 
 ##  Changing Arity
 
 If a gate accepts only two values in its sample, for instance, you can
-chain together multiple calls automatically using the `;:` {% tooltip
-label="miccol" href="/language/hoon/reference/rune/mic#-miccol" /%}
-rune.
+chain together multiple calls automatically using the `;:`
+[miccol](/language/hoon/reference/rune/mic#-miccol) rune.
 
 ```hoon
 > (add 3 (add 4 5))
@@ -49,8 +47,7 @@ rune.
 
 This is called changing the
 [_arity_](https://en.wikipedia.org/wiki/Arity) of the gate.  (Does this
-work on {% tooltip label="++mul:rs"
-href="/language/hoon/reference/stdlib/3b#mulrs" /%}?)
+work on [++mul:rs](/language/hoon/reference/stdlib/3b#mulrs)?)
 
 
 ##  Binding the Sample
@@ -60,12 +57,11 @@ function of multiple arguments and reducing it to a set of functions
 that each take only one argument.  _Binding_, an allied process, is used
 to set the value of some of those arguments permanently.
 
-If you have a {% tooltip label="gate" href="/glossary/gate" /%} which
-accepts multiple values in the {% tooltip label="sample"
-href="/glossary/sample" /%}, you can fix one of these.  To fix the head
-of the sample (the first argument), use {% tooltip label="++cury"
-href="/language/hoon/reference/stdlib/2n#cury" /%}; to bind the tail,
-use [`++curr`](/language/hoon/reference/stdlib/2n#curr).
+If you have a [gate](/glossary/gate) which accepts multiple values in
+the [sample](/glossary/sample), you can fix one of these.  To fix the
+head of the sample (the first argument), use
+[++cury](/language/hoon/reference/stdlib/2n#cury); to bind the tail, use
+[`++curr`](/language/hoon/reference/stdlib/2n#curr).
 
 Consider calculating _a x² + b x + c_, a situation we earlier resolved
 using a door.  We can resolve the situation differently using currying:
@@ -82,13 +78,11 @@ using a door.  We can resolve the situation differently using currying:
 117
 ```
 
-One can also {% tooltip label="++cork"
-href="/language/hoon/reference/stdlib/2n#cork" /%} a gate, or arrange it
-such that it applies to the result of the next gate.  This pairs well
-with `;:` {% tooltip label="miccol"
-href="/language/hoon/reference/rune/mic#-miccol" /%}.  (There is
-also {% tooltip label="++corl"
-href="/language/hoon/reference/stdlib/2n#corl" /%}, which composes
+One can also [++cork](/language/hoon/reference/stdlib/2n#cork) a gate,
+or arrange it such that it applies to the result of the next gate.  This
+pairs well with `;:`
+[miccol](/language/hoon/reference/rune/mic#-miccol).  (There is also
+[++corl](/language/hoon/reference/stdlib/2n#corl), which composes
 backwards rather than forwards.) This example decrements a value then
 converts it to `@ux` by corking two gates:
 
@@ -100,31 +94,26 @@ converts it to `@ux` by corking two gates:
 ### Exercise:  Bind Gate Arguments
 
 - Create a gate `++inc` which increments a value in one step, analogous
-  to {% tooltip label="++dec"
-  href="/language/hoon/reference/stdlib/1a#dec" /%}.
+  to [++dec](/language/hoon/reference/stdlib/1a#dec).
 
 ### Exercise:  Chain Gate Values
 
-- Write an expression which yields the parent {% tooltip label="galaxy"
-  href="/glossary/galaxy" /%} of a {% tooltip label="planet's"
-  href="/glossary/planet" /%} sponsoring {% tooltip label="star"
-  href="/glossary/star" /%} by composing two gates.
+- Write an expression which yields the parent [galaxy](/glossary/galaxy)
+  of a [planet's](/glossary/planet) sponsoring [star](/glossary/star) by
+  composing two gates.
 
 ##  Working Across `list`s
 
-The {% tooltip label="++turn"
-href="/language/hoon/reference/stdlib/2b#turn" /%} function takes a list
-and a {% tooltip label="gate" href="/glossary/gate" /%}, and returns a
+The [++turn](/language/hoon/reference/stdlib/2b#turn) function takes a list
+and a [gate](/glossary/gate), and returns a
 list of the products of applying each item of the input list to the
-gate. For example, to add 1 to each item in a list of {% tooltip
-label="atoms" href="/glossary/atom" /%}:
+gate. For example, to add 1 to each item in a list of [atoms](/glossary/atom):
 
 ```hoon
 > (turn `(list @)`~[11 22 33 44] |=(a=@ +(a)))
 ~[12 23 34 45]
 ```
-Or to double each item in a {% tooltip label="list"
-href="/glossary/list" /%} of atoms:
+Or to double each item in a [list](/glossary/list) of atoms:
 
 ```hoon
 > (turn `(list @)`~[11 22 33 44] |=(a=@ (mul 2 a)))
@@ -152,12 +141,11 @@ We can rewrite the Caesar cipher program using turn:
 c
 ```
 
-{% tooltip label="++roll" href="/language/hoon/reference/stdlib/2b#roll" /%} and
-{% tooltip label="++reel" href="/language/hoon/reference/stdlib/2b#reel" /%} are used to
-left-fold and right-fold a {% tooltip label="list" href="/glossary/list"
-/%}, respectively.  To fold a list is similar to {% tooltip
-label="++turn" href="/language/hoon/reference/stdlib/2b#turn" /%},
-except that instead of yielding a `list` with the values having had each
+[++roll](/language/hoon/reference/stdlib/2b#roll) and
+[++reel](/language/hoon/reference/stdlib/2b#reel) are used to left-fold
+and right-fold a [list](/glossary/list), respectively.  To fold a list
+is similar to [++turn](/language/hoon/reference/stdlib/2b#turn), except
+that instead of yielding a `list` with the values having had each
 applied, `++roll` and `++reel` produce an accumulated value.
 
 ```hoon
@@ -170,8 +158,7 @@ applied, `++roll` and `++reel` produce an accumulated value.
 
 ### Exercise:  Calculate a Factorial
 
-- Use `++reel` to produce a {% tooltip label="gate"
-  href="/glossary/gate" /%} which calculates the factorial of a number.
+- Use `++reel` to produce a [gate](/glossary/gate) which calculates the factorial of a number.
 
 
 ##  Classic Operations
@@ -183,37 +170,32 @@ produce operations on collections of data:
    a set or iterable object, resulting in the same final number of items
    transformed.  In Hoon terms, we would say slamming a gate on each
    member of a `list` or `set`.  The standard library arms that
-   accomplish this include {% tooltip label="++turn"
-   href="/language/hoon/reference/stdlib/2b#turn" /%} for a {% tooltip
-   label="list" href="/glossary/list" /%}, {% tooltip label="++run:in"
-   href="/language/hoon/reference/stdlib/2h#repin" /%} for a {% tooltip
-   label="set" href="/language/hoon/reference/stdlib/2o#set" /%}, and {%
-   tooltip label="++run:by"
-   href="/language/hoon/reference/stdlib/2i#runby" /%} for a {% tooltip
-   label="map" href="/language/hoon/reference/stdlib/2o#map" /%}.
+   accomplish this include
+   [++turn](/language/hoon/reference/stdlib/2b#turn) for a
+   [list](/glossary/list),
+   [++run:in](/language/hoon/reference/stdlib/2h#repin) for a
+   [set](/language/hoon/reference/stdlib/2o#set), and
+   [++run:by](/language/hoon/reference/stdlib/2i#runby) for a
+   [map](/language/hoon/reference/stdlib/2o#map).
 
 2. Reduce.  The Reduce operation applies a function as a sequence of
    pairwise operations to each item, resulting in one summary value. The
-   standard library {% tooltip label="arms" href="/glossary/arm" /} that
-   accomplish this are {% tooltip label="++roll"
-   href="/language/hoon/reference/stdlib/2b#roll" /%} and {% tooltip
-   label="++reel" href="/language/hoon/reference/stdlib/2b#reel" /%} for
-   a {% tooltip label="list" href="/glossary/list" /%}, {% tooltip
-   label="++rep:in" href="/language/hoon/reference/stdlib/2h#repin" /%}
-   for a {% tooltip label="set"
-   href="/language/hoon/reference/stdlib/2o#set" /%}, and {% tooltip
-   label="++rep:by" href="/language/hoon/reference/stdlib/2i#repby" /%}
-   for a {% tooltip label="map"
-   href="/language/hoon/reference/stdlib/2o#map" /%}.
+   standard library [arms](/glossary/arm) that accomplish this are
+   [++roll](/language/hoon/reference/stdlib/2b#roll) and
+   [++reel](/language/hoon/reference/stdlib/2b#reel) for a
+   [list](/glossary/list),
+   [++rep:in](/language/hoon/reference/stdlib/2h#repin) for a
+   [set](/language/hoon/reference/stdlib/2o#set), and
+   [++rep:by](/language/hoon/reference/stdlib/2i#repby) for a
+   [map](/language/hoon/reference/stdlib/2o#map).
 
 3. Filter.  The Filter operation applies a true/false function to each
    member of a collection, resulting in some number of items equal to or
    fewer than the size of the original set.  In Hoon, the library arms
-   that carry this out include {% tooltip label="++skim"
-   href="/language/hoon/reference/stdlib/2b#skim" /%}, {% tooltip
-   label="++skid" href="/language/hoon/reference/stdlib/2b#skid" /%}, {%
-   tooltip label="++murn" href="/language/hoon/reference/stdlib/2b#murn"
-   /%} for a {% tooltip label="list" href="/glossary/list" /%}, and {%
-   tooltip label="++rib:by"
-   href="/language/hoon/reference/stdlib/2i#ribby" /%} for a {% tooltip
-   label="map" href="/language/hoon/reference/stdlib/2o#map" /%}.
+   that carry this out include
+   [++skim](/language/hoon/reference/stdlib/2b#skim),
+   [++skid](/language/hoon/reference/stdlib/2b#skid),
+   [++murn](/language/hoon/reference/stdlib/2b#murn) for a
+   [list](/glossary/list), and
+   [++rib:by](/language/hoon/reference/stdlib/2i#ribby) for a
+   [map](/language/hoon/reference/stdlib/2o#map).

--- a/content/courses/hoon-school/Q2-parsing.md
+++ b/content/courses/hoon-school/Q2-parsing.md
@@ -8,9 +8,9 @@ objectives = ["Tokenize text simply using `find` and `trim`.", "Identify element
 _This module covers text parsing.  It may be considered optional and
 skipped if you are speedrunning Hoon School._
 
-We need to build a tool to accept a {% tooltip label="tape"
-href="/glossary/tape" /%} containing some characters, then turn it into
-something else, something computational.
+We need to build a tool to accept a [tape](/glossary/tape) containing
+some characters, then turn it into something else, something
+computational.
 
 For instance, a calculator could accept an input like `3+4` and return
 `7`.  A command-line interface may look for a program to evaluate (like
@@ -27,16 +27,15 @@ The basic problem all parsers face is this:
 
 ## The Hoon Parser
 
-We could build a simple parser out of a {% tooltip label="trap"
-href="/glossary/trap" /%} and {% tooltip label="++snag"
-href="/language/hoon/reference/stdlib/2b#snag" /%}, but it would be
+We could build a simple parser out of a [trap](/glossary/trap) and
+[++snag](/language/hoon/reference/stdlib/2b#snag), but it would be
 brittle and difficult to extend.  The Hoon parser is very sophisticated,
 since it has to take a file of ASCII characters (and some UTF-8 strings)
-and turn it via an AST into {% tooltip label="Nock"
-href="/glossary/nock" /%} code.  What makes parsing challenging is that
-we have to wade directly into a sea of new types and processes.  To wit:
+and turn it via an AST into [Nock](/glossary/nock) code.  What makes
+parsing challenging is that we have to wade directly into a sea of new
+types and processes.  To wit:
 
--   A {% tooltip label="tape" href="/glossary/tape" /%} is the string to
+-   A [tape](/glossary/tape) is the string to
     be parsed.
 -   A `hair` is the position in the text the parser is at, as a cell of
     column & line, `[p=@ud q=@ud]`.
@@ -60,12 +59,12 @@ goes into more detail than this quick overview.
 
 ## Scanning Through a `tape`
 
-{% tooltip label="++scan" href="/language/hoon/reference/stdlib/4g#scan" /%} parses
-a `tape` or crashes, simple enough.  It will be our workhorse.  All we
-really need to know in order to use it is how to build a `rule`.
+[++scan](/language/hoon/reference/stdlib/4g#scan) parses a `tape` or
+crashes, simple enough.  It will be our workhorse.  All we really need
+to know in order to use it is how to build a `rule`.
 
-Here we will preview using {% tooltip label="++shim"
-href="/language/hoon/reference/stdlib/4f#shim" /%} to match characters
+Here we will preview using
+[++shim](/language/hoon/reference/stdlib/4f#shim) to match characters
 with in a given range, here lower-case.  If you change the character
 range, e.g. putting `' '` in the `++shim` will span from ASCII `32`, `'
 '` to ASCII `122`, `'z'`.
@@ -87,7 +86,7 @@ together to achieve the desired effect.
 
 ### `rule`s to parse fixed strings
 
-- {% tooltip label="++just" href="/language/hoon/reference/stdlib/4f#just" /%} takes
+- [++just](/language/hoon/reference/stdlib/4f#just) takes
   in a single `char` and produces a `rule` that attempts to match that
   `char` to the first character in the `tape` of the input `nail`.
 
@@ -96,7 +95,7 @@ together to achieve the desired effect.
     [p=[p=1 q=2] q=[~ [p='a' q=[p=[p=1 q=2] q="bc"]]]]
     ```
 
-- {% tooltip label="++jest" href="/language/hoon/reference/stdlib/4f#jest" /%} matches
+- [++jest](/language/hoon/reference/stdlib/4f#jest) matches
   a `cord`. It takes an input `cord` and produces a `rule` that
   attempts to match that `cord` against the beginning of the input.
 
@@ -113,16 +112,16 @@ together to achieve the desired effect.
 
     (Keep an eye on the structure of the return `edge` there.)
 
-- {% tooltip label="++shim" href="/language/hoon/reference/stdlib/4f#shim" /%} parses
-  characters within a given range. It takes in two atoms and returns a `rule`.
+- [++shim](/language/hoon/reference/stdlib/4f#shim) parses characters
+  within a given range. It takes in two atoms and returns a `rule`.
 
     ```hoon
     > ((shim 'a' 'z') [[1 1] "abc"])
     [p=[p=1 q=2] q=[~ [p='a' q=[p=[p=1 q=2] q="bc"]]]]
     ```
 
-- {% tooltip label="++next" href="/language/hoon/reference/stdlib/4f#next" /%} is
-  a simple `rule` that takes in the next character and returns it as the parsing result.
+- [++next](/language/hoon/reference/stdlib/4f#next) is a simple `rule`
+  that takes in the next character and returns it as the parsing result.
 
     ```hoon
     > (next [[1 1] "abc"])
@@ -132,9 +131,8 @@ together to achieve the desired effect.
 ### `rule`s to parse flexible strings
 
 So far we can only parse one character at a time, which isn't much
-better than just using {% tooltip label="++snag"
-href="/language/hoon/reference/stdlib/2b#snag" /%} in a {% tooltip
-label="trap" href="/glossary/trap" /%}.
+better than just using [++snag](/language/hoon/reference/stdlib/2b#snag)
+in a [trap](/glossary/trap).
 
 ```hoon
 > (scan "a" (shim 'a' 'z'))  
@@ -149,8 +147,8 @@ dojo: hoon expression failed
 How do we parse multiple characters in order to break things up
 sensibly?
 
-- {% tooltip label="++star" href="/language/hoon/reference/stdlib/4f#star" /%} will
-  match a multi-character list of values.
+- [++star](/language/hoon/reference/stdlib/4f#star) will match a
+  multi-character list of values.
 
     ```hoon
     > (scan "a" (just 'a'))
@@ -165,18 +163,17 @@ sensibly?
     "aaaaa"
     ```
 
-- {% tooltip label="++plug" href="/language/hoon/reference/stdlib/4e#plug" /%} takes
-  the `nail` in the `edge` produced by one rule and passes it to the
-  next `rule`, forming a {% tooltip label="cell" href="/glossary/cell"
-  /%} of the results as it proceeds.
+- [++plug](/language/hoon/reference/stdlib/4e#plug) takes the `nail` in
+  the `edge` produced by one rule and passes it to the next `rule`,
+  forming a [cell](/glossary/cell) of the results as it proceeds.
 
     ```hoon
     > (scan "starship" ;~(plug (jest 'star') (jest 'ship')))
     ['star' 'ship']
     ```
 
-- {% tooltip label="++pose" href="/language/hoon/reference/stdlib/4e#pose" /%} tries
-    each `rule` you hand it successively until it finds one that works.
+- [++pose](/language/hoon/reference/stdlib/4e#pose) tries each `rule`
+  you hand it successively until it finds one that works.
 
     ```hoon
     > (scan "a" ;~(pose (just 'a') (just 'b')))
@@ -189,14 +186,13 @@ sensibly?
     [p=[p=1 q=2] q=[~ u=[p='a' q=[p=[p=1 q=2] q=[i='b' t=""]]]]]
     ```
 
-- {% tooltip label="++glue" href="/language/hoon/reference/stdlib/4e#glue" /%} parses
-  a delimiter (a `rule`) in between each `rule` and forms a {% tooltip
-  label="cell" href="/glossary/cell" /%} of the results of each
-  non-delimiter `rule`.  Delimiters representing each symbol used in
-  Hoon are named according to their [aural ASCII](/glossary/aural-ascii)
-  pronunciation. Sets of characters can also be used as delimiters, such
-  as `prn` for printable characters ([more
-  here](/language/hoon/reference/stdlib/4i)).
+- [++glue](/language/hoon/reference/stdlib/4e#glue) parses a delimiter
+  (a `rule`) in between each `rule` and forms a [cell](/glossary/cell)
+  of the results of each non-delimiter `rule`.  Delimiters representing
+  each symbol used in Hoon are named according to their [aural
+  ASCII](/glossary/aural-ascii) pronunciation. Sets of characters can
+  also be used as delimiters, such as `prn` for printable characters
+  ([more here](/language/hoon/reference/stdlib/4i)).
 
     ```hoon
     > (scan "a b" ;~((glue ace) (just 'a') (just 'b')))  
@@ -213,9 +209,8 @@ sensibly?
     ['a' 'b' 'a']
     ```
 
-- The `;~` {% tooltip label="micsig"
-  href="/language/hoon/reference/rune/mic#-micsig" /%} will create
-  `;~(combinator (list rule))` to use multiple `rule`s.
+- The `;~` [micsig](/language/hoon/reference/rune/mic#-micsig) will
+  create `;~(combinator (list rule))` to use multiple `rule`s.
 
     ```hoon
     > (scan "after the" ;~((glue ace) (star (shim 'a' 'z')) (star (shim 'a' 'z'))))  
@@ -234,13 +229,12 @@ sensibly?
     -->
 
 At this point we have two problems:  we are just getting raw `@t` atoms
-back, and we can't iteratively process arbitrarily long strings. {%
-tooltip label="++cook" href="/language/hoon/reference/stdlib/4f#cook"
-/%} will help us with the first of these:
+back, and we can't iteratively process arbitrarily long strings.
+[++cook](/language/hoon/reference/stdlib/4f#cook) will help us with the
+first of these:
 
-- {% tooltip label="++cook" href="/language/hoon/reference/stdlib/4f#cook" /%} will
-  take a `rule` and a {% tooltip label="gate" href="/glossary/gate" /%}
-  to apply to the successful parse.
+- [++cook](/language/hoon/reference/stdlib/4f#cook) will take a `rule`
+  and a [gate](/glossary/gate) to apply to the successful parse.
 
     ```hoon
     > ((cook ,@ud (just 'a')) [[1 1] "abc"])
@@ -256,12 +250,11 @@ tooltip label="++cook" href="/language/hoon/reference/stdlib/4f#cook"
     [p=[p=1 q=2] q=[~ u=[p='b' q=[p=[p=1 q=2] q="bc"]]]]
     ```
 
-However, to parse iteratively, we need to use the {% tooltip
-label="++knee" href="/language/hoon/reference/stdlib/4f#knee" /%}
-function, which takes a noun as the {% tooltip label="bunt"
-href="/glossary/bunt" /%} of the type the `rule` produces, and produces
-a `rule` that recurses properly.  (You'll probably want to treat this as
-a recipe for now and just copy it when necessary.)
+However, to parse iteratively, we need to use the
+[++knee](/language/hoon/reference/stdlib/4f#knee) function, which takes
+a noun as the [bunt](/glossary/bunt) of the type the `rule` produces,
+and produces a `rule` that recurses properly.  (You'll probably want to
+treat this as a recipe for now and just copy it when necessary.)
 
 ```hoon {% copy=true %}
 |-(;~(plug prn ;~(pose (knee *tape |.(^$)) (easy ~))))
@@ -269,22 +262,22 @@ a recipe for now and just copy it when necessary.)
 
 There is an example of a calculator [in the parsing
 guide](/language/hoon/guides/parsing#recursive-parsers) that's worth a
-read at this point.  It uses {% tooltip label="++knee"
-href="/language/hoon/reference/stdlib/4f#knee" /%} to scan in a set of numbers
-at a time.
+read at this point.  It uses
+[++knee](/language/hoon/reference/stdlib/4f#knee) to scan in a set of
+numbers at a time.
 
 ### Example:  Parse a String of Numbers
 
-A simple {% tooltip label="++shim"
-href="/language/hoon/reference/stdlib/4f#shim" /%}-based parser:
+A simple [++shim](/language/hoon/reference/stdlib/4f#shim)-based parser:
 
 ```hoon
 > (scan "1234567890" (star (shim '0' '9')))  
 [i='1' t=<|2 3 4 5 6 7 8 9 0|>]
 ```
 
-A refined {% tooltip label="++cook"
-href="/language/hoon/reference/stdlib/4f#cook" /%}/{% tooltip label="++cury" href="/language/hoon/reference/stdlib/2n#cury" /%}/{% tooltip label="++jest" href="/language/hoon/reference/stdlib/4f#jest" /%} parser:
+A refined
+[++cook](/language/hoon/reference/stdlib/4f#cook)/[++cury](/language/hoon/reference/stdlib/2n#cury)/[++jest](/language/hoon/reference/stdlib/4f#jest)
+parser:
 
 ```hoon
 > ((cook (cury slaw %ud) (jest '1')) [[1 1] "123"])  

--- a/content/courses/hoon-school/R-metals.md
+++ b/content/courses/hoon-school/R-metals.md
@@ -5,19 +5,17 @@ nodes = [288, 299]
 objectives = ["Distinguish dry and wet cores.", "Describe use cases for wet gates (using genericity).", "Enumerate and distinguish use cases for dry cores (using variance):", "- Covariant (`%zinc`)", "- Contravariant (`%iron`)", "- Bivariant (`%lead`)", "- Invariant (`%gold`)"]
 +++
 
-_This module introduces how {% tooltip label="cores"
-href="/glossary/core" /%} can be extended for different behavioral
-patterns.  It may be considered optional and skipped if you are
-speedrunning Hoon School._
+_This module introduces how [cores](/glossary/core) can be extended for
+different behavioral patterns.  It may be considered optional and
+skipped if you are speedrunning Hoon School._
 
 Cores can expose and operate with many different assumptions about their
 inputs and structure.  `[battery payload]` describes the top-level
 structure of a core, but within that we already know other requirements
-can be enforced, like `[battery [sample context]]` for a {% tooltip
-label="gate" href="/glossary/gate" /%}, or no `sample` for a {% tooltip
-label="trap" href="/glossary/trap" /%}.  Cores can also expose and
-operate on their input values with different relationships.  This lesson
-is concerned with examining
+can be enforced, like `[battery [sample context]]` for a
+[gate](/glossary/gate), or no `sample` for a [trap](/glossary/trap).
+Cores can also expose and operate on their input values with different
+relationships.  This lesson is concerned with examining
 [_genericity_](https://en.wikipedia.org/wiki/Generic_programming)
 including certain kinds of [parametric
 polymorphism](https://en.wikipedia.org/wiki/Parametric_polymorphism),
@@ -29,19 +27,16 @@ If cores never changed, we wouldn't need polymorphism.  Of course, nouns
 are immutable and never change, but we use them as templates to
 construct new nouns around.
 
-Suppose we take a core, a {% tooltip label="cell" href="/glossary/cell"
-/%} `[battery payload]`, and replace `payload` with a different {%
-tooltip label="noun" href="/glossary/noun" /%}. Then, we invoke an {%
-tooltip label="arm" href="/glossary/arm" /%} from the {% tooltip
-label="battery" href="/glossary/battery" /%}.
+Suppose we take a core, a [cell](/glossary/cell) `[battery payload]`,
+and replace `payload` with a different [noun](/glossary/noun). Then, we
+invoke an [arm](/glossary/arm) from the [battery](/glossary/battery).
 
 Is this legal?  Does it make sense?  Every function call in Hoon does
 this, so we'd better make it work well.
 
-The full core stores _both_ {% tooltip label="payload"
-href="/glossary/payload" /%} types:  the type that describes the
-`payload` currently in the {% tooltip label="core" href="/glossary/core"
-/%}, and the type that the core was compiled with.
+The full core stores _both_ [payload](/glossary/payload) types:  the
+type that describes the `payload` currently in the
+[core](/glossary/core), and the type that the core was compiled with.
 
 In the [Bertrand Meyer tradition of type
 theory](https://en.wikipedia.org/wiki/Object-Oriented_Software_Construction),
@@ -53,9 +48,8 @@ genericity.
 This lesson discusses both genericity and variance for core management.
 These two sections may be read separately or in either order, and all of
 this content is not a requirement for working extensively with Gall
-agents.  If you're just starting off, {% tooltip label="wet gates"
-href="/glossary/wet-gate" /%} (genericity) make the most sense to have
-in your toolkit now.
+agents.  If you're just starting off, [wet gates](/glossary/wet-gate)
+(genericity) make the most sense to have in your toolkit now.
 
 
 ##  Genericity
@@ -68,77 +62,68 @@ and Hoon is no exception.
 ### Dry Cores
 
 A dry gate is the kind of gate that you're already familiar with:  a
-one-armed {% tooltip label="core" href="/glossary/core" /%} with a
-sample.  A {% tooltip label="wet gate" href="/glossary/wet-gate" /%} is
-also a one-armed core with a {% tooltip label="sample"
-href="/glossary/sample" /%}, but there is a difference in how types are
+one-armed [core](/glossary/core) with a sample.  A [wet
+gate](/glossary/wet-gate) is also a one-armed core with a
+[sample](/glossary/sample), but there is a difference in how types are
 handled.  With a dry gate, when you pass in an argument and the code
 gets compiled, the type system will try to cast to the type specified by
-the {% tooltip label="gate" href="/glossary/gate" /%}; if you pass
-something that does not fit in the specified type, for example a `cord`
-instead of a `cell` you will get a {% tooltip label="nest-fail"
-href="/language/hoon/reference/hoon-errors#nest-fail" /%} error.
+the [gate](/glossary/gate); if you pass something that does not fit in
+the specified type, for example a `cord` instead of a `cell` you will
+get a [nest-fail](/language/hoon/reference/hoon-errors#nest-fail) error.
 
-A core's {% tooltip label="payload" href="/glossary/payload" /%} can
-change from its original value.  In fact, this happens in the typical
-function call:  the default {% tooltip label="sample"
-href="/glossary/sample" /%} is replaced with an input value.  How can we
-ensure that the core's {% tooltip label="arms" href="/glossary/arm" /%}
-are able to run correctly, that the payload type is still appropriate
-despite whatever changes it has undergone?
+A core's [payload](/glossary/payload) can change from its original
+value.  In fact, this happens in the typical function call:  the default
+[sample](/glossary/sample) is replaced with an input value.  How can we
+ensure that the core's [arms](/glossary/arm) are able to run correctly,
+that the payload type is still appropriate despite whatever changes it
+has undergone?
 
-There is a type check for each {% tooltip label="arm"
-href="/glossary/arm" /%} of a dry core, intended to verify that the
-arm's parent core has a {% tooltip label="payload"
-href="/glossary/payload" /%} of the correct type.
+There is a type check for each [arm](/glossary/arm) of a dry core,
+intended to verify that the arm's parent core has a
+[payload](/glossary/payload) of the correct type.
 
-When the `$` buc arm of a dry {% tooltip label="gate"
-href="/glossary/gate" /%} is evaluated it takes its parent core—the dry
-gate itself—as the {% tooltip label="subject" href="/glossary/subject"
-/%}, often with a modified sample value.  But any change in sample type
-should be conservative; the modified sample value must be of the same
-type as the default sample value (or possibly a subtype).  When the `$`
-buc arm is evaluated it should have a subject of a type it knows how to
-use.
+When the `$` buc arm of a dry [gate](/glossary/gate) is evaluated it
+takes its parent core—the dry gate itself—as the
+[subject](/glossary/subject), often with a modified sample value.  But
+any change in sample type should be conservative; the modified sample
+value must be of the same type as the default sample value (or possibly
+a subtype).  When the `$` buc arm is evaluated it should have a subject
+of a type it knows how to use.
 
 ### Wet Gates
 
-When you pass arguments to a {% tooltip label="wet gate"
-href="/glossary/wet-gate" /%}, their types are preserved and type
-analysis is done at the definition site of the gate rather than at the
-call site.  In other words, for a wet gate, we ask:  “Suppose this core
-was actually _compiled_ using the modified {% tooltip label="payload"
-href="/glossary/payload" /%} instead of the one it was originally built
-with?  Would the {% tooltip label="Nock" href="/glossary/nock" /%}
-formula we generated for the original template actually work for the
-modified `payload`?” Basically, wet gates allow you to hot-swap code at
-runtime and see if it “just works”—they defer the actual substitution in
-the {% tooltip label="sample" href="/glossary/sample" /%}.  Wet gates
-are rather like
+When you pass arguments to a [wet gate](/glossary/wet-gate), their types
+are preserved and type analysis is done at the definition site of the
+gate rather than at the call site.  In other words, for a wet gate, we
+ask:  “Suppose this core was actually _compiled_ using the modified
+[payload](/glossary/payload) instead of the one it was originally built
+with?  Would the [Nock](/glossary/nock) formula we generated for the
+original template actually work for the modified `payload`?” Basically,
+wet gates allow you to hot-swap code at runtime and see if it “just
+works”—they defer the actual substitution in the
+[sample](/glossary/sample).  Wet gates are rather like
 [macros](https://en.wikipedia.org/wiki/Macro_%28computer_science%29) in
 this sense.
 
-Consider a function like {% tooltip label="++turn"
-href="/language/hoon/reference/stdlib/2b#turn" /%} which transforms each
-element of a list. To use `++turn`, we install a {% tooltip label="list"
-href="/glossary/list" /%} and a transformation function in a generic
-core.  The type of the list we produce depends on the type of the list
-and the type of the transformation function.  But the Nock formulas for
-transforming each element of the list will work on any function and any
-list, so long as the function's argument is the list item.
+Consider a function like
+[++turn](/language/hoon/reference/stdlib/2b#turn) which transforms each
+element of a list. To use `++turn`, we install a [list](/glossary/list)
+and a transformation function in a generic core.  The type of the list
+we produce depends on the type of the list and the type of the
+transformation function.  But the Nock formulas for transforming each
+element of the list will work on any function and any list, so long as
+the function's argument is the list item.
 
-A wet gate is defined by a `|*` {% tooltip label="bartar"
-href="/language/hoon/reference/rune/bar#-bartar" /%} rune rather than a
-`|=` {% tooltip label="bartis"
-href="/language/hoon/reference/rune/bar#-bartis" /%}.  More generally,
-cores that contain wet arms **must** be defined using `|@` {% tooltip
-label="barpat" href="/language/hoon/reference/rune/bar#-barpat" /%}
-instead of `|%` {% tooltip label="barcen"
-href="/language/hoon/reference/rune/bar#-barcen" /%} (`|*` expands to a
-`|@` core with `$` buc arm). There is also `|$` {% tooltip
-label="barbuc" href="/language/hoon/reference/rune/bar#-barbuc" /%}
-which defines the wet gate {% tooltip label="mold" href="/glossary/mold"
-/%} builder (remember, we like gates that build gates).
+A wet gate is defined by a `|*`
+[bartar](/language/hoon/reference/rune/bar#-bartar) rune rather than a
+`|=` [bartis](/language/hoon/reference/rune/bar#-bartis).  More
+generally, cores that contain wet arms **must** be defined using `|@`
+[barpat](/language/hoon/reference/rune/bar#-barpat) instead of `|%`
+[barcen](/language/hoon/reference/rune/bar#-barcen) (`|*` expands to a
+`|@` core with `$` buc arm). There is also `|$`
+[barbuc](/language/hoon/reference/rune/bar#-barbuc) which defines the
+wet gate [mold](/glossary/mold) builder (remember, we like gates that
+build gates).
 
 In a nutshell, compare these two gates:
 
@@ -155,22 +140,21 @@ In a nutshell, compare these two gates:
 ```
 
 The dry gate does not preserve the type of `a` and `b`, but downcasts it
-to `*`; the {% tooltip label="wet gate" href="/glossary/wet-gate" /%}
-does preserve the input types.  It is good practice to include a cast in
-all {% tooltip label="gates" href="/glossary/gate" /%}, even wet gates.
-But in many cases the desired output type depends on the input type.
-How can we cast appropriately?  Often we can cast by example, using the
-input values themselves (using `^+` {% tooltip label="ketlus"
-href="/language/hoon/reference/rune/ket#-ketlus" /%}).
+to `*`; the [wet gate](/glossary/wet-gate) does preserve the input
+types.  It is good practice to include a cast in all
+[gates](/glossary/gate), even wet gates. But in many cases the desired
+output type depends on the input type. How can we cast appropriately?
+Often we can cast by example, using the input values themselves (using
+`^+` [ketlus](/language/hoon/reference/rune/ket#-ketlus)).
 
 Wet gates are therefore used when incoming type information is not well
 known and needs to be preserved.  This includes parsing, building, and
-structuring arbitrary {% tooltip label="nouns" href="/glossary/noun"
-/%}.  (If you are familiar with them, you can think of C++'s templates
-and operator overloading, and Haskell's typeclasses.)  Wet gates are
-very powerful; they're enough rope to hang yourself with.  Don't use
-them unless you have a specific reason to do so.  (If you see `mull-*`
-errors then something has gone wrong with using wet gates.)
+structuring arbitrary [nouns](/glossary/noun).  (If you are familiar
+with them, you can think of C++'s templates and operator overloading,
+and Haskell's typeclasses.)  Wet gates are very powerful; they're enough
+rope to hang yourself with.  Don't use them unless you have a specific
+reason to do so.  (If you see `mull-*` errors then something has gone
+wrong with using wet gates.)
 
 - [~timluc-miptev, “Wet Gates”](https://blog.timlucmiptev.space/wetgates.html)
 
@@ -180,10 +164,9 @@ The [trapezoid rule](https://en.wikipedia.org/wiki/Trapezoidal_rule)
 solves a definite integral.  It approximates the area under the curve by
 a trapezoid or (commonly) a series of trapezoids.  The rule requires a
 function as one of the inputs, i.e. it applies _for a specific
-function_.  We will use {% tooltip label="wet gates"
-href="/glossary/wet-gate" /%} to accomplish this without stripping type
-information of the input {% tooltip label="gate" href="/glossary/gate"
-/%} core.
+function_.  We will use [wet gates](/glossary/wet-gate) to accomplish
+this without stripping type information of the input
+[gate](/glossary/gate) core.
 
 ![](https://upload.wikimedia.org/wikipedia/commons/thumb/d/d1/Integration_num_trapezes_notation.svg/573px-Integration_num_trapezes_notation.svg.png)
 
@@ -199,10 +182,10 @@ information of the input {% tooltip label="gate" href="/glossary/gate"
 -->
 
 - Produce a trapezoid-rule integrator which accepts a wet gate (as a
-  function of a single variable) and a {% tooltip label="list"
-  href="/glossary/list" /%} of _x_ values, and yields the integral as a
-  `@rs` floating-point value.  (If you are not yet familiar with these,
-  you may wish to skip ahead to the next lesson.)
+  function of a single variable) and a [list](/glossary/list) of _x_
+  values, and yields the integral as a `@rs` floating-point value.  (If
+  you are not yet familiar with these, you may wish to skip ahead to the
+  next lesson.)
 
 ```hoon {% copy=true %}
 ++  trapezint
@@ -221,32 +204,28 @@ The meat of this gate is concerned with correctly implementing the
 mathematical equation.  In particular, wetness is required because `b`
 can be _any_ gate (although it should only be a gate with one argument,
 lest the whole thing `mull-grow` fail).  If you attempt to create the
-equivalent dry gate (`|=` {% tooltip label="bartis"
-href="/language/hoon/reference/rune/bar#-bartis" /%}), Hoon fails to
-build it with a {% tooltip label="nest-fail"
-href="/language/hoon/reference/hoon-errors#nest-fail" /%} due to the
+equivalent dry gate (`|=`
+[bartis](/language/hoon/reference/rune/bar#-bartis)), Hoon fails to
+build it with a
+[nest-fail](/language/hoon/reference/hoon-errors#nest-fail) due to the
 loss of type information from the gate `b`.
 
 #### Tutorial:  `++need`
 
-{% tooltip label="Wet gates" href="/glossary/wet-gate" /%} and wet cores
-are used in Hoon when type information isn't well-characterized ahead of
-time, as when constructing {% tooltip label="++maps"
-href="/language/hoon/reference/stdlib/2o#map" /%} or {% tooltip
-label="++sets" href="/language/hoon/reference/stdlib/2o#set" /%}.  For
-instance, almost all of the arms in {% tooltip label="++by"
-href="/language/hoon/reference/stdlib/2i#by" /%} and {% tooltip
-label="++in" href="/language/hoon/reference/stdlib/2h#in" /%}, as well
-as most {% tooltip label="++list" href="/glossary/list" /%} tools, are
-wet gates.
+[Wet gates](/glossary/wet-gate) and wet cores are used in Hoon when type
+information isn't well-characterized ahead of time, as when constructing
+[++maps](/language/hoon/reference/stdlib/2o#map) or
+[++sets](/language/hoon/reference/stdlib/2o#set).  For instance, almost
+all of the arms in [++by](/language/hoon/reference/stdlib/2i#by) and
+[++in](/language/hoon/reference/stdlib/2h#in), as well as most
+[++list](/glossary/list) tools, are wet gates.
 
 Let's take a look at a particular wet gate from the Hoon standard
-library, {% tooltip label="++need"
-href="/language/hoon/reference/stdlib/2a#need" /%}.  `++need` works with
-a {% tooltip label="unit" href="/language/hoon/reference/stdlib/1c#unit"
-/%} to produce the value of a successful `unit` call, or crash on `~`.
-(As this code is already defined in your `hoon.hoon`, you do not need to
-define it in the Dojo to use it.)
+library, [++need](/language/hoon/reference/stdlib/2a#need).  `++need`
+works with a [unit](/language/hoon/reference/stdlib/1c#unit) to produce
+the value of a successful `unit` call, or crash on `~`. (As this code is
+already defined in your `hoon.hoon`, you do not need to define it in the
+Dojo to use it.)
 
 ```hoon {% copy=true %}
 ++  need                                                ::  demand
@@ -268,10 +247,9 @@ This declares a wet gate which accepts a `unit`.
 ```
 
 If `a` is empty, `~`, then the `unit` cannot be unwrapped.  Crash with
-`!!` {% tooltip label="zapzap"
-href="/language/hoon/reference/rune/zap#-zapzap" /%}, but use `~>` {%
-tooltip label="siggar" href="/language/hoon/reference/rune/sig#-siggar"
-/%} to hint to the runtime interpreter how to handle the crash.
+`!!` [zapzap](/language/hoon/reference/rune/zap#-zapzap), but use `~>`
+[siggar](/language/hoon/reference/rune/sig#-siggar) to hint to the
+runtime interpreter how to handle the crash.
 
 ```hoon
 u.a
@@ -284,24 +262,21 @@ extract from the `unit`.
 
 ### Parametric Polymorphism
 
-We encountered `|$` {% tooltip label="barbuc"
-href="/language/hoon/reference/rune/bar#-barbuc" /%} above as a {%
-tooltip label="wet gate" href="/glossary/wet-gate" /%} that is a mold
-builder rune which takes in a list of {% tooltip label="molds"
-href="/glossary/mold" /%} and produces a new mold.  Here we take another
-look at this rune as an implementation of _parametric polymorphism_ in
-Hoon.
+We encountered `|$` [barbuc](/language/hoon/reference/rune/bar#-barbuc)
+above as a [wet gate](/glossary/wet-gate) that is a mold builder rune
+which takes in a list of [molds](/glossary/mold) and produces a new
+mold.  Here we take another look at this rune as an implementation of
+_parametric polymorphism_ in Hoon.
 
-For example, we have
-{% tooltip label="lists" href="/glossary/list" /%}, {% tooltip
-label="trees" href="/language/hoon/reference/stdlib/1c#tree" /%}, and {%
-tooltip label="sets" href="/language/hoon/reference/stdlib/2o#set" /%}
-in Hoon, which are each defined in `hoon.hoon` as wet gate mold
-builders. Take a moment to see for yourself. Each `++` arm is followed
-by `|$` and a list of labels for input types inside brackets `[ ]`.
-After that subexpression comes another that defines a type that is
-parametrically polymorphic with respect to the input values. For
-example, here is the definition of `list` from `hoon.hoon`:
+For example, we have [lists](/glossary/list),
+[trees](/language/hoon/reference/stdlib/1c#tree), and
+[sets](/language/hoon/reference/stdlib/2o#set) in Hoon, which are each
+defined in `hoon.hoon` as wet gate mold builders. Take a moment to see
+for yourself. Each `++` arm is followed by `|$` and a list of labels for
+input types inside brackets `[ ]`. After that subexpression comes
+another that defines a type that is parametrically polymorphic with
+respect to the input values. For example, here is the definition of
+`list` from `hoon.hoon`:
 
 ```hoon {% copy=true %}
 ++  list
@@ -314,12 +289,11 @@ example, here is the definition of `list` from `hoon.hoon`:
   $@(~ [i=item t=(list item)])
 ```
 
-The `|$` {% tooltip label="barbuc"
-href="/language/hoon/reference/rune/bar#-barbuc" /%} rune is especially
-useful for defining containers of various kinds.  Indeed, `list`s,
-`tree`s, and `set`s are all examples of containers that accept subtypes.
-You can have a `(list @)`, a `(list ^)`, a `(list *)`, a `(tree @)`, a
-`(tree ^)`, a `(tree *)`, etc.  The same holds for `set`.
+The `|$` [barbuc](/language/hoon/reference/rune/bar#-barbuc) rune is
+especially useful for defining containers of various kinds.  Indeed,
+`list`s, `tree`s, and `set`s are all examples of containers that accept
+subtypes. You can have a `(list @)`, a `(list ^)`, a `(list *)`, a
+`(tree @)`, a `(tree ^)`, a `(tree *)`, etc.  The same holds for `set`.
 
 One nice thing about containers defined by `|$` is that they nest in the
 expected way.  Intuitively a `(list @)` should nest under `(list *)`,
@@ -344,11 +318,10 @@ nest-fail
 
 ### Drying Out a Gate
 
-Some functional tools like {% tooltip label="++cury"
-href="/language/hoon/reference/stdlib/2n#cury" /%} don't work with {%
-tooltip label="wet gates" href="/glossary/wet-gate" /%}.  It is,
-however, possible to “dry out“ a wet gate using {% tooltip
-label="++bake" href="/language/hoon/reference/stdlib/2b#bake" /%}:
+Some functional tools like
+[++cury](/language/hoon/reference/stdlib/2n#cury) don't work with [wet
+gates](/glossary/wet-gate).  It is, however, possible to “dry out“ a wet
+gate using [++bake](/language/hoon/reference/stdlib/2b#bake):
 
 ```hoon
 > ((curr reel add) `(list @)`[1 2 3 4 ~])
@@ -366,24 +339,21 @@ powerful and for that reason not apt for every purpose.
 
 ##  Variance
 
-Dry polymorphism works by substituting {% tooltip label="cores"
-href="/glossary/core" /%}.  Typically, one core is used as the interface
-definition, then replaced with another core which does something useful.
+Dry polymorphism works by substituting [cores](/glossary/core).
+Typically, one core is used as the interface definition, then replaced
+with another core which does something useful.
 
-For core `b` to nest within core `a`, the {% tooltip label="batteries"
-href="/glossary/battery" /%} of `a` and `b` must have the same tree
-shape, and the product of each `b` {% tooltip label="arm"
-href="/glossary/arm" /%} must nest within the product of the `a` arm.
+For core `b` to nest within core `a`, the [batteries](/glossary/battery)
+of `a` and `b` must have the same tree shape, and the product of each
+`b` [arm](/glossary/arm) must nest within the product of the `a` arm.
 Wet arms (described above) are not compatible unless the Hoon expression
-is exactly the same.  But for dry cores we also apply a {% tooltip
-label="payload" href="/glossary/payload" /%} test that depends on the
-rules of variance.
+is exactly the same.  But for dry cores we also apply a
+[payload](/glossary/payload) test that depends on the rules of variance.
 
-There are four kinds of {% tooltip label="cores" href="/glossary/core"
-/%}: `%gold`, `%iron`, `%zinc`, and `%lead`. You are able to use
-core-variance rules to create programs which take other programs as
-arguments. Which particular rules depends on which kind of core your
-program needs to complete.
+There are four kinds of [cores](/glossary/core): `%gold`, `%iron`,
+`%zinc`, and `%lead`. You are able to use core-variance rules to create
+programs which take other programs as arguments. Which particular rules
+depends on which kind of core your program needs to complete.
 
 Before we embark on the following discussion, we want you to know that
 [variance](https://en.wikipedia.org/wiki/Covariance_and_contravariance_%28computer_science%29)
@@ -422,8 +392,8 @@ has a _variance property_, but that property doesn't manifest until
 cores are used together with each other.
 
 Variance describes the four possible relationships that type rules are
-able to have to each other.  Hoon imaginatively designates these by {%
-tooltip label="metals" href="/glossary/metals" /%}.  Briefly:
+able to have to each other.  Hoon imaginatively designates these by
+[metals](/glossary/metals).  Briefly:
 
 1. **Covariance (`%zinc`)** means that specific types nest inside of
    generic types:  it's like claiming that a core that produces a
@@ -464,9 +434,8 @@ Covariance means that specific types nest inside of generic types:
 `%tree` nests inside of `%plant`.  Covariant data types are sources, or
 read-only values.
 
-A zinc core `z` has a read-only {% tooltip label="sample"
-href="/glossary/sample" /%} ({% tooltip label="payload"
-href="/glossary/payload" /%} head, `+6.z`) and an opaque context
+A zinc core `z` has a read-only [sample](/glossary/sample)
+([payload](/glossary/payload) head, `+6.z`) and an opaque context
 (payload tail, `+7.z`). (_Opaque_ here means that the faces and arms are
 not exported into the namespace, and that the values of faces and arms
 can't be written to. The object in question can be replaced by something
@@ -494,18 +463,16 @@ ford: %ride failed to compute type:
 Informally, a function fits an interface if the function has a more
 specific result and/or a less specific argument than the interface.
 
-The `^&` {% tooltip label="ketpam"
-href="/language/hoon/reference/rune/ket#-ketpam" /%} rune converts a
-core to a `%zinc` covariant core.
+The `^&` [ketpam](/language/hoon/reference/rune/ket#-ketpam) rune
+converts a core to a `%zinc` covariant core.
 
 ### `%iron` Contravariance
 
 Contravariance means that generic types nest inside of specific types.
 Contravariant data types are sinks, or write-only values.
 
-An `%iron` core `i` has a write-only {% tooltip label="sample"
-href="/glossary/sample" /%} ({% tooltip label="payload"
-href="/glossary/payload" /%} head, `+6.i`) and an opaque context
+An `%iron` core `i` has a write-only [sample](/glossary/sample)
+([payload](/glossary/payload) head, `+6.i`) and an opaque context
 (payload tail, `+7.i`).  A core `j` which nests within it must be a
 `%gold` or `%iron` core, such that `+6.i` nests within `+6.j`. Hence,
 **contravariant**.
@@ -517,27 +484,25 @@ accepting `y` and producing `xx`.
 Informally, a function fits an interface if the function has a more
 specific result and/or a less specific argument than the interface.
 
-For instance, the archetypal {% tooltip label="Gall"
-href="/glossary/gall" /%} agents in `/sys/lull.hoon` are composed using
-iron gates since they will be used as examples for building actual {%
-tooltip label="agent" href="/glossary/agent" /%} cores.  The {% tooltip
-label="++rs" href="/language/hoon/reference/stdlib/3b#rs" /%} and sister
-gates in `/sys/hoon.hoon` are built using iron doors with specified
-rounding behavior so when you actually use the core (like {% tooltip
-label="++add:rs" href="/language/hoon/reference/stdlib/3b#addrs" /%})
-the core you are using has been built as an example.
+For instance, the archetypal [Gall](/glossary/gall) agents in
+`/sys/lull.hoon` are composed using iron gates since they will be used
+as examples for building actual [agent](/glossary/agent) cores.  The
+[++rs](/language/hoon/reference/stdlib/3b#rs) and sister gates in
+`/sys/hoon.hoon` are built using iron doors with specified rounding
+behavior so when you actually use the core (like
+[++add:rs](/language/hoon/reference/stdlib/3b#addrs)) the core you are
+using has been built as an example.
 
-The `|~` {% tooltip label="barsig"
-href="/language/hoon/reference/rune/bar#-barsig" /%} rune produces an
-iron gate.  The `^|` {% tooltip label="ketbar"
-href="/language/hoon/reference/rune/ket#-ketbar" /%} rune converts a
+The `|~` [barsig](/language/hoon/reference/rune/bar#-barsig) rune
+produces an iron gate.  The `^|`
+[ketbar](/language/hoon/reference/rune/ket#-ketbar) rune converts a
 `%gold` invariant core to an iron core.
 
 ### `%lead` Bivariance
 
 Bivariance means that both covariance and contravariance apply.
-Bivariant data types have an opaque {% tooltip label="payload"
-href="/glossary/payload" /%} that can neither be read or written to.
+Bivariant data types have an opaque [payload](/glossary/payload) that
+can neither be read or written to.
 
 A lead core `l` has an opaque `payload` which can be neither read nor
 written to.  There is no constraint on the payload of a core `m` which
@@ -547,35 +512,31 @@ If type `x` nests within type `xx`, a lead core producing `x` nests
 within a lead core producing `xx`.
 
 Bivariant data types are neither readable nor writeable, but have no
-constraints on nesting.  These are commonly used for `/mar` {% tooltip
-label="marks" href="/glossary/mark" /%} and `/sur` structure files. They
-are useful as examples which produce types.
+constraints on nesting.  These are commonly used for `/mar`
+[marks](/glossary/mark) and `/sur` structure files. They are useful as
+examples which produce types.
 
-Informally, a more specific {% tooltip label="generator"
-href="/glossary/generator" /%} can be used as a less specific generator.
+Informally, a more specific [generator](/glossary/generator) can be used
+as a less specific generator.
 
 For instance, several archetypal cores in `/sys/lull.hoon` which define
-operational data structures for {% tooltip label="Arvo"
-href="/glossary/arvo" /%} are composed using lead {% tooltip
-label="gates" href="/glossary/gate" /%}.
+operational data structures for [Arvo](/glossary/arvo) are composed
+using lead [gates](/glossary/gate).
 
-The `|?` {% tooltip label="barwut"
-href="/language/hoon/reference/rune/bar#-barwut" /%} rune produces a
-lead trap.  The `^?` {% tooltip label="ketwut"
-href="/language/hoon/reference/rune/ket#-ketwut" /%} rune converts any
+The `|?` [barwut](/language/hoon/reference/rune/bar#-barwut) rune
+produces a lead trap.  The `^?`
+[ketwut](/language/hoon/reference/rune/ket#-ketwut) rune converts any
 core to a `%lead` bivariant core.
 
 ### `%gold` Invariance
 
 Invariance means that type nesting is disallowed.  Invariant data types
-have a read-write {% tooltip label="payload" href="/glossary/payload"
-/%}.
+have a read-write [payload](/glossary/payload).
 
-A `%gold` {% tooltip label="core" href="/glossary/core" /%} `g` has a
-read-write payload; another core `h` that nests within it (i.e., can be
-substituted for it) must be a `%gold` core whose `payload` is mutually
-compatible (`+3.g` nests in `+3.h`, `+3.h` nests in `+3.g`).  Hence,
-**invariant**.
+A `%gold` [core](/glossary/core) `g` has a read-write payload; another
+core `h` that nests within it (i.e., can be substituted for it) must be
+a `%gold` core whose `payload` is mutually compatible (`+3.g` nests in
+`+3.h`, `+3.h` nests in `+3.g`).  Hence, **invariant**.
 
 By default, cores are `%gold` invariant cores.
 
@@ -588,9 +549,8 @@ Usually it makes sense to cast for a `%gold` core type when you're
 treating a core as a state machine.  The check ensures that the payload,
 which includes the relevant state, doesn't vary in type.
 
-Let's look at simpler examples here, using the `^+` {% tooltip
-label="ketlus" href="/language/hoon/reference/rune/ket#-ketlus" /%}
-rune:
+Let's look at simpler examples here, using the `^+`
+[ketlus](/language/hoon/reference/rune/ket#-ketlus) rune:
 
 ```hoon
 > ^+(|=(^ 15) |=(^ 16))
@@ -615,15 +575,13 @@ nest-fail
 ```
 
 The first cast goes through because the right-hand gold core has the
-same {% tooltip label="sample" href="/glossary/sample" /%} type as the
-left-hand gold core. The sample types mutually nest. The second cast
-fails because the right-hand sample type is more specific than the
-left-hand sample type. (Not all {% tooltip label="cells"
-href="/glossary/cell" /%}, `^`, are pairs of {% tooltip label="atoms"
-href="/glossary/atom" /%}, `[@ @]`.) And the third cast fails because
-the right-hand sample type is broader than the left-hand sample type.
-(Not all {% tooltip label="nouns" href="/glossary/noun" /%}, `*`, are
-cells, `^`.)
+same [sample](/glossary/sample) type as the left-hand gold core. The
+sample types mutually nest. The second cast fails because the right-hand
+sample type is more specific than the left-hand sample type. (Not all
+[cells](/glossary/cell), `^`, are pairs of [atoms](/glossary/atom), `[@
+@]`.) And the third cast fails because the right-hand sample type is
+broader than the left-hand sample type. (Not all
+[nouns](/glossary/noun), `*`, are cells, `^`.)
 
 Two more examples:
 
@@ -644,12 +602,11 @@ the right-hand core has the wrong type of context -- three atoms, `[@ @
 
 #### Tutorial:  `%iron` Contravariant Polymorphism
 
-`%iron` {% tooltip label="gates" href="/glossary/gate" /%} are
-particularly useful when you want to pass gates (having various {%
-tooltip label="payload" href="/glossary/payload" /%} types) to other
+`%iron` [gates](/glossary/gate) are particularly useful when you want to
+pass gates (having various [payload](/glossary/payload) types) to other
 gates.  We can illustrate this use with a very simple example. Save the
-following as `/gen/gatepass.hoon` in your `%base` {% tooltip
-label="desk" href="/glossary/desk" /%}:
+following as `/gen/gatepass.hoon` in your `%base`
+[desk](/glossary/desk):
 
 ```hoon {% copy=true %}
 |=  a=_^|(|=(@ 15))
@@ -658,12 +615,11 @@ label="desk" href="/glossary/desk" /%}:
 (add b 20)
 ```
 
-This {% tooltip label="generator" href="/glossary/generator" /%} is
-rather simple except for the first line.  The sample is defined as an
-`%iron` gate and gives it the {% tooltip label="face"
-href="/glossary/face" /%} `a`.  The function as a whole is for taking
-some gate as input, calling it by passing it the value `10`, adding `20`
-to it, and returning the result.  Let's try it out in the Dojo:
+This [generator](/glossary/generator) is rather simple except for the
+first line.  The sample is defined as an `%iron` gate and gives it the
+[face](/glossary/face) `a`.  The function as a whole is for taking some
+gate as input, calling it by passing it the value `10`, adding `20` to
+it, and returning the result.  Let's try it out in the Dojo:
 
 ```hoon
 > +gatepass |=(a=@ +(a))
@@ -678,18 +634,17 @@ to it, and returning the result.  Let's try it out in the Dojo:
 
 But we still haven't fully explained the first line of the code.  What
 does `_^|(|=(@ 15))` mean? The inside portion is clear enough:  `|=(@
-15)` produces a normal (i.e., `%gold`) {% tooltip label="gate"
-href="/glossary/gate" /%} that takes an atom and returns `15`.  The `^|`
-{% tooltip label="ketbar"
-href="/language/hoon/reference/rune/ket#-ketbar" /%} rune is used to
-turn `%gold` gates to `%iron`.  (Reverse alchemy!)  And the `_`
-character turns that `%iron` gate value into a structure, i.e. a type.
-So the whole subexpression means, roughly:  “the same type as an iron
-gate whose {% tooltip label="sample" href="/glossary/sample" /%} is an
-atom, `@`, and whose product is another atom, `@`”. The context isn't
-checked at all.  This is good, because that allows us to accept gates
-defined and produced in drastically different environments.  Let's try
-passing a gate with a different context:
+15)` produces a normal (i.e., `%gold`) [gate](/glossary/gate) that takes
+an atom and returns `15`.  The `^|`
+[ketbar](/language/hoon/reference/rune/ket#-ketbar) rune is used to turn
+`%gold` gates to `%iron`.  (Reverse alchemy!)  And the `_` character
+turns that `%iron` gate value into a structure, i.e. a type. So the
+whole subexpression means, roughly:  “the same type as an iron gate
+whose [sample](/glossary/sample) is an atom, `@`, and whose product is
+another atom, `@`”. The context isn't checked at all.  This is good,
+because that allows us to accept gates defined and produced in
+drastically different environments.  Let's try passing a gate with a
+different context:
 
 ```hoon
 > +gatepass =>([22 33] |=(a=@ +(a)))
@@ -708,14 +663,12 @@ There's a simpler way to define an iron sample. Revise the first line of
 (add b 20)
 ```
 
-If you test it, you'll find that the {% tooltip label="generator"
-href="/glossary/generator" /%} behaves the same as it did before the
-edits.  The `$-` {% tooltip label="buchep"
-href="/language/hoon/reference/rune/buc#--buchep" /%} rune is used to
+If you test it, you'll find that the [generator](/glossary/generator)
+behaves the same as it did before the edits.  The `$-`
+[buchep](/language/hoon/reference/rune/buc#--buchep) rune is used to
 create an `%iron` gate structure, i.e., an `%iron` gate type.  The first
-expression defines the desired {% tooltip label="sample"
-href="/glossary/sample" /%} type, and the second subexpression defines
-the gate's desired output type.
+expression defines the desired [sample](/glossary/sample) type, and the
+second subexpression defines the gate's desired output type.
 
 The sample type of an `%iron` gate is contravariant.  This means that,
 when doing a cast with some `%iron` gate, the desired gate must have
@@ -730,14 +683,14 @@ gate that only takes **dogs** as input, because `F` might call it with a
 **cat**.  But `F` can accept a gate that takes all **animals** as input,
 because a gate that can handle any **animal** can handle **any mammal**.
 
-`%iron` {% tooltip label="cores" href="/glossary/core" /%} are designed
-precisely with this purpose in mind.  The reason that the {% tooltip
-label="sample" href="/glossary/sample" /%} is write-only is that we want
-to be able to assume, within function `F`, that the sample of `G` is a
-**mammal**. But that might not be true when `G` is first passed into
-`F`—the default value of `G` could be another **animal**, say, a
-**lizard**.  So we restrict looking into the sample of `G` by making the
-sample write-only. The illusion is maintained and type safety secured.
+`%iron` [cores](/glossary/core) are designed precisely with this purpose
+in mind.  The reason that the [sample](/glossary/sample) is write-only
+is that we want to be able to assume, within function `F`, that the
+sample of `G` is a **mammal**. But that might not be true when `G` is
+first passed into `F`—the default value of `G` could be another
+**animal**, say, a **lizard**.  So we restrict looking into the sample
+of `G` by making the sample write-only. The illusion is maintained and
+type safety secured.
 
 Let's illustrate `%iron` core nesting properties:
 
@@ -765,9 +718,9 @@ nest-fail
 >
 ```
 
-(As before, we use the `^|` {% tooltip label="ketbar"
-href="/language/hoon/reference/rune/ket#-ketbar" /%} rune to turn
-`%gold` gates to `%iron`.)
+(As before, we use the `^|`
+[ketbar](/language/hoon/reference/rune/ket#-ketbar) rune to turn `%gold`
+gates to `%iron`.)
 
 The first cast goes through because the two gates have the same sample
 type.  The second cast fails because the right-hand gate has a more
@@ -779,11 +732,10 @@ goes through because the right-hand gate sample type is broader than the
 left-hand gate sample type.  A gate that can take any noun as its
 sample, `*`, works just fine if we choose only to pass it cells, `^`.
 
-We mentioned previously that an `%iron` core has a write-only {% tooltip
-label="sample" href="/glossary/sample" /%} and an opaque context.  Let's
-prove it.
+We mentioned previously that an `%iron` core has a write-only
+[sample](/glossary/sample) and an opaque context.  Let's prove it.
 
-Let's define a trivial {% tooltip label="gate" href="/glossary/gate" /%}
+Let's define a trivial [gate](/glossary/gate)
 with a context of `[g=22 h=44 .]`, convert it to `%iron` with `^|`, and
 bind it to `iron-gate` in the dojo:
 
@@ -806,9 +758,8 @@ with a wing expression: `p.q`. Not so with the iron gate:
 -find.g.iron-gate
 ```
 
-And usually we can look at the sample value using the {% tooltip
-label="face" href="/glossary/face" /%} given in the gate definition. Not
-in this case:
+And usually we can look at the sample value using the
+[face](/glossary/face) given in the gate definition. Not in this case:
 
 ```hoon
 > a.iron-gate
@@ -844,18 +795,17 @@ away:
 
 #### Tutorial:  `%zinc` Covariant Polymorphism
 
-As with `%iron` {% tooltip label="cores" href="/glossary/core" /%}, the
+As with `%iron` [cores](/glossary/core), the
 context of `%zinc` cores is opaque—they cannot be written-to or
-read-from.  The {% tooltip label="sample" href="/glossary/sample" /%} of
+read-from.  The [sample](/glossary/sample) of
 a `%zinc` core is read-only.  That means, among other things, that
 `%zinc` cores cannot be used for function calls.  Function calls in Hoon
 involve a change to the sample (the default sample is replaced with the
 argument value), which is disallowed as type-unsafe for `%zinc` cores.
 
 We can illustrate the casting properties of `%zinc` cores with a few
-examples.  The `^&` {% tooltip label="ketpam"
-href="/language/hoon/reference/rune/ket#-ketpam" /%} rune is used to
-convert `%gold` cores to `%zinc`:
+examples.  The `^&` [ketpam](/language/hoon/reference/rune/ket#-ketpam)
+rune is used to convert `%gold` cores to `%zinc`:
 
 ```hoon
 > ^+(^&(|=(^ 15)) |=(^ 16))
@@ -881,15 +831,14 @@ mint-nice
 nest-fail
 ```
 
-The first two casts succeed because the right-hand core {% tooltip
-label="sample" href="/glossary/sample" /%} type is either the same or a
-subset of the left-hand core sample type.  The last one fails because
-the right-hand sample type is a superset.
+The first two casts succeed because the right-hand core
+[sample](/glossary/sample) type is either the same or a subset of the
+left-hand core sample type.  The last one fails because the right-hand
+sample type is a superset.
 
 Even though you can't function call a `%zinc` core, the arms of a
 `%zinc` core can be computed and the sample can be read.  Let's test
-this with a `%zinc` {% tooltip label="gate" href="/glossary/gate" /%} of
-our own:
+this with a `%zinc` [gate](/glossary/gate) of our own:
 
 ```hoon
 > =zinc-gate ^&  |=(a=_22 (add 10 a))
@@ -907,10 +856,10 @@ payload-block
 #### Tutorial:  `%lead` Bivariant Polymorphism
 
 `%lead` cores have more permissive nesting rules than either `%iron` or
-`%zinc` cores.  There is no restriction on which {% tooltip
-label="payload" href="/glossary/payload" /%} types nest. That means,
-among other things, that the payload type of a `%lead` core is both
-covariant and contravariant ( ‘bivariant’).
+`%zinc` cores.  There is no restriction on which
+[payload](/glossary/payload) types nest. That means, among other things,
+that the payload type of a `%lead` core is both covariant and
+contravariant ( ‘bivariant’).
 
 In order to preserve type safety when working with `%lead` cores, a
 severe restriction is needed.  The whole payload of a `%lead` core is
@@ -918,9 +867,9 @@ opaque—the payload can neither be written-to or read-from.  For this
 reason, as was the case with `%zinc` cores, `%lead` cores cannot be
 called as functions.
 
-The {% tooltip label="arms" href="/glossary/arm" /%} of a `%lead` core
-can still be evaluated, however. We can use the `^?` rune to convert a
-`%gold`, `%iron`, or `%zinc` core to lead:
+The [arms](/glossary/arm) of a `%lead` core can still be evaluated,
+however. We can use the `^?` rune to convert a `%gold`, `%iron`, or
+`%zinc` core to lead:
 
 ```hoon
 > =lead-gate ^?  |=(a=_22 (add 10 a))
@@ -941,22 +890,19 @@ But don't try to read the sample:
 - Calculate the Fibonacci series using `%lead` and `%iron` cores.
 
 This program produces a list populated by the first ten elements of the
-`++fib` {% tooltip label="arm" href="/glossary/arm" /%}.  It consists of
-five arms; in brief:
+`++fib` [arm](/glossary/arm).  It consists of five arms; in brief:
 
 - `++fib` is a trap (core with no sample and default arm `$` buc)
-- `++stream` is a {% tooltip label="mold" href="/glossary/mold" /%}
-  builder that produces a trap, a function with no argument.  This {%
-  tooltip label="trap" href="/glossary/trap" /%} can yield a value or a
-  `~`.
-- `++stream-type` is a {% tooltip label="wet gate"
-  href="/glossary/wet-gate" /%} that produces the type of items stored
-  in `++stream`.
-- `++to-list` is a wet gate that converts a `++stream` to a {% tooltip
-  label="list" href="/glossary/list" /%}.
+- `++stream` is a [mold](/glossary/mold) builder that produces a trap, a
+  function with no argument.  This [trap](/glossary/trap) can yield a
+  value or a `~`.
+- `++stream-type` is a [wet gate](/glossary/wet-gate) that produces the
+  type of items stored in `++stream`.
+- `++to-list` is a wet gate that converts a `++stream` to a
+  [list](/glossary/list).
 - `++take` is a wet gate that takes a `++stream` and an atom and yields
-  a modified {% tooltip label="subject" href="/glossary/subject" /%} (!)
-  and another trap of `++stream`'s type.
+  a modified [subject](/glossary/subject) (!) and another trap of
+  `++stream`'s type.
 
 **`/gen/fib.hoon`**
 
@@ -1020,37 +966,31 @@ Let's examine each arm in detail.
   ~
 ```
 
-`++stream` is a mold-builder. It's a {% tooltip label="wet gate"
-href="/glossary/wet-gate" /%} that takes one argument, `of`, which is a
-{% tooltip label="mold" href="/glossary/mold" /%}, and produces a
-`%lead` {% tooltip label="trap" href="/glossary/trap" /%}—a function
-with no `sample` and an arm `$` buc, with opaque {%
-tooltip label="payload" href="/glossary/payload" /%}.
+`++stream` is a mold-builder. It's a [wet gate](/glossary/wet-gate) that
+takes one argument, `of`, which is a [mold](/glossary/mold), and
+produces a `%lead` [trap](/glossary/trap)—a function with no `sample`
+and an arm `$` buc, with opaque [payload](/glossary/payload).
 
-`$_` {% tooltip label="buccab"
-href="/language/hoon/reference/rune/buc#_-buccab" /%} is a rune that
-produces a type from an example; `^?` {% tooltip label="ketwut"
-href="/language/hoon/reference/rune/ket#-ketwut" /%} converts (casts) a
-core to lead; `|.` {% tooltip label="bardot"
-href="/language/hoon/reference/rune/bar#-bardot" /%} forms the {%
-tooltip label="trap" href="/glossary/trap" /%}.  So to follow this
-sequence we read it backwards:  we create a trap, convert it to a lead
-trap (making its payload inaccessible), and then use that lead trap as
-an example from which to produce a type.
+`$_` [buccab](/language/hoon/reference/rune/buc#_-buccab) is a rune that
+produces a type from an example; `^?`
+[ketwut](/language/hoon/reference/rune/ket#-ketwut) converts (casts) a
+core to lead; `|.` [bardot](/language/hoon/reference/rune/bar#-bardot)
+forms the [trap](/glossary/trap).  So to follow this sequence we read it
+backwards:  we create a trap, convert it to a lead trap (making its
+payload inaccessible), and then use that lead trap as an example from
+which to produce a type.
 
 With the line `^- $@(~ [item=of more=^$])`, the output of the trap will
-be cast into a new type.  `$@` {% tooltip label="bucpat"
-href="/language/hoon/reference/rune/buc#-bucpat" /%} is the rune to
-describe a data structure that can either be an {% tooltip label="atom"
-href="/glossary/atom" /%} or a {% tooltip label="cell"
-href="/glossary/cell" /%}.  The first part describes the atom, which
+be cast into a new type.  `$@`
+[bucpat](/language/hoon/reference/rune/buc#-bucpat) is the rune to
+describe a data structure that can either be an [atom](/glossary/atom)
+or a [cell](/glossary/cell).  The first part describes the atom, which
 here is going to be `~`.  The second part describes a cell, which we
-define to have the head of type `of` with the {% tooltip label="face"
-href="/glossary/face" /%} `item`, and a tail with a face of `more`.  The
-expression `^$` is not a rune (no children), but rather a reference to
-the enclosing {% tooltip label="wet gate" href="/glossary/wet-gate" /%},
-so the tail of this cell will be of the same type produced by this wet
-gate.
+define to have the head of type `of` with the [face](/glossary/face)
+`item`, and a tail with a face of `more`.  The expression `^$` is not a
+rune (no children), but rather a reference to the enclosing [wet
+gate](/glossary/wet-gate), so the tail of this cell will be of the same
+type produced by this wet gate.
 
 The final `~` here is used as the type produced when initially calling
 this wet gate.  This is valid because it nests within the type we
@@ -1070,14 +1010,14 @@ some type and a `++stream`.  This type represents an infinite series.
 ```
 
 `++stream-type` is a wet gate that produces the type of items stored in
-the `stream` {% tooltip label="arm" href="/glossary/arm" /%}.  The
-`(stream)` syntax is a shortcut for `(stream *)`; a stream of some type.
+the `stream` [arm](/glossary/arm).  The `(stream)` syntax is a shortcut
+for `(stream *)`; a stream of some type.
 
-Calling a `++stream`, which is a {% tooltip label="trap"
-href="/glossary/trap" /%}, will either produce `item` and `more` or it
-will produce `~`. If it does produce `~`, the `++stream` is empty and we
-can't find what type it is, so we simply crash with `!!` {% tooltip
-label="zapzap" href="/language/hoon/reference/rune/zap#-zapzap" /%}.
+Calling a `++stream`, which is a [trap](/glossary/trap), will either
+produce `item` and `more` or it will produce `~`. If it does produce
+`~`, the `++stream` is empty and we can't find what type it is, so we
+simply crash with `!!`
+[zapzap](/language/hoon/reference/rune/zap#-zapzap).
 
 ##### `++take`
 
@@ -1098,10 +1038,9 @@ label="zapzap" href="/language/hoon/reference/rune/zap#-zapzap" /%}.
 ```
 
 `++take` is another wet gate. This time it takes a `++stream` `s` and an
-atom `n`. We add an atom to the {% tooltip label="subject"
-href="/glossary/subject" /%} and then make sure that the {% tooltip
-label="trap" href="/glossary/trap" /%} we are creating is going to be of
-the same type as `s`, the `++stream` we passed in.
+atom `n`. We add an atom to the [subject](/glossary/subject) and then
+make sure that the [trap](/glossary/trap) we are creating is going to be
+of the same type as `s`, the `++stream` we passed in.
 
 If `i` and `n` are equal, the trap will produce `~`.  If not, `s` is
 called and has its result put on the front of the subject.  If its value
@@ -1129,18 +1068,16 @@ been infinite.
 ```
 
 `++to-list` is a wet gate that takes `s`, a `++stream`, only here it
-will, as you may expect, produce a {% tooltip label="list"
-href="/glossary/list" /%}.  The rest of this wet gate is straightforward
-but we can examine it quickly anyway.  As is the proper style, this list
-that is produced will be reversed, so {% tooltip label="flop"
-href="/language/hoon/reference/stdlib/2b#flop" /%} is used to put it in
-the order it is in the stream.  Recall that adding to the front of a
-list is cheap, while adding to the back is expensive.
+will, as you may expect, produce a [list](/glossary/list).  The rest of
+this wet gate is straightforward but we can examine it quickly anyway.
+As is the proper style, this list that is produced will be reversed, so
+[flop](/language/hoon/reference/stdlib/2b#flop) is used to put it in the
+order it is in the stream.  Recall that adding to the front of a list is
+cheap, while adding to the back is expensive.
 
-`r` is added to the {% tooltip label="subject" href="/glossary/subject"
-/%} as an empty {% tooltip label="list" href="/glossary/list" /%} of
-whatever type is produced by `s`.  A new {% tooltip label="trap"
-href="/glossary/trap" /%} is formed and called, and it will produce the
+`r` is added to the [subject](/glossary/subject) as an empty
+[list](/glossary/list) of whatever type is produced by `s`.  A new
+[trap](/glossary/trap) is formed and called, and it will produce the
 same type as `r`.  Then `s` is called and has its value added to the
 subject. If the result is `~`, the trap produces `r`. Otherwise, we want
 to call the trap again, adding `item` to the front of `r` and changing
@@ -1161,15 +1098,14 @@ want to feed `to-list` an infinite stream as it would never terminate.
 ```
 
 The final arm in our core is `++fib`, which is a `++stream` of `@ud` and
-therefore is a `%lead` {% tooltip label="core" href="/glossary/core"
-/%}.  Its subject contains `p` and `q`, which will not be accessible
-outside of this {% tooltip label="trap" href="/glossary/trap" /%}, but
-because of the `%=` {% tooltip label="centis"
-href="/language/hoon/reference/rune/cen#-centis" /%} will be retained in
+therefore is a `%lead` [core](/glossary/core).  Its subject contains `p`
+and `q`, which will not be accessible outside of this
+[trap](/glossary/trap), but because of the `%=`
+[centis](/language/hoon/reference/rune/cen#-centis) will be retained in
 their modified form in the product trap.  The product of the trap is a
-pair (`:-` {% tooltip label="colhep"
-href="/language/hoon/reference/rune/col#--colhep" /%}) of an `@ud` and
-the trap that will produce the next `@ud` in the Fibonacci series.
+pair (`:-` [colhep](/language/hoon/reference/rune/col#--colhep)) of an
+`@ud` and the trap that will produce the next `@ud` in the Fibonacci
+series.
 
 ```hoon
 =<  (to-list (take fib 10))
@@ -1189,9 +1125,8 @@ correctly handle it.
 
 ### Exercise:  `%lead` Bivariant Polymorphism
 
-- Produce a `%say` {% tooltip label="generator"
-  href="/glossary/generator" /%} that yields another self-referential
-  sequence, like the [Lucas
+- Produce a `%say` [generator](/glossary/generator) that yields another
+  self-referential sequence, like the [Lucas
   numbers](https://en.wikipedia.org/wiki/Lucas_number) or the
   [Thue–Morse
   sequence](https://en.wikipedia.org/wiki/Thue%E2%80%93Morse_sequence).

--- a/content/courses/hoon-school/S-math.md
+++ b/content/courses/hoon-school/S-math.md
@@ -112,11 +112,11 @@ implementation of floating-point math for four bitwidth representations.
 | `@rd` | Double-precision 64-bit mathematics | `.~4.5` |
 | `@rq` | Quadruple-precision 128-bit mathematics | `.~~~4.5` |
 
-There are also a few {% tooltip label="molds" href="/glossary/mold" /%}
+There are also a few [molds](/glossary/mold)
 which can represent the separate values of the FP representation.  These
 are used internally but mostly don't appear in userspace code.
 
-As the {% tooltip label="arms" href="/glossary/arm" /%} for the four
+As the [arms](/glossary/arm) for the four
 `@r` auras are identical within their appropriate core, we will use
 [`@rs` single-precision floating-point
 mathematics](/language/hoon/reference/stdlib/3b#rs) to demonstrate all
@@ -149,8 +149,7 @@ why:  to represent one exactly, we have to use {% math %}1.0 = (-1)^0
 `0b11.1111.1000.0000.0000.0000.0000.0000`.
 
 So to carry out this conversion from `@ud` to `@rs` correctly, we should
-use the {% tooltip label="++sun:rs"
-href="/language/hoon/reference/stdlib/3b#sunrs" /%} arm.
+use the [++sun:rs](/language/hoon/reference/stdlib/3b#sunrs) arm.
 
 ```hoon
 > (sun:rs 1)
@@ -159,8 +158,7 @@ href="/language/hoon/reference/stdlib/3b#sunrs" /%} arm.
 
 To go the other way requires us to use an algorithm for converting an
 arbitrary number with a fractional part back into `@ud` unsigned
-integers.  The {% tooltip label="++fl"
-href="/language/hoon/reference/stdlib/3b#fl" /%} named tuple
+integers.  The [++fl](/language/hoon/reference/stdlib/3b#fl) named tuple
 representation serves this purpose, and uses the [Dragon4
 algorithm](https://dl.acm.org/doi/10.1145/93548.93559) to accomplish the
 conversion:
@@ -178,8 +176,7 @@ conversion:
 
 It's up to you to decide how to handle this result, however!  Perhaps a
 better option for many cases is to round the answer to an `@s` integer
-with {% tooltip label="++toi:rs"
-href="/language/hoon/reference/stdlib/3b#toirs" /%}:
+with [++toi:rs](/language/hoon/reference/stdlib/3b#toirs):
 
 ```hoon
 > (toi:rs .3.1415926535)
@@ -190,7 +187,7 @@ href="/language/hoon/reference/stdlib/3b#toirs" /%}:
 
 ### Floating-point specific operations
 
-As with {% tooltip label="aura" href="/glossary/aura" /%} conversion,
+As with [aura](/glossary/aura) conversion,
 the standard mathematical operators don't work for `@rs`:
 
 ```hoon
@@ -201,9 +198,8 @@ the standard mathematical operators don't work for `@rs`:
 .1.0000001
 ```
 
-The {% tooltip label="++rs" href="/language/hoon/reference/stdlib/3b#rs"
-/%} core defines a set of `@rs`-affiliated operations which should be
-used instead:
+The [++rs](/language/hoon/reference/stdlib/3b#rs) core defines a set of
+`@rs`-affiliated operations which should be used instead:
 
 ```hoon
 > (add:rs .1 .1)
@@ -212,24 +208,22 @@ used instead:
 
 This includes:
 
-- {% tooltip label="++add:rs" href="/language/hoon/reference/stdlib/3b#addrs" /%}, addition
-- {% tooltip label="++sub:rs" href="/language/hoon/reference/stdlib/3b#subrs" /%}, subtraction
-- {% tooltip label="++mul:rs" href="/language/hoon/reference/stdlib/3b#mulrs" /%}, multiplication
-- {% tooltip label="++div:rs" href="/language/hoon/reference/stdlib/3b#divrs" /%}, division
-- {% tooltip label="++gth:rs" href="/language/hoon/reference/stdlib/3b#gthrs" /%}, greater than
-- {% tooltip label="++gte:rs" href="/language/hoon/reference/stdlib/3b#gters" /%}, greater than or equal to
-- {% tooltip label="++lth:rs" href="/language/hoon/reference/stdlib/3b#lthrs" /%}, less than
-- {% tooltip label="++lte:rs" href="/language/hoon/reference/stdlib/3b#lters" /%}, less than or equal to
-- {% tooltip label="++equ:rs" href="/language/hoon/reference/stdlib/3b#equrs" /%}, check equality (but not nearness!)
-- {% tooltip label="++sqt:rs" href="/language/hoon/reference/stdlib/3b#sqtrs" /%}, square root
+- [++add:rs](/language/hoon/reference/stdlib/3b#addrs), addition
+- [++sub:rs](/language/hoon/reference/stdlib/3b#subrs), subtraction
+- [++mul:rs](/language/hoon/reference/stdlib/3b#mulrs), multiplication
+- [++div:rs](/language/hoon/reference/stdlib/3b#divrs), division
+- [++gth:rs](/language/hoon/reference/stdlib/3b#gthrs), greater than
+- [++gte:rs](/language/hoon/reference/stdlib/3b#gters), greater than or equal to
+- [++lth:rs](/language/hoon/reference/stdlib/3b#lthrs), less than
+- [++lte:rs](/language/hoon/reference/stdlib/3b#lters), less than or equal to
+- [++equ:rs](/language/hoon/reference/stdlib/3b#equrs), check equality (but not nearness!)
+- [++sqt:rs](/language/hoon/reference/stdlib/3b#sqtrs), square root
 
 ### Exercise:  `++is-close`
 
-The {% tooltip label="++equ:rs"
-href="/language/hoon/reference/stdlib/3b#equrs" /%} arm checks for
-complete equality of two values.  The downside of this {% tooltip
-label="arm" href="/glossary/arm" /%} is that it doesn't find very close
-values:
+The [++equ:rs](/language/hoon/reference/stdlib/3b#equrs) arm checks for
+complete equality of two values.  The downside of this
+[arm](/glossary/arm) is that it doesn't find very close values:
 
 ```hoon
 > (equ:rs .1 .1)
@@ -249,7 +243,7 @@ values:
 
 #### Tutorial:  Length Converter
 
-- Write a {% tooltip label="generator" href="/glossary/generator" /%} to
+- Write a [generator](/glossary/generator) to
   take a `@tas` input measurement unit of length, a `@rs` value, and a
   `@tas` output unit to which we will convert the input measurement.
   For instance, this generator could convert a number of imperial feet
@@ -335,22 +329,19 @@ This program shows several interesting aspects, which we've covered
 before but highlight here:
 
 - Meters form the standard unit of length.
-- `~|` {% tooltip label="sigbar"
-  href="/language/hoon/reference/rune/sig#-sigbar" /%} produces an error
+- `~|` [sigbar](/language/hoon/reference/rune/sig#-sigbar) produces an error
   message in case of a bad input.
-- `+$` {% tooltip label="lusbuc"
-  href="/language/hoon/reference/rune/lus#-lusbuc" /%} is a type
+- `+$` [lusbuc](/language/hoon/reference/rune/lus#-lusbuc) is a type
   constructor arm, here for a type union over units of length.
 
 ### Exercise:  Measurement Converter
 
-- Add to this {% tooltip label="generator" href="/glossary/generator"
-  /%} the ability to convert some other measurement (volume, mass,
-  force, or another of your choosing).
-- Add an argument to the {% tooltip label="cell" href="/glossary/cell"
-  /%} required by the {% tooltip label="gate" href="/glossary/gate" /%}
-  that indicates whether the measurements are distance or your new
-  measurement.
+- Add to this [generator](/glossary/generator) the ability to convert
+  some other measurement (volume, mass, force, or another of your
+  choosing).
+- Add an argument to the [cell](/glossary/cell) required by the
+  [gate](/glossary/gate) that indicates whether the measurements are
+  distance or your new measurement.
 - Enforce strictly that the `fr-meas` and `to-meas` values are either
   lengths or your new type.
 - Create a new map of conversion values to handle your new measurement
@@ -366,29 +357,26 @@ What is `++rs`?  It's a door with 21 arms:
 <21|ezj [r=?(%d %n %u %z) <51.njr 139.oyl 33.uof 1.pnw %138>]>
 ```
 
-The {% tooltip label="battery" href="/glossary/battery" /%} of this {%
-tooltip label="core" href="/glossary/core" /%}, pretty-printed as
-`21|ezj`, has 21 arms that define functions specifically for `@rs`
-atoms.  One of these arms is named `++add`; it's a different `add` from
-the standard one we've been using for vanilla atoms, and thus the one we
-used above.  When you invoke {% tooltip label="add:rs"
-href="/language/hoon/reference/stdlib/3b#addrs" /%} instead of just
-`add` in a function call, (1) the `rs` door is produced, and then (2)
-the name search for `add` resolves to the special `add` {% tooltip
-label="arm" href="/glossary/arm" /%} in `rs`. This produces the {%
-tooltip label="gate" href="/glossary/gate" /%} for adding `@rs` atoms:
+The [battery](/glossary/battery) of this [core](/glossary/core),
+pretty-printed as `21|ezj`, has 21 arms that define functions
+specifically for `@rs` atoms.  One of these arms is named `++add`; it's
+a different `add` from the standard one we've been using for vanilla
+atoms, and thus the one we used above.  When you invoke
+[add:rs](/language/hoon/reference/stdlib/3b#addrs) instead of just `add`
+in a function call, (1) the `rs` door is produced, and then (2) the name
+search for `add` resolves to the special `add` [arm](/glossary/arm) in
+`rs`. This produces the [gate](/glossary/gate) for adding `@rs` atoms:
 
 ```hoon
 > add:rs
 <1.uka [[a=@rs b=@rs] <21.ezj [r=?(%d %n %u %z) <51.njr 139.oyl 33.uof 1.pnw %138>]>]>
 ```
 
-What about the sample of the `rs` {% tooltip label="door"
-href="/glossary/door" /%}?  The pretty-printer shows `r=?(%d %n %u %z)`.
-The {% tooltip label="rs" href="/language/hoon/reference/stdlib/3b#rs"
-/%} sample can take one of four values: `%d`, `%n`, `%u`, and `%z`.
-These argument values represent four options for how to round `@rs`
-numbers:
+What about the sample of the `rs` [door](/glossary/door)?  The
+pretty-printer shows `r=?(%d %n %u %z)`. The
+[rs](/language/hoon/reference/stdlib/3b#rs) sample can take one of four
+values: `%d`, `%n`, `%u`, and `%z`. These argument values represent four
+options for how to round `@rs` numbers:
 
 - `%d` rounds down
 - `%n` rounds to the nearest value
@@ -397,12 +385,11 @@ numbers:
 
 The default value is `%z`, round to zero.  When we invoke `++add:rs` to
 call the addition function, there is no way to modify the `rs` door
-sample, so the default rounding option is used.  How do we change it?
-We use the `~( )` notation: `~(arm door arg)`.
+sample, so the default rounding option is used.  How do we change it? We
+use the `~( )` notation: `~(arm door arg)`.
 
-Let's evaluate the `add` {% tooltip label="arm" href="/glossary/arm" /%}
-of `rs`, also modifying the door {% tooltip label="sample"
-href="/glossary/sample" /%} to `%u` for 'round up':
+Let's evaluate the `add` [arm](/glossary/arm) of `rs`, also modifying
+the door [sample](/glossary/sample) to `%u` for 'round up':
 
 ```hoon
 > ~(add rs %u)
@@ -410,22 +397,20 @@ href="/glossary/sample" /%} to `%u` for 'round up':
 ```
 
 This is the gate produced by `add`, and you can see that its sample is a
-pair of `@rs` atoms. But if you look in the context you'll see the {%
-tooltip label="rs" href="/language/hoon/reference/stdlib/3b#rs" /%}
-door. Let's look in the sample of that {% tooltip label="core"
-href="/glossary/core" /%} to make sure that it changed to `%u`. We'll
-use the wing `+6.+7` to look at the sample of the {% tooltip
-label="gate's" href="/glossary/gate" /%} context:
+pair of `@rs` atoms. But if you look in the context you'll see the
+[rs](/language/hoon/reference/stdlib/3b#rs) door. Let's look in the
+sample of that [core](/glossary/core) to make sure that it changed to
+`%u`. We'll use the wing `+6.+7` to look at the sample of the
+[gate's](/glossary/gate) context:
 
 ```hoon
 > +6.+7:~(add rs %u)
 r=%u
 ```
 
-It did indeed change.  We also see that the door {% tooltip
-label="sample" href="/glossary/sample"/%} uses the {% tooltip
-label="face" href="/glossary/face" /%} `r`, so let's use that instead of
-the unwieldy `+6.+7`:
+It did indeed change.  We also see that the door
+[sample](/glossary/sample) uses the [face](/glossary/face) `r`, so let's
+use that instead of the unwieldy `+6.+7`:
 
 ```hoon
 > r:~(add rs %u)
@@ -456,7 +441,7 @@ Why does this gap exist?  Single-precision floats are 32-bit and there's
 only so many distinctions that can be made in floats before you run out
 of bits.
 
-Just as there is a {% tooltip label="door" href="/glossary/door" /%} for
+Just as there is a [door](/glossary/door) for
 `@rs` functions, there is a Hoon standard library door for `@rd`
 functions (double-precision 64-bit floats), another for `@rq` functions
 (quad-precision 128-bit floats), and one more for `@rh` functions
@@ -498,11 +483,10 @@ mathematical operations.
 
 ### Hoon Operations
 
-`@u`-{% tooltip label="aura" href="/glossary/aura" /%} atoms are
-_unsigned_ values, but there is a complete set of _signed_ auras in the
-`@s` series.  ZigZag was chosen for Hoon's signed integer representation
-because it represents negative values with small absolute magnitude as
-short binary terms.
+`@u`-[aura](/glossary/aura) atoms are _unsigned_ values, but there is a
+complete set of _signed_ auras in the `@s` series.  ZigZag was chosen
+for Hoon's signed integer representation because it represents negative
+values with small absolute magnitude as short binary terms.
 
 | Aura | Meaning | Example |
 | ---- | ------- | ------- |
@@ -514,15 +498,14 @@ short binary terms.
 | `@sx` | signed hexadecimal | `--0x5f5.e138` (positive) |
 |       |                    | `-0x5f5.e138` (negative) |
 
-The {% tooltip label="++si" href="/language/hoon/reference/stdlib/3a#si"
-/%} core supports signed-integer operations correctly.  However, unlike
-the `@r` operations, `@s` operations have different names (likely to
-avoid accidental mental overloading).
+The [++si](/language/hoon/reference/stdlib/3a#si) core supports
+signed-integer operations correctly.  However, unlike the `@r`
+operations, `@s` operations have different names (likely to avoid
+accidental mental overloading).
 
-To produce a signed integer from an unsigned value, use {% tooltip
-label="++new:si" href="/language/hoon/reference/stdlib/3a#newsi" /%}
-with a sign flag, or simply use {% tooltip label="++sun:si"
-href="/language/hoon/reference/stdlib/3a#sunsi" /%}
+To produce a signed integer from an unsigned value, use
+[++new:si](/language/hoon/reference/stdlib/3a#newsi) with a sign flag,
+or simply use [++sun:si](/language/hoon/reference/stdlib/3a#sunsi)
 
 ```hoon
 > (new:si & 2)
@@ -535,9 +518,9 @@ href="/language/hoon/reference/stdlib/3a#sunsi" /%}
 --5
 ```
 
-To recover an unsigned integer from a signed integer, use {% tooltip
-label="++old:si" href="/language/hoon/reference/stdlib/3a#oldsi" /%},
-which returns the magnitude and the sign.
+To recover an unsigned integer from a signed integer, use
+[++old:si](/language/hoon/reference/stdlib/3a#oldsi), which returns the
+magnitude and the sign.
 
 ```hoon
 > (old:si --5)
@@ -547,20 +530,18 @@ which returns the magnitude and the sign.
 [%.n 5]
 ```
 
-- {% tooltip label="++sum:si" href="/language/hoon/reference/stdlib/3a#sumsi" /%}, addition
-- {% tooltip label="++dif:si" href="/language/hoon/reference/stdlib/3a#difsi" /%}, subtraction
-- {% tooltip label="++pro:si" href="/language/hoon/reference/stdlib/3a#prosi" /%}, multiplication
-- {% tooltip label="++fra:si" href="/language/hoon/reference/stdlib/3a#frasi" /%}, division
-- {% tooltip label="++rem:si" href="/language/hoon/reference/stdlib/3a#remsi" /%}, modulus (remainder after division), b modulo a as `@s`
-- {% tooltip label="++abs:si" href="/language/hoon/reference/stdlib/3a#abssi" /%}, absolute value
-- {% tooltip label="++cmp:si" href="/language/hoon/reference/stdlib/3a#synsi" /%}, test for greater value (as index, `>` → `--1`, `<` → `-1`, `=` → `--0`)
+- [++sum:si](/language/hoon/reference/stdlib/3a#sumsi), addition
+- [++dif:si](/language/hoon/reference/stdlib/3a#difsi), subtraction
+- [++pro:si](/language/hoon/reference/stdlib/3a#prosi), multiplication
+- [++fra:si](/language/hoon/reference/stdlib/3a#frasi), division
+- [++rem:si](/language/hoon/reference/stdlib/3a#remsi), modulus (remainder after division), b modulo a as `@s`
+- [++abs:si](/language/hoon/reference/stdlib/3a#abssi), absolute value
+- [++cmp:si](/language/hoon/reference/stdlib/3a#synsi), test for greater value (as index, `>` → `--1`, `<` → `-1`, `=` → `--0`)
 
-To convert a floating-point value from number (atom) to text, use {%
-tooltip label="++scow" href="/language/hoon/reference/stdlib/4m#scow"
-/%} or {% tooltip label="++r-co:co"
-href="/language/hoon/reference/stdlib/4k#r-coco" /%} with {% tooltip
-label="++rlys" href="/language/hoon/reference/stdlib/3b#rlys" /%} (and
-friends):
+To convert a floating-point value from number (atom) to text, use
+[++scow](/language/hoon/reference/stdlib/4m#scow) or
+[++r-co:co](/language/hoon/reference/stdlib/4k#r-coco) with
+[++rlys](/language/hoon/reference/stdlib/3b#rlys) (and friends):
 
 ```hoon
 > (scow %rs .3.14159)
@@ -575,8 +556,8 @@ friends):
 The Hoon standard library at the current time omits many [transcendental
 functions](https://en.wikipedia.org/wiki/Transcendental_function), such
 as the trigonometric functions.  It is useful to implement pure-Hoon
-versions of these, although they are not as efficient as {% tooltip
-label="jetted" href="/glossary/jet" /%} mathematical code would be.
+versions of these, although they are not as efficient as
+[jetted](/glossary/jet) mathematical code would be.
 
 - Produce a version of `++factorial` which can operate on `@rs` inputs
   correctly.
@@ -677,8 +658,8 @@ F_n = \frac{\varphi^n - (-\varphi)^{-n}}{\sqrt 5}
 F_n = \frac{\varphi^n-(-\varphi)^{-n}}{\sqrt 5} = \frac{\varphi^n-(-\varphi)^{-n}}{2 \varphi - 1}
 -->
 
-- Implement this analytical formula for the Fibonacci series as a {%
-  tooltip label="gate" href="/glossary/gate" /%}.
+- Implement this analytical formula for the Fibonacci series as a
+  [gate](/glossary/gate).
 
 ##  Date & Time Mathematics
 
@@ -702,10 +683,10 @@ since values are unsigned integers, no date before that time can be
 represented.
 
 Time values, often referred to as _timestamps_, are commonly represented
-by the [UTC](https://www.timeanddate.com/time/aboututc.html) value.
-Time representations are complicated by offset such as timezones,
-regular adjustments like daylight savings time, and irregular
-adjustments like leap seconds.  (Read [Dave Taubler's excellent
+by the [UTC](https://www.timeanddate.com/time/aboututc.html) value. Time
+representations are complicated by offset such as timezones, regular
+adjustments like daylight savings time, and irregular adjustments like
+leap seconds.  (Read [Dave Taubler's excellent
 overview](https://levelup.gitconnected.com/why-is-programming-with-dates-so-hard-7477b4aeff4c)
 of the challenges involved with calculating dates for further
 considerations, as well as [Martin Thoma's “What Every Developer Should
@@ -718,12 +699,10 @@ A timestamp can be separated into the time portion, which is the
 relative offset within a given day, and the date portion, which
 represents the absolute day.
 
-There are two {% tooltip label="molds" href="/glossary/mold" /%} to
-represent time in Hoon:  the `@d` {% tooltip label="aura"
-href="/glossary/aura" /%}, with `@da` for a full timestamp and `@dr` for
-an offset; and the {% tooltip label="+$date"
-href="/language/hoon/reference/stdlib/2q#date" /%}/{% tooltip
-label="+$tarp" href="/language/hoon/reference/stdlib/2q#tarp" /%}
+There are two [molds](/glossary/mold) to represent time in Hoon:  the
+`@d` [aura](/glossary/aura), with `@da` for a full timestamp and `@dr`
+for an offset; and the
+[+$date](/language/hoon/reference/stdlib/2q#date)/[+$tarp](/language/hoon/reference/stdlib/2q#tarp)
 structure:
 
 | Aura | Meaning | Example |
@@ -740,8 +719,8 @@ structure:
 
 `now` returns the `@da` of the current timestamp (in UTC).
 
-To go from a `@da` to a `+$tarp`, use {% tooltip label="++yell"
-href="/language/hoon/reference/stdlib/3c#yell" /%}:
+To go from a `@da` to a `+$tarp`, use
+[++yell](/language/hoon/reference/stdlib/3c#yell):
 
 ```hoon
 > *tarp
@@ -757,8 +736,8 @@ href="/language/hoon/reference/stdlib/3c#yell" /%}:
 [d=20 h=0 m=0 s=0 f=~]
 ```
 
-To go from a `@da` to a `+$date`, use {% tooltip label="++yore"
-href="/language/hoon/reference/stdlib/3c#yore" /%}:
+To go from a `@da` to a `+$date`, use
+[++yore](/language/hoon/reference/stdlib/3c#yore):
 
 ```hoon
 > (yore ~2014.6.6..21.09.15..0a16)
@@ -768,8 +747,8 @@ href="/language/hoon/reference/stdlib/3c#yore" /%}:
 [[a=%.y y=2.022] m=5 t=[d=24 h=16 m=20 s=57 f=~[0xbaec]]]
 ```
 
-To go from a `+$date` to a `@da`, use {% tooltip label="++year"
-href="/language/hoon/reference/stdlib/3c#year" /%}:
+To go from a `+$date` to a `@da`, use
+[++year](/language/hoon/reference/stdlib/3c#year):
 
 ```hoon
 > (year [[a=%.y y=2.014] m=8 t=[d=4 h=20 m=4 s=57 f=~[0xd940]]])
@@ -779,8 +758,8 @@ href="/language/hoon/reference/stdlib/3c#year" /%}:
 ~2022.5.24..16.24.16..d184
 ```
 
-To go from a `+$tarp` to a `@da`, use {% tooltip label="++yule"
-href="/language/hoon/reference/stdlib/3c#yule" /%}:
+To go from a `+$tarp` to a `@da`, use
+[++yule](/language/hoon/reference/stdlib/3c#yule):
 
 ```hoon
 > (yule (yell now))
@@ -803,9 +782,9 @@ The Urbit date system correctly compensates for the lack of Year Zero:
 ~1-.1.1
 ```
 
-The {% tooltip label="++yo" href="/language/hoon/reference/stdlib/3c#yo"
-/%} core contains constants useful for calculating time, but in general
-you should not hand-roll time or timezone calculations.
+The [++yo](/language/hoon/reference/stdlib/3c#yo) core contains
+constants useful for calculating time, but in general you should not
+hand-roll time or timezone calculations.
 
 ### Tutorial:  Julian Day
 
@@ -890,11 +869,11 @@ are in the same order as `@p`, however.  Thus:
 .~nec-dozzod-dozzod-dozzod-dozzod-dozzod-dozzod-dozzod-dozzod
 ```
 
-`@q` {% tooltip label="auras" href="/glossary/aura" /%} can be used as
+`@q` [auras](/glossary/aura) can be used as
 sequential mnemonic markers for values.
 
-The {% tooltip label="++po" href="/language/hoon/reference/stdlib/4a#po"
-/%} core contains tools for directly parsing `@q` atoms.
+The [++po](/language/hoon/reference/stdlib/4a#po) core contains tools
+for directly parsing `@q` atoms.
 
 ### Base-32 and Base-64
 
@@ -972,8 +951,7 @@ like keystroke typing latency to produce random bits.
 ### Random Numbers
 
 Given a source of entropy to seed a random number generator, one can
-then use the {% tooltip label="++og"
-href="/language/hoon/reference/stdlib/3d#og" /%} door to produce various
+then use the [++og](/language/hoon/reference/stdlib/3d#og) door to produce various
 kinds of random numbers.  The basic operations of `++og` are described
 in [the lesson on subject-oriented
 programming](/courses/hoon-school/O-subject).
@@ -1018,11 +996,11 @@ stream, as Cook illustrates in Python?
   numbers in the range [0, 1] with equal likelihood to machine
   precision.
 
-We use the LCG defined above, then chop out 23-bit slices using {%
-tooltip label="++rip" href="/language/hoon/reference/stdlib/2c#rip" /%}
-to produce each number, manually compositing the result into a valid
-floating-point number in the range [0, 1].  (We avoid producing special
-sequences like [`NaN`](https://en.wikipedia.org/wiki/NaN).)
+We use the LCG defined above, then chop out 23-bit slices using
+[++rip](/language/hoon/reference/stdlib/2c#rip) to produce each number,
+manually compositing the result into a valid floating-point number in
+the range [0, 1].  (We avoid producing special sequences like
+[`NaN`](https://en.wikipedia.org/wiki/NaN).)
 
 **`/gen/uniform.hoon`**
 
@@ -1057,8 +1035,7 @@ sequences like [`NaN`](https://en.wikipedia.org/wiki/NaN).)
 --
 ```
 
-- Convert the above to a `%say` {% tooltip label="generator"
-  href="/glossary/generator" /%} that can optionally accept a seed; if
+- Convert the above to a `%say` [generator](/glossary/generator) that can optionally accept a seed; if
   no seed is provided, use `eny`.
 
 - Produce a higher-quality Mersenne Twister uniform RNG, such as [per
@@ -1223,7 +1200,8 @@ Z = \text{sgn}\left(U-\frac{1}{2}\right) \left( t - \frac{c_{0}+c_{1} t+c_{2} t^
 $$
 -->
 
-- Implement this formula in Hoon to produce normally-distributed random numbers.
+- Implement this formula in Hoon to produce normally-distributed random
+  numbers.
 - How would you implement other random number generators?
 
 <!--
@@ -1363,8 +1341,7 @@ corresponds to it.  Hashes can be used for many purposes:
 4. **Data lookup**.  [Hash
    tables](https://en.wikipedia.org/wiki/Hash_table) are one way to
    implement a key→value mapping, such as the functionality offered by
-   Hoon's {% tooltip label="++map"
-   href="/language/hoon/reference/stdlib/2o#map" /%}.
+   Hoon's [++map](/language/hoon/reference/stdlib/2o#map).
 
 Theoretically, since the number of fixed-length hashes are finite, an
 infinite number of possible programs can yield any given hash.  This is
@@ -1374,10 +1351,9 @@ practical purposes such a collision is extremely unlikely.
 
 ### Hoon Operations
 
-The Hoon standard library supports fast insecure hashing with {% tooltip
-label="++mug" href="/language/hoon/reference/stdlib/2e#mug" /%}, which
-accepts any {% tooltip label="noun" href="/glossary/noun" /%} and
-produces an atom of the hash.
+The Hoon standard library supports fast insecure hashing with
+[++mug](/language/hoon/reference/stdlib/2e#mug), which accepts any
+[noun](/glossary/noun) and produces an atom of the hash.
 
 ```hoon
 > `@ux`(mug 1)
@@ -1410,12 +1386,11 @@ Hoon-specific metadata like aura:
 Hoon also includes [SHA-256 and
 SHA-512](https://en.wikipedia.org/wiki/SHA-2)
 [tooling](/language/hoon/reference/stdlib/3d).
-({% tooltip label="++og" href="/language/hoon/reference/stdlib/3d#og"
-/%}, the random number generator, is based on SHA-256 hashing.)
+([++og](/language/hoon/reference/stdlib/3d#og), the random number
+generator, is based on SHA-256 hashing.)
 
-- {% tooltip label="++shax" href="/language/hoon/reference/stdlib/3d#shax" /%} produces
-    a hashed atom of 256 bits from any {% tooltip label="atom"
-    href="/glossary/atom" /%}.
+- [++shax](/language/hoon/reference/stdlib/3d#shax) produces
+    a hashed atom of 256 bits from any [atom](/glossary/atom).
 
     ```hoon > (shax 1)
     69.779.012.276.202.546.540.741.613.998.220.636.891.790.827.476.075.440.677.599.814.057.037.833.368.907
@@ -1433,7 +1408,7 @@ SHA-512](https://en.wikipedia.org/wiki/SHA-2)
     0x84a4.929b.1d69.708e.d4b7.0fb8.ca97.cc85.c4a6.1aae.4596.f753.d0d2.6357.e7b9.eb0f
     ```
 
-- {% tooltip label="++shaz" href="/language/hoon/reference/stdlib/3d#shaz" /%} produces
+- [++shaz](/language/hoon/reference/stdlib/3d#shaz) produces
   a hashed atom of 512 bits from any atom.
 
     ```hoon

--- a/content/courses/hoon-school/_index.md
+++ b/content/courses/hoon-school/_index.md
@@ -31,10 +31,10 @@ The short version is that Hoon uses Urbit's provisions and protocols to
 enable very fast application development with shared primitives,
 sensible affordances, and straightforward distribution.
 
-Urbit consists of an identity protocol ({% tooltip label="\"Azimuth\""
-href="/glossary/azimuth" /%}, or “Urbit ID”) and a system protocol ({%
-tooltip label="\"Arvo\"" href="/glossary/arvo" /%}, or “Urbit OS”).
-These two parts work hand-in-hand to build your hundred-year computer.
+Urbit consists of an identity protocol (["Azimuth"](/glossary/azimuth),
+or “Urbit ID”) and a system protocol (["Arvo"](/glossary/arvo), or
+“Urbit OS”). These two parts work hand-in-hand to build your
+hundred-year computer.
 
 1. **Urbit ID (Azimuth)** is a general-purpose public-key infrastructure
    (PKI) on the Ethereum blockchain, used as a platform for Urbit
@@ -54,8 +54,8 @@ mathematical functions, making it
 and
 [functional-as-in-programming](https://en.wikipedia.org/wiki/Functional_programming).
 Such strong guarantees require an operating protocol, the [Nock virtual
-machine](/language/nock/reference/definition), which will be persistent across
-hardware changes and always provide an upgrade path for necessary
+machine](/language/nock/reference/definition), which will be persistent
+across hardware changes and always provide an upgrade path for necessary
 changes.
 
 It's hard to write a purely functional operating system on hardware
@@ -94,7 +94,8 @@ Before beginning, you'll need to get a development ship running and
 configure an appropriate editor.  See the [Environment
 Setup](/courses/environment) guide for details.
 
-Once you have a `dojo>` prompt, the system is ready to go and waiting on input.
+Once you have a `dojo>` prompt, the system is ready to go and waiting on
+input.
 
 ##  Getting started
 
@@ -113,10 +114,9 @@ http: live (insecure, loopback) on 12321
 ```
 
 You just used a function from the Hoon standard library, `add`, which
-for reasons that will become clear later is frequently written {%
-tooltip label="++add" href="/language/hoon/reference/stdlib/1a#add" /%}.
-Next, quit Urbit by entering {% tooltip label="|exit"
-href="/manual/os/dojo-tools#exit" /%} :
+for reasons that will become clear later is frequently written
+[++add](/language/hoon/reference/stdlib/1a#add). Next, quit Urbit by
+entering [|exit](/manual/os/dojo-tools#exit) :
 
 ```hoon {% copy=true %}
 > %-  add  [2 2]
@@ -148,7 +148,7 @@ You'll see:
 ```
 
 You asked Dojo to evaluate `17` and it echoed the number back at you.
-This value is a {% tooltip label="noun" href="/glossary/noun" /%}. We'll
+This value is a [noun](/glossary/noun). We'll
 talk more about nouns in the next lesson.
 
 Basically, every Hoon expression operates on the values it is given
@@ -162,13 +162,13 @@ One more:
 [1 2]
 ```
 
-This `:-` rune takes two values and composes them into a {% tooltip
-label="cell" href="/glossary/cell" /%}, a pair of values.
+This `:-` rune takes two values and composes them into a
+[cell](/glossary/cell), a pair of values.
 
 
 ##  Pronouncing Hoon
 
-Hoon uses {% tooltip label="runes" href="/glossary/rune" /%}, or
+Hoon uses [runes](/glossary/rune), or
 two-character ASCII symbols, to describe its structure.  (These are
 analogous to keywords in other programming languages.)  Because there
 has not really been a standard way of pronouncing, say, `#` (hash,

--- a/content/glossary/cue.md
+++ b/content/glossary/cue.md
@@ -3,10 +3,10 @@ title = "Cue"
 +++
 
 **Cue** is the deserialization function for nouns serialized into atoms with
-the {% tooltip label="jam" href="/glossary/jam" /%} function. Cue and Jam are
-used extensively by the kernel.
+the [jam](/glossary/jam) function. Cue and Jam are used extensively by the
+kernel.
 
-Example in the {%tooltip label="Dojo" href="/glossary/dojo" /%}:
+Example in the [Dojo](/glossary/dojo):
 
 ```
 > (jam [1 2 3])

--- a/content/glossary/head.md
+++ b/content/glossary/head.md
@@ -2,9 +2,8 @@
 title = "Head"
 +++
 
-A {% tooltip label="cell" href="/glossary/cell" /%} is an ordered pair. The
-left-hand item is called the **head**, and the right-hand item is called the {%
-tooltip label="tail" href="/glossary/tail" /%}.
+A [cell](/glossary/cell) is an ordered pair. The
+left-hand item is called the **head**, and the right-hand item is called the [tail](/glossary/tail).
 
 ```
 head

--- a/content/glossary/jam.md
+++ b/content/glossary/jam.md
@@ -2,14 +2,12 @@
 title = "Jam"
 +++
 
-**Jam** is the primary {% tooltip label="noun" href="/glossary/noun" /%}
-serialization function. It allows any noun to be packed into an {% tooltip
-label="atom" href="/glossary/atom" /%} for tranmission over the network or
-storage on disk. The jammed noun can be unpacked again with the {% tooltip
-label="cue" href="/glossary/cue" /%} function. Jam and Cue are used extensively
-by the kernel.
+**Jam** is the primary [noun](/glossary/noun) serialization function. It allows
+any noun to be packed into an [atom](/glossary/atom) for tranmission over the
+network or storage on disk. The jammed noun can be unpacked again with the
+[cue](/glossary/cue) function. Jam and Cue are used extensively by the kernel.
 
-Example in the {%tooltip label="Dojo" href="/glossary/dojo" /%}:
+Example in the [Dojo](/glossary/dojo):
 
 ```
 > (jam [1 2 3])
@@ -18,10 +16,10 @@ Example in the {%tooltip label="Dojo" href="/glossary/dojo" /%}:
 [1 2 3]
 ```
 
-Note that {% tooltip label="vases" href="/glossary/vase" /%} shouldn't be
-jammed as non-trivial types pull in a lot of the standard library and result in
-an enormous jam file. Instead, they should be cue'd to a raw noun and then {%
-tooltip label="molded" href="/glossary/mold" /%} to the desired type.
+Note that [vases](/glossary/vase) shouldn't be jammed as non-trivial types pull
+in a lot of the standard library and result in an enormous jam file. Instead,
+they should be cue'd to a raw noun and then [molded](/glossary/mold) to the
+desired type.
 
 #### Further Reading
 

--- a/content/glossary/lark.md
+++ b/content/glossary/lark.md
@@ -3,24 +3,22 @@ title = "Lark"
 +++
 
 **Lark** notation is a way to reference a relative tree address, an alternative
-to using a numerical {% tooltip label="axis" href="/glossary/axis" /%}. It's
-valid syntax as part of a {% tooltip label="wing" href="/glossary/wing" /%}
-address.
+to using a numerical [axis](/glossary/axis). It's valid syntax as part of a
+[wing](/glossary/wing) address.
 
-The syntax alternates between using `-`/`+` and `<`/`>` for {% tooltip
-label="head" href="/glossary/head" /%}/{% tooltip label="tail"
-href="/glossary/tail" /%}. It always starts with a `-`/`+`, then can follow
-with a `<`/`>`, then back to `-`/`+`, and so on. For example, `-<+>+` means
-"the tail of the tail of the tail of the head of the head of the subject" or,
-put another way, "descend into the head, then head, then tail, then tail, then
-tail."
+The syntax alternates between using `-`/`+` and `<`/`>` for
+[head](/glossary/head)/[tail](/glossary/tail). It always starts with a `-`/`+`,
+then can follow with a `<`/`>`, then back to `-`/`+`, and so on. For example,
+`-<+>+` means "the tail of the tail of the tail of the head of the head of the
+subject" or, put another way, "descend into the head, then head, then tail,
+then tail, then tail."
 
 Lark notation is usually only used for trivial cases, like `+<` or `-.foo`.
 It's generally bad practice to use long expressions like `+<->+<-<+>->-`. You
-should also use {% tooltip label="faces" href="/glossary/face" /%} like `p.foo`
+should also use [faces](/glossary/face) like `p.foo`
 rather than lark notation like `-.foo` where possible.
 
-A couple of examples in the {% tooltip label="dojo" href="/glossary/dojo" /%}:
+A couple of examples in the [dojo](/glossary/dojo):
 
 ```
 :: get the 4th item in a cell

--- a/content/glossary/tail.md
+++ b/content/glossary/tail.md
@@ -2,8 +2,8 @@
 title = "Tail"
 +++
 
-A {% tooltip label="cell" href="/glossary/cell" /%} is an ordered pair. The
-left-hand item is called the {% tooltip label="head" href="/glossary/head" /%},
+A [cell](/glossary/cell) is an ordered pair. The
+left-hand item is called the [head](/glossary/head),
 and the right-hand item is called the **tail**.
 
 ```

--- a/content/glossary/term.md
+++ b/content/glossary/term.md
@@ -2,16 +2,14 @@
 title = "Term"
 +++
 
-A **term** is an {% tooltip label="atom" href="/glossary/atom" /%} with an {%
-tooltip label="aura" href="/glossary/aura" /%} of `@tas`. It's for strings, but
-with a highly-restricted character set: lower-case letters, numbers, and the
-hyphen symbol. Additionally, the first character must be a letter. It's used
-mostly for naming and tagging.
+A **term** is an [atom](/glossary/atom) with an [aura](/glossary/aura) of
+`@tas`. It's for strings, but with a highly-restricted character set:
+lower-case letters, numbers, and the hyphen symbol. Additionally, the first
+character must be a letter. It's used mostly for naming and tagging.
 
 Note that the aura alone doesn't restrict the characters, and if necessary
-should be enforced with {% tooltip label="++sane"
-href="/language/hoon/reference/stdlib/4b#sane" /%} and {% tooltip
-label="++sand" href="/language/hoon/reference/stdlib/4b#sand" /%}.
+should be enforced with [++sane](/language/hoon/reference/stdlib/4b#sane) and
+[++sand](/language/hoon/reference/stdlib/4b#sand).
 
 ### Further Reading
 

--- a/content/manual/running/vere.md
+++ b/content/manual/running/vere.md
@@ -4,10 +4,10 @@ template = "doc.html"
 weight = 0
 +++
 
-The Urbit runtime is named {% tooltip label="Vere" href="/glossary/vere" /%}.
-It's the binary executable you use to run your ship. Vere manages your ship's
-{% tooltip label="pier" href="/glossary/pier" /%}, handles events, and runs the
-Nock virtual machine that performs your ship's computations.
+The Urbit runtime is named [Vere](/glossary/vere). It's the binary executable
+you use to run your ship. Vere manages your ship's [pier](/glossary/pier),
+handles events, and runs the Nock virtual machine that performs your ship's
+computations.
 
 Before version 1.9, Vere was split into two separate binaries: The `urbit`
 "king"/"urth" responsible for I/O and event persistence, and the `urbit-worker`

--- a/content/system/kernel/eyre/guides/eauth.md
+++ b/content/system/kernel/eyre/guides/eauth.md
@@ -3,12 +3,11 @@ title = "EAuth"
 weight = 100
 +++
 
-EAuth is a system built into {% tooltip label="Eyre" href="/glossary/eyre" /%}
-which allows one {% tooltip label="ship" href="/glossary/ship" /%} to log into
+EAuth is a system built into [Eyre](/glossary/eyre)
+which allows one [ship](/glossary/ship) to log into
 the web interface of another. Once logged in, all requests through Eyre will
-appear to Gall {% tooltip label="agents" href="/glossary/agent" /%} as having
-come from the foreign ship, in the `src` of the {% tooltip label="bowl"
-href="/glossary/bowl" /%}. The agents can apply whatever logic they want based
+appear to Gall [agents](/glossary/agent) as having
+come from the foreign ship, in the `src` of the [bowl](/glossary/bowl). The agents can apply whatever logic they want based
 on the foreign `src`. Most Urbit apps (including Landscape) don't currently
 allow requests from anyone but the local ship. Nevertheless, EAuth has many
 potential useful applications, such as a allowing comments from other ships on
@@ -16,15 +15,15 @@ a public-facing Urbit-hosted blog.
 
 ## When to use
 
-{% tooltip label="Landscape" href="/glossary/landscape" /%} and its `%docket`
+[Landscape](/glossary/landscape) and its `%docket`
 agent don't currently support access from foreign ships. You therefore cannot
 provide an app-launcher interface to foreign ships, nor serve them an ordinary
-{% tooltip label="globbed" href="/glossary/glob" /%} front-end. This leaves
+[globbed](/glossary/glob) front-end. This leaves
 three potential use-cases:
 
-1. A {%tooltip label="sail-based" href="/glossary/sail" /%} UI for a
+1. A [sail-based](/glossary/sail) UI for a
    public-facing Urbit-hosted app.
-2. A {% tooltip label="glob" href="/glossary/glob" /%}-based UI, but with the
+2. A [glob](/glossary/glob)-based UI, but with the
    front-end files served independently from `%docket`.
 3. As an authentication system for an externally hosted service, with an
    additional API for that service to talk to the ship.

--- a/content/userspace/apps/guides/remote-scry.md
+++ b/content/userspace/apps/guides/remote-scry.md
@@ -4,25 +4,24 @@ description = "Learn about scrying over the network"
 weight = 5
 +++
 
-To {% tooltip label="scry" href="/glossary/scry" /%} is to perform a
-*read* from Urbit's referentially transparent namespace. In other words,
-it's a function from a `path` to a `noun` (although in some cases, the
-resulting type may be more constrained). Previously we only supported
-scrying within the same ship, but from Kernel version `[%zuse 413]`, it
-is possible to scry from *other* ships.
+To [scry](/glossary/scry) is to perform a *read* from Urbit's
+referentially transparent namespace. In other words, it's a function
+from a `path` to a `noun` (although in some cases, the resulting type
+may be more constrained). Previously we only supported scrying within
+the same ship, but from Kernel version `[%zuse 413]`, it is possible to
+scry from *other* ships.
 
 ## Lifecycle of a scry
 
-When you think of scry, you probably think of `.^` {% tooltip
-label="dotket" href="/language/hoon/reference/rune/dot#-dotket" /%}.
-However, since networking is asynchronous, this is not a suitable
-interface for remote scry. Instead, a ship that wants to read from a
-remote part of the namespace will have to (directly or indirectly) ask
-Ames to perform the scry, which then cooperates with {% tooltip
-label="Vere" href="/glossary/vere" /%} to produce the desired data. In
-some future event when the result is available, Ames gives it back as a
-`%tune` gift. From the requester's perspective, this is the entire
-default lifecycle of a remote scry request.
+When you think of scry, you probably think of `.^`
+[dotket](/language/hoon/reference/rune/dot#-dotket). However, since
+networking is asynchronous, this is not a suitable interface for remote
+scry. Instead, a ship that wants to read from a remote part of the
+namespace will have to (directly or indirectly) ask Ames to perform the
+scry, which then cooperates with [Vere](/glossary/vere) to produce the
+desired data. In some future event when the result is available, Ames
+gives it back as a `%tune` gift. From the requester's perspective, this
+is the entire default lifecycle of a remote scry request.
 
 Of course, you need to know how Ame's `%chum` and `%tune` look, as well
 as Gall's `%keen` note, to be able to use them. There are also a few
@@ -32,8 +31,7 @@ moment, but first, let's look at what kind of data is possible to scry.
 ## Publishing
 
 At the moment, there are two vanes that can handle remote scry requests:
-{% tooltip label="Clay" href="/glossary/clay" /%} and {% tooltip
-label="Gall" href="/glossary/gall" /%}. Clay uses it to distribute
+[Clay](/glossary/clay) and [Gall](/glossary/gall). Clay uses it to distribute
 source code in a more efficient manner than is possible with
 conventional Ames, but conceptually it only extends its [local
 scries](/system/kernel/clay/reference/scry) over the network, with the


### PR DESCRIPTION
replace {% tooltip ... /%} with normal markdown links and fix line wrapping