### PR TITLE
Unwrap runes from backticks in /rune H2 headings

### DIFF
--- a/content/hoon/reference/rune/bar.md
+++ b/content/hoon/reference/rune/bar.md
@@ -4,7 +4,7 @@ Core expressions produce cores. A core is a cell of `[battery payload]`. The `ba
 
 Five core runes (`|=`, `|.`, `|-`, `|*`, and `|$`) produce a core with a single arm, named `$`. As with all arms, we can recompute `$` with changes, which is useful for recursion among other things.
 
-## `|$` "barbuc" {#barbuc}
+## |$ "barbuc" {#barbuc}
 
 Declares a mold builder wet gate with one or more molds as its sample.
 
@@ -87,7 +87,7 @@ Proper style for `|$` is to enclose the first argument with brackets, even if it
 
 ---
 
-## `|_` "barcab" {#barcab}
+## |_ "barcab" {#barcab}
 
 Produce a **door** (a core with a sample).
 
@@ -198,7 +198,7 @@ The `ne` door prints a digit in base 10, 16, 32 or 64:
 
 ---
 
-## `|:` "barcol" {#barcol}
+## |: "barcol" {#barcol}
 
 Produce a gate with a custom sample.
 
@@ -270,7 +270,7 @@ This is useful if you want a gate to have a sample of a particular type, but you
 
 ---
 
-## `|%` "barcen" {#barcen}
+## |% "barcen" {#barcen}
 
 Produce a core, `[battery payload]`.
 
@@ -352,7 +352,7 @@ A trivial core:
 
 ---
 
-## `|.` "bardot" {#bardot}
+## |. "bardot" {#bardot}
 
 Produce a trap (a core with one arm `$`).
 
@@ -422,7 +422,7 @@ Note that we can use `$()` to recurse back into the trap, since it's a core with
 
 ---
 
-## `|^` "barket" {#barket}
+## |^ "barket" {#barket}
 
 Produce a core whose battery includes a `$` arm and compute the latter.
 
@@ -501,7 +501,7 @@ A trivial example:
 
 ---
 
-## `|-` "barhep" {#barhep}
+## |- "barhep" {#barhep}
 
 Produce a trap (a core with one arm `$`) and evaluate it.
 
@@ -560,7 +560,7 @@ The classic loop is a decrement:
 
 ---
 
-## `|~` "barsig" {#barsig}
+## |~ "barsig" {#barsig}
 
 Produce an iron gate.
 
@@ -624,7 +624,7 @@ See [this discussion of core variance models](../advanced.md)
 
 ---
 
-## `|*` "bartar" {#bartar}
+## |* "bartar" {#bartar}
 
 Produce a wet gate (one-armed core with sample).
 
@@ -688,7 +688,7 @@ The dry gate does not preserve the type of `a` and `b`; the wet gate does.
 
 ---
 
-## `|=` "bartis" {#bartis}
+## |= "bartis" {#bartis}
 
 Produce a gate (a one-armed core with a sample).
 
@@ -774,7 +774,7 @@ A slightly less trivial gate:
 
 ---
 
-## `|@` "barpat" {#barpat}
+## |@ "barpat" {#barpat}
 
 Produce a 'wet' core `[battery payload]`.
 
@@ -829,7 +829,7 @@ The `|@` rune is just like the `|%` rune except that instead of producing a 'dry
 
 ---
 
-## `|?` "barwut" {#barwut}
+## |? "barwut" {#barwut}
 
 Produce a lead trap.
 

--- a/content/hoon/reference/rune/buc.md
+++ b/content/hoon/reference/rune/buc.md
@@ -16,7 +16,7 @@ In any case, since molds are just functions, we can use functional programming t
 
 ---
 
-## `$|` "bucbar" {#bucbar}
+## $| "bucbar" {#bucbar}
 
 Structure that satisfies a validator.
 
@@ -103,7 +103,7 @@ Here [`|$`](bar.md#barbuc) is used to define a mold builder that takes in a mold
 
 ---
 
-## `$_` "buccab" {#buccab}
+## $_ "buccab" {#buccab}
 
 Structure that normalizes to an example.
 
@@ -148,7 +148,7 @@ One argument, fixed.
 
 ---
 
-## `$%` "buccen" {#buccen}
+## $% "buccen" {#buccen}
 
 Structure which recognizes a union tagged by head atom.
 
@@ -221,7 +221,7 @@ Make sure the last item in your `$%` terminates, or the default will be an infin
 
 ---
 
-## `$:` "buccol" {#buccol}
+## $: "buccol" {#buccol}
 
 Form a cell type.
 
@@ -300,7 +300,7 @@ The tuple the length of `p`.
 
 ---
 
-## `$<` "bucgal" {#bucgal}
+## $< "bucgal" {#bucgal}
 
 Filters a pre-existing mold to obtain a mold that excludes a particular structure.
 
@@ -367,7 +367,7 @@ ford: %ride failed to execute:
 
 ---
 
-## `$>` "bucgar" {#bucgar}
+## $> "bucgar" {#bucgar}
 
 Filters a mold to obtain a new mold matching a particular structure.
 
@@ -446,7 +446,7 @@ ford: %ride failed to execute:
 
 ---
 
-## `$-` "buchep" {#buchep}
+## $- "buchep" {#buchep}
 
 Structure that normalizes to an example gate.
 
@@ -511,7 +511,7 @@ Since a `$-` reduces to a [`$_`](#_-buccab), it is not useful for normalizing, j
 
 ---
 
-## `$^` "bucket" {#bucket}
+## $^ "bucket" {#bucket}
 
 Structure which normalizes a union tagged by head depth (cell).
 
@@ -579,7 +579,7 @@ The default of `p`.
 
 ---
 
-## `$+` "buclus" {#buclus}
+## $+ "buclus" {#buclus}
 
 Specify a shorthand type name for use in prettyprinting.
 
@@ -641,7 +641,7 @@ The default of `p`.
 
 ---
 
-## `$&` "bucpam" {#bucpam}
+## $& "bucpam" {#bucpam}
 
 Repair a value of a tagged union type.
 
@@ -713,7 +713,7 @@ Here `adapting` is a structure that bunts to `[%1 ^]` but also normalizes from `
 
 ---
 
-## `$~` "bucsig" {#bucsig}
+## $~ "bucsig" {#bucsig}
 
 Define a custom type default value.
 
@@ -809,7 +809,7 @@ Using `$~`:
 
 ---
 
-## `$@` "bucpat" {#bucpat}
+## $@ "bucpat" {#bucpat}
 
 Structure which normalizes a union tagged by head depth (atom).
 
@@ -879,7 +879,7 @@ A structure which applies `p` if its sample is an atom, `q` if its sample is a c
 
 ---
 
-## `$=` "buctis" {#buctis}
+## $= "buctis" {#buctis}
 
 Structure which wraps a face around another structure.
 
@@ -947,7 +947,7 @@ ford: %ride failed to execute:
 
 ---
 
-## `$?` "bucwut" {#bucwut}
+## $? "bucwut" {#bucwut}
 
 Form a type from a union of other types.
 

--- a/content/hoon/reference/rune/cen.md
+++ b/content/hoon/reference/rune/cen.md
@@ -4,7 +4,7 @@ The `%` family of runes is used for making 'function calls' in Hoon. To be more 
 
 These runes reduce to the `%=` rune.
 
-## `%_` "cencab" {#cencab}
+## %_ "cencab" {#cencab}
 
 Resolve a wing with changes, preserving type.
 
@@ -101,7 +101,7 @@ See [how wings are resolved](../limbs).
 
 ---
 
-## `%:` "cencol" {#cencol}
+## %: "cencol" {#cencol}
 
 Call a gate with many arguments.
 
@@ -184,7 +184,7 @@ When `%:` is used in tall-form syntax, the series of expressions after `p` must 
 
 ---
 
-## `%.` "cendot" {#cendot}
+## %. "cendot" {#cendot}
 
 Call a gate (function), inverted.
 
@@ -227,7 +227,7 @@ The `%.` rune is for evaluating the `$` arm of a gate, i.e., calling a function.
 
 ---
 
-## `%-` "cenhep" {#cenhep}
+## %- "cenhep" {#cenhep}
 
 Call a gate (function).
 
@@ -296,7 +296,7 @@ This rune is for evaluating the `$` arm of a gate, i.e., calling a gate as a fun
 
 ---
 
-## `%^` "cenket" {#cenket}
+## %^ "cenket" {#cenket}
 
 Call gate with triple sample.
 
@@ -358,7 +358,7 @@ d
 
 ---
 
-## `%+` "cenlus" {#cenlus}
+## %+ "cenlus" {#cenlus}
 
 Call gate with a cell sample.
 
@@ -422,7 +422,7 @@ A `%+` expression is for calling a gate with a cell sample. `a` is the gate to b
 
 ---
 
-## `%~` "censig" {#censig}
+## %~ "censig" {#censig}
 
 Evaluate an arm in a door.
 
@@ -497,7 +497,7 @@ See also [`|_`](bar.md#barcab).
 
 ---
 
-## `%*` "centar" {#centar}
+## %* "centar" {#centar}
 
 Evaluate an expression, then resolve a wing with changes.
 
@@ -601,7 +601,7 @@ A `%*` expression evaluates some arbitrary Hoon expression, `b`, and then resolv
 
 ---
 
-## `%=` "centis" {#centis}
+## %= "centis" {#centis}
 
 Resolve a wing with changes.
 

--- a/content/hoon/reference/rune/col.md
+++ b/content/hoon/reference/rune/col.md
@@ -3,7 +3,7 @@
 The `:` ("col") expressions are used to produce cells, which are pairs of
 values. E.g., `:-(p q)` produces the cell `[p q]`. All `:` runes reduce to `:-`.
 
-## `:-` "colhep" {#colhep}
+## :- "colhep" {#colhep}
 
 Construct a cell (2-tuple).
 
@@ -74,7 +74,7 @@ Hoon expressions actually use the same "autocons" pattern as Nock formulas. If y
 
 ---
 
-## `:_` "colcab" {#colcab}
+## :_ "colcab" {#colcab}
 
 Construct a cell, inverted.
 
@@ -130,7 +130,7 @@ None
 
 ---
 
-## `:+` "collus" {#collus}
+## :+ "collus" {#collus}
 
 Construct a triple (3-tuple).
 
@@ -194,7 +194,7 @@ r
 
 ---
 
-## `:^` "colket" {#colket}
+## :^ "colket" {#colket}
 
 Construct a quadruple (4-tuple).
 
@@ -260,7 +260,7 @@ s
 
 ---
 
-## `:*` "coltar" {#coltar}
+## :* "coltar" {#coltar}
 
 Construct an n-tuple.
 
@@ -350,7 +350,7 @@ $(p t.p)
 
 ---
 
-## `:~` "colsig" {#colsig}
+## :~ "colsig" {#colsig}
 
 Construct a null-terminated list.
 
@@ -438,7 +438,7 @@ Note that this does not produce a `list` type, it just produces a null-terminate
 
 ---
 
-## `::` "colcol" {#colcol}
+## :: "colcol" {#colcol}
 
 Code comment.
 

--- a/content/hoon/reference/rune/dot.md
+++ b/content/hoon/reference/rune/dot.md
@@ -2,7 +2,7 @@
 
 Anything Nock can do, Hoon can do also. These runes are used for carrying out Nock operations in Hoon.
 
-## `.^` "dotket" {#dotket}
+## .^ "dotket" {#dotket}
 
 Load from the Arvo namespace (scry) with a fake Nock instruction: Nock 12.
 
@@ -114,7 +114,7 @@ You can modify the time of the file listing quite simply and ask for a listing f
 
 ---
 
-## `.+` "dotlus" {#dotlus}
+## .+ "dotlus" {#dotlus}
 
 Increment an atom with Nock `4`.
 
@@ -152,7 +152,7 @@ nest-fail
 
 ---
 
-## `.*` "dottar" {#dottar}
+## .* "dottar" {#dottar}
 
 Evaluate with Nock `2`.
 
@@ -229,7 +229,7 @@ Note also that `.*` ("dottar") can be used to bypass the type system. It's there
 
 ---
 
-## `.=` "dottis" {#dottis}
+## .= "dottis" {#dottis}
 
 Test for equality with Nock `5`.
 
@@ -301,7 +301,7 @@ Like Nock equality, `.=` ("dottis") tests whether two nouns are the same, ignori
 
 ---
 
-## `.?` "dotwut" {#dotwut}
+## .? "dotwut" {#dotwut}
 
 Test for cell or atom with Nock `3`.
 

--- a/content/hoon/reference/rune/fas.md
+++ b/content/hoon/reference/rune/fas.md
@@ -13,7 +13,7 @@ The Dojo does not support Ford runes at the current time, so you should instead 
 'baz'
 ```
 
-## `/-` "fashep" {#fashep}
+## /- "fashep" {#fashep}
 
 Import structure libraries from `/sur`.
 
@@ -33,7 +33,7 @@ Imports may be given a different face by doing `xyz=foo`. Imports may have their
 
 ---
 
-## `/+` "faslus" {#faslus}
+## /+ "faslus" {#faslus}
 
 Import libraries from `/lib`.
 
@@ -53,7 +53,7 @@ Imports may be given a different face by doing `xyz=foo`. Imports may have their
 
 ---
 
-## `/=` "fastis" {#fastis}
+## /= "fastis" {#fastis}
 
 Build and import a hoon file at the specified path.
 
@@ -81,7 +81,7 @@ To build and import `/foo/bar.hoon` you would do:
 
 ---
 
-## `/*` "fastar" {#fastar}
+## /* "fastar" {#fastar}
 
 Import the file at the specified path as the specified mark.
 
@@ -111,7 +111,7 @@ To import `/foo/bar.hoon` you would do:
 
 ---
 
-## `/$` "fasbuc" {#fasbuc}
+## /$ "fasbuc" {#fasbuc}
 
 Import mark conversion gate.
 
@@ -149,7 +149,7 @@ like:
 
 ---
 
-## `/~` "fassig" {#fassig}
+## /~ "fassig" {#fassig}
 
 Import, build, evaluate and pin the results of many hoon files in a directory.
 
@@ -193,7 +193,7 @@ Then the following `/~` expression:
 
 ---
 
-## `/%` "fascen" {#fascen}
+## /% "fascen" {#fascen}
 
 Build and import a mark core.
 

--- a/content/hoon/reference/rune/ket.md
+++ b/content/hoon/reference/rune/ket.md
@@ -4,7 +4,7 @@
 
 The `nest` algorithm which tests subtyping is conservative; it never allows invalid nests, it sometimes rejects valid nests.
 
-## `^|` "ketbar" {#ketbar}
+## ^| "ketbar" {#ketbar}
 
 Convert a gold core to an iron core (contravariant).
 
@@ -48,7 +48,7 @@ The prettyprinter shows the core metal (`.` gold, `|` iron):
 
 ---
 
-## `^:` "ketcol" {#ketcol}
+## ^: "ketcol" {#ketcol}
 
 Switch parser into structure mode (mold definition) and produce a gate for type `p`.  (See [`,` com]() which toggles modes.)
 
@@ -109,7 +109,7 @@ ford: %ride failed to execute:
 
 ---
 
-## `^.` "ketdot" {#ketdot}
+## ^. "ketdot" {#ketdot}
 
 Typecast on value produced by passing `q` to `p`.
 
@@ -181,7 +181,7 @@ mint-vain
 
 ---
 
-## `^-` "kethep" {#kethep}
+## ^- "kethep" {#kethep}
 
 Typecast by explicit type label.
 
@@ -254,7 +254,7 @@ It's a good practice to put a `^-` ("kethep") at the top of every arm (including
 [~ ~.a]
 ```
 
-## `^+` "ketlus" {#ketlus}
+## ^+ "ketlus" {#ketlus}
 
 Typecast by inferred type.
 
@@ -308,7 +308,7 @@ The value of `q` with the type of `p`, if the type of `q` nests within the type 
 
 ---
 
-## `^&` "ketpam" {#ketpam}
+## ^& "ketpam" {#ketpam}
 
 Convert a core to a zinc core (covariant).
 
@@ -373,7 +373,7 @@ ford: %ride failed to compute type:
 
 ---
 
-## `^~` "ketsig" {#ketsig}
+## ^~ "ketsig" {#ketsig}
 
 Fold constant at compile time.
 
@@ -407,7 +407,7 @@ One argument, fixed.
 
 ---
 
-## `^*` "kettar" {#kettar}
+## ^* "kettar" {#kettar}
 
 Produce example type value.
 
@@ -464,7 +464,7 @@ Irregular:
 
 ---
 
-## `^=` "kettis" {#kettis}
+## ^= "kettis" {#kettis}
 
 Bind name to a value.
 
@@ -533,7 +533,7 @@ a=1
 
 ---
 
-## `^?` "ketwut" {#ketwut}
+## ^? "ketwut" {#ketwut}
 
 Convert any core to a lead core (bivariant).
 

--- a/content/hoon/reference/rune/lus.md
+++ b/content/hoon/reference/rune/lus.md
@@ -6,7 +6,7 @@ Arm runes are used to define arms in a core, and thus can only be used from with
 
 There are various arm runes you can use to produce different kinds of arms. Normal arms use `++`; arms defining a structure (or 'mold') use `+$`; and constructor arms use `+*`.
 
-## `+|` "lusbar" {#lusbar}
+## +| "lusbar" {#lusbar}
 
 Chapter label (not useful)
 
@@ -58,7 +58,7 @@ Notice that `p.q` has the label `%numbers`. Contrast with:
 
 ---
 
-## `$` "lusbuc" {#lusbuc}
+## +$ "lusbuc" {#lusbuc}
 
 Produce a structure arm (type definition).
 
@@ -98,7 +98,7 @@ nest-fail
 
 ---
 
-## `+` "luslus" {#luslus}
+## ++ "luslus" {#luslus}
 
 Produce a normal arm.
 
@@ -135,7 +135,7 @@ Any Hoon expression, `q`, may be used to define the arm computation.
 
 ---
 
-## `+*` "lustar" {#lustar}
+## +* "lustar" {#lustar}
 
 Defines deferred expressions within doors.
 

--- a/content/hoon/reference/rune/mic.md
+++ b/content/hoon/reference/rune/mic.md
@@ -2,7 +2,7 @@
 
 Miscellaneous useful macros.
 
-## `;:` "miccol" {#miccol}
+## ;: "miccol" {#miccol}
 
 Call a binary function as an n-ary function.
 
@@ -93,7 +93,7 @@ Irregular form:
 
 ---
 
-## `;<` "micgal" {#micgal}
+## ;< "micgal" {#micgal}
 
 Monadic do notation.
 
@@ -165,7 +165,7 @@ Here we see the result of chaining them together:
 
 ---
 
-## `;+` "miclus" {#miclus}
+## ;+ "miclus" {#miclus}
 
 make a single XML node (Sail)
 
@@ -226,7 +226,7 @@ One interesting thing about Sail is that it allows you to use complex Hoon expre
 
 ---
 
-## `;;` "micmic" {#micmic}
+## ;; "micmic" {#micmic}
 
 Mold noun.
 
@@ -298,7 +298,7 @@ Using micmic instead:
 
 ---
 
-## `;/` "micfas" {#micfas}
+## ;/ "micfas" {#micfas}
 
 Tape as XML element.
 
@@ -331,7 +331,7 @@ One argument, fixed.
 
 ---
 
-## `;~` "micsig" {#micsig}
+## ;~ "micsig" {#micsig}
 
 Glue a pipeline together with a product-sample adapter.
 
@@ -469,7 +469,7 @@ A more complicated example:
 
 ---
 
-## `;*` "mictar" {#mictar}
+## ;* "mictar" {#mictar}
 
 make a list of XML nodes from complex Hoon expression (Sail)
 
@@ -523,7 +523,7 @@ If you need a complex Hoon expression to produce a `marl`, use the `;*` rune. Of
 
 ---
 
-## `;=` "mictis" {#mictis}
+## ;= "mictis" {#mictis}
 
 make a list of XML nodes (Sail)
 

--- a/content/hoon/reference/rune/sig.md
+++ b/content/hoon/reference/rune/sig.md
@@ -2,7 +2,7 @@
 
 Runes that use Nock `11` to pass non-semantic info to the interpreter. A mnemonic to remember what sig runes are for is "we're *sig*naling some information to the interpreter".
 
-## `~>` "siggar" {#siggar}
+## ~> "siggar" {#siggar}
 
 Raw hint, applied to computation.
 
@@ -74,7 +74,7 @@ Running the compiler:
 
 ---
 
-## `~|` "sigbar" {#sigbar}
+## ~| "sigbar" {#sigbar}
 
 Tracing printf.
 
@@ -138,7 +138,7 @@ dojo: hoon expression failed
 
 ---
 
-## `~$` "sigbuc" {#sigbuc}
+## ~$ "sigbuc" {#sigbuc}
 
 Profiling hit counter.
 
@@ -215,7 +215,7 @@ my-hit-counter: 42
 
 ---
 
-## `~_` "sigcab" {#sigcab}
+## ~_ "sigcab" {#sigcab}
 
 User-formatted tracing printf.
 
@@ -283,7 +283,7 @@ dojo: hoon expression failed
 
 ---
 
-## `~%` "sigcen" {#sigcen}
+## ~% "sigcen" {#sigcen}
 
 Jet registration.
 
@@ -376,7 +376,7 @@ Here we label the entire `++aes` core for optimization.
 
 ---
 
-## `~<` "siggal" {#siggal}
+## ~< "siggal" {#siggal}
 
 Raw hint, applied to product.
 
@@ -438,7 +438,7 @@ None
 
 ---
 
-## `~+` "siglus" {#siglus}
+## ~+ "siglus" {#siglus}
 
 Cache a computation.
 
@@ -489,7 +489,7 @@ This should work fine:
 
 ---
 
-## `~/` "sigfas" {#sigfas}
+## ~/ "sigfas" {#sigfas}
 
 Jet registration for gate with registered context.
 
@@ -551,7 +551,7 @@ From the kernel:
 
 ---
 
-## `~&` "sigpam" {#sigpam}
+## ~& "sigpam" {#sigpam}
 
 Debugging printf.
 
@@ -629,7 +629,7 @@ A logging level can be specified by including `>` markers, i.e. `>`, `>>`,
 
 ---
 
-## `~=` "sigtis" {#sigtis}
+## ~= "sigtis" {#sigtis}
 
 Detect duplicate.
 
@@ -699,7 +699,7 @@ Without `~=`, it would build a copy of a completely unchanged tree. Sad!
 
 ---
 
-## `~?` "sigwut" {#sigwut}
+## ~? "sigwut" {#sigwut}
 
 Conditional debug printf.
 
@@ -773,7 +773,7 @@ If `p` is true, prettyprints `q` on the console before computing `r`.
 
 ---
 
-## `~!` "sigzap" {#sigzap}
+## ~! "sigzap" {#sigzap}
 
 Print type on compilation fail.
 

--- a/content/hoon/reference/rune/terminators.md
+++ b/content/hoon/reference/rune/terminators.md
@@ -2,7 +2,7 @@
 
 The `--` and `==` are used as terminators: `--` for core expressions, and `==` for terminating a 'running' or 'jogging' series of Hoon expressions.
 
-## `--` "hephep" {#hephep}
+## -- "hephep" {#hephep}
 
 #### Syntax
 
@@ -33,7 +33,7 @@ The `|%`, `|_`, and `|^` runes are used to create cores that can have arbitraril
 
 ---
 
-## `==` "tistis" {#tistis}
+## == "tistis" {#tistis}
 
 #### Syntax
 

--- a/content/hoon/reference/rune/tis.md
+++ b/content/hoon/reference/rune/tis.md
@@ -12,7 +12,7 @@ Of course there are many variations on ways to modify the subject, useful for di
 
 ---
 
-## `=>` "tisgar" {#tisgar}
+## => "tisgar" {#tisgar}
 
 Compose two expressions.
 
@@ -81,7 +81,7 @@ the product of `q`, with the product of `p` taken as the subject.
 
 ---
 
-## `=|` "tisbar" {#tisbar}
+## =| "tisbar" {#tisbar}
 
 Combine a named noun with the subject by "bunting" (producing the default value) of a given mold.
 
@@ -146,7 +146,7 @@ Speaking more loosely, `=|` usually "declares a variable" which is "uninitialize
 
 ---
 
-## `=:` "tiscol" {#tiscol}
+## =: "tiscol" {#tiscol}
 
 Change multiple legs in the subject.
 
@@ -213,7 +213,7 @@ This rune is like `=.`, but for modifying the values of multiple legs of the sub
 
 ---
 
-## `=,` "tiscom" {#tiscom}
+## =, "tiscom" {#tiscom}
 
 Expose namespace.
 
@@ -293,7 +293,7 @@ With a dojo-defined face:
 
 ---
 
-## `=.` "tisdot" {#tisdot}
+## =. "tisdot" {#tisdot}
 
 Change one leg in the subject.
 
@@ -363,7 +363,7 @@ nest-fail
 
 ---
 
-## `=-` "tishep" {#tishep}
+## =- "tishep" {#tishep}
 
 Combine a new noun with the subject, inverted.
 
@@ -431,7 +431,7 @@ None
 
 ---
 
-## `=^` "tisket" {#tisket}
+## =^ "tisket" {#tisket}
 
 Pin the head of a pair; change a leg with the tail.
 
@@ -510,7 +510,7 @@ The `og` core is a stateful pseudo-random number generator. We have to change th
 
 ---
 
-## `=<` "tisgal" {#tisgal}
+## =< "tisgal" {#tisgal}
 
 Compose two expressions, inverted.
 
@@ -582,7 +582,7 @@ p:q
 
 ---
 
-## `=+` "tislus" {#tislus}
+## =+ "tislus" {#tislus}
 
 Combine a new noun with the subject.
 
@@ -650,7 +650,7 @@ Loosely speaking, `=+` is the simplest way of "declaring a variable."
 
 ---
 
-## `=;` "tismic" {#tismic}
+## =; "tismic" {#tismic}
 
 Combine a named noun with the subject, possibly with type annotation; inverted order.
 
@@ -716,7 +716,7 @@ None
 
 ---
 
-## `=/` "tisfas" {#tisfas}
+## =/ "tisfas" {#tisfas}
 
 Combine a named noun with the subject, possibly with type annotation.
 
@@ -805,7 +805,7 @@ r
 
 ---
 
-## `=~` "tissig" {#tissig}
+## =~ "tissig" {#tissig}
 
 Compose many expressions.
 
@@ -886,7 +886,7 @@ The product of the chain composition.
 
 ---
 
-## `=*` "tistar" {#tistar}
+## =* "tistar" {#tistar}
 
 Define a deferred expression.
 
@@ -963,7 +963,7 @@ This lets you reference the whole `state` while also being able to reference its
 
 ---
 
-## `=?` "tiswut" {#tiswut}
+## =? "tiswut" {#tiswut}
 
 Conditionally change one leg in the subject.
 

--- a/content/hoon/reference/rune/wut.md
+++ b/content/hoon/reference/rune/wut.md
@@ -14,7 +14,7 @@ If the compiler detects that the branch is degenerate (only one side is taken), 
 
 ---
 
-## `?|` "wutbar" {#wutbar}
+## ?| "wutbar" {#wutbar}
 
 Logical OR.
 
@@ -95,7 +95,7 @@ If any argument evaluates to true (`%.y`), true. If all arguments evaluate to fa
 
 ---
 
-## `?-` "wuthep" {#wuthep}
+## ?- "wuthep" {#wuthep}
 
 Switch against a union, with no default.
 
@@ -208,7 +208,7 @@ A missing case will throw the `mint-lost` error. An extra case will throw `mint-
 
 ---
 
-## `?:` "wutcol" {#wutcol}
+## ?: "wutcol" {#wutcol}
 
 Branch on a boolean test.
 
@@ -282,7 +282,7 @@ Note also that all other branching expressions reduce to `?:`.
 
 ---
 
-## `?.` "wutdot" {#wutdot}
+## ?. "wutdot" {#wutdot}
 
 Branch on a boolean test, inverted.
 
@@ -355,7 +355,7 @@ As is usual with inverted forms, use `?.` when the true-case expression is much 
 
 ---
 
-## `?^` "wutket" {#wutket}
+## ?^ "wutket" {#wutket}
 
 Branch on whether a wing of the subject is a cell.
 
@@ -423,7 +423,7 @@ The type of the wing, `p`, must not be known to be either an atom or a cell, or 
 
 ---
 
-## `?<` "wutgal" {#wutgal}
+## ?< "wutgal" {#wutgal}
 
 Negative assertion.
 
@@ -494,7 +494,7 @@ nest-fail
 
 ---
 
-## `?>` "wutgar" {#wutgar}
+## ?> "wutgar" {#wutgar}
 
 Positive assertion.
 
@@ -565,7 +565,7 @@ nest-fail
 
 ---
 
-## `?+` "wutlus" {#wutlus}
+## ?+ "wutlus" {#wutlus}
 
 Switch against a union, with a default.
 
@@ -676,7 +676,7 @@ If there is a case that is never taken you'll get a `mint-vain` error.
 
 ---
 
-## `?&` "wutpam" {#wutpam}
+## ?& "wutpam" {#wutpam}
 
 Logical AND.
 
@@ -756,7 +756,7 @@ If ALL arguments evaluate to true (`%.y`), true (`%.y`). If one or more evalute 
 
 ---
 
-## `?@` "wutpat" {#wutpat}
+## ?@ "wutpat" {#wutpat}
 
 Branch on whether a wing of the subject is an atom.
 
@@ -828,7 +828,7 @@ The type of the wing, `p`, must not be known to be either an atom or a cell, or 
 
 ---
 
-## `?~` "wutsig" {#wutsig}
+## ?~ "wutsig" {#wutsig}
 
 Branch on whether a wing of the subject is null.
 
@@ -896,7 +896,7 @@ null, `~`.
 
 ---
 
-## `?=` "wuttis" {#wuttis}
+## ?= "wuttis" {#wuttis}
 
 Test pattern match.
 
@@ -959,7 +959,7 @@ A common error is `find.$`, meaning `p` is not a type.
 
 ---
 
-## `?!` "wutzap" {#wutzap}
+## ?! "wutzap" {#wutzap}
 
 Logical NOT.
 

--- a/content/hoon/reference/rune/zap.md
+++ b/content/hoon/reference/rune/zap.md
@@ -1,6 +1,6 @@
 # ! zap · Wild
 
-## `!,` "zapcom" {#zapcom}
+## !, "zapcom" {#zapcom}
 
 Produce the Hoon AST of an expression.
 
@@ -57,7 +57,7 @@ This produces the [`$hoon`](../stdlib/4o.md#hoon) AST of expression `q`. The fir
 
 ---
 
-## `!>` "zapgar" {#zapgar}
+## !> "zapgar" {#zapgar}
 
 Wrap a noun in its type (form a [`vase`](../stdlib/4o.md#vase)).
 
@@ -99,7 +99,7 @@ If you want just the type value, use a 'type spear'. This is `-:!>`, i.e., the h
 
 ---
 
-## `!<` "zapgal" {#zapgal}
+## !< "zapgal" {#zapgal}
 
 Extracts a [`vase`](../stdlib/4o.md#vase) to the given mold if its type nests.
 
@@ -163,7 +163,7 @@ nest-fail
 
 ---
 
-## `!;` "zapmic" {#zapmic}
+## !; "zapmic" {#zapmic}
 
 Wrap a noun in its type (raw).
 
@@ -224,7 +224,7 @@ It's unlikely you'd use this rune directly; [`!>`](#-zapgar) is much more typica
 
 ---
 
-## `!=` "zaptis" {#zaptis}
+## != "zaptis" {#zaptis}
 
 Make the Nock formula for a Hoon expression.
 
@@ -299,7 +299,7 @@ The syntax difference is that a test for equality takes two subexpressions, and 
 
 ---
 
-## `!?` "zapwut" {#zapwut}
+## !? "zapwut" {#zapwut}
 
 Restrict Hoon version.
 
@@ -367,7 +367,7 @@ When `p` is a cell:
 
 ---
 
-## `!@` "zappat" {#zappat}
+## !@ "zappat" {#zappat}
 
 Branch on whether a wing exists.
 
@@ -427,7 +427,7 @@ None
 
 ---
 
-## `!!` "zapzap" {#zapzap}
+## !! "zapzap" {#zapzap}
 
 Crash.
 
@@ -462,7 +462,7 @@ dojo: hoon expression failed
 
 ---
 
-## `!:` "zapcol" {#zapcol}
+## !: "zapcol" {#zapcol}
 
 Turn on stack trace.
 
@@ -497,7 +497,7 @@ dojo: hoon expression failed
 
 ---
 
-## `!.` "zapdot" {#zapdot}
+## !. "zapdot" {#zapdot}
 
 Turn off stack trace for a subexpression `p`
 


### PR DESCRIPTION
Attempt to make runes more searchable. Can't test new searchbar results in the GitBook preview, so I'm just merging this.