### PR TITLE
Fix some link formatting

### DIFF
--- a/content/SUMMARY.md
+++ b/content/SUMMARY.md
@@ -138,8 +138,8 @@
   * [Wire](glossary/wire.md)
   * [Wrapper](glossary/wrapper.md)
   * [Zuse](glossary/zuse.md)
-  * [\~](glossary/null.md)
-  * [\~zod](glossary/zod.md)
+  * [~](glossary/null.md)
+  * [~zod](glossary/zod.md)
 
 ## Build on Urbit
 

--- a/content/urbit-id/what-is-urbit-id.md
+++ b/content/urbit-id/what-is-urbit-id.md
@@ -33,14 +33,14 @@ You can read these contracts on Etherscan:
 
 ### General Azimuth Resources <a href="#general-azimuth-resources" id="general-azimuth-resources"></a>
 
-These documents pertain to L1 and other general aspects of Azimuth. For L2 docs, [see below](https://docs.urbit.org/urbit-id#naive-rollups).
+These documents pertain to L1 and other general aspects of Azimuth. For L2 docs, [see below](#naive-rollups).
 
-* [HD Wallet](https://docs.urbit.org/urbit-id/concepts/hd-wallet) - Azimuth has its own optional hierarchical deterministic wallet system, often referred to as a "master ticket".
-* [Data Flow](https://docs.urbit.org/urbit-id/concepts/flow) - Diagrams and explanations of how data flows between Bridge and the various components inside Urbit involved with Azimuth and L2.
-* [Azimuth.eth](https://docs.urbit.org/urbit-id/reference/azimuth-eth) - A description of the azimuth.eth smart contract, which is the data store for Azimuth.
-* [Ecliptic.eth](https://docs.urbit.org/urbit-id/reference/ecliptic) - A description of the ecliptic.eth smart contract, which is the business logic for azimuth.eth. This includes an overview of all function calls available.
-* [Advanced Azimuth Tools](https://docs.urbit.org/urbit-id/guides/advanced-azimuth-tools) - Expert-level tooling for generating, signing, and sending layer 1 Azimuth transactions from within Urbit itself.
-* [Life and Rift](https://docs.urbit.org/urbit-id/concepts/life-and-rift) - An explanation of how Azimuth indexes networking keys revisions and breaches to keep track of the most recent set of networking keys necessary to communicate with a ship.
+* [HD Wallet](./concepts/hd-wallet.md) - Azimuth has its own optional hierarchical deterministic wallet system, often referred to as a "master ticket".
+* [Data Flow](./concepts/flow.md) - Diagrams and explanations of how data flows between Bridge and the various components inside Urbit involved with Azimuth and L2.
+* [Azimuth.eth](./reference/azimuth-eth.md) - A description of the azimuth.eth smart contract, which is the data store for Azimuth.
+* [Ecliptic.eth](./reference/ecliptic.md) - A description of the ecliptic.eth smart contract, which is the business logic for azimuth.eth. This includes an overview of all function calls available.
+* [Advanced Azimuth Tools](./guides/advanced-azimuth-tools.md) - Expert-level tooling for generating, signing, and sending layer 1 Azimuth transactions from within Urbit itself.
+* [Life and Rift](./concepts/life-and-rift.md) - An explanation of how Azimuth indexes networking keys revisions and breaches to keep track of the most recent set of networking keys necessary to communicate with a ship.
 
 ### Naive rollups <a href="#naive-rollups" id="naive-rollups"></a>
 
@@ -50,9 +50,8 @@ Due to the extremely low cost, Tlon offers their own roller that is free for ord
 
 #### Layer 2 resources <a href="#layer-2-resources" id="layer-2-resources"></a>
 
-* [Layer 2 Overview](https://docs.urbit.org/urbit-id/concepts/layer2) - An overview of how naive rollups work.
-* [Custom Roller Tutorial](https://docs.urbit.org/urbit-id/guides/roller-tutorial) - A guide to running your own L2 roller locally.
-* [Actions Reference](https://docs.urbit.org/urbit-id/reference/l2-actions) - Details of the L2 API's possible actions.
-* [Transaction Format Reference](https://docs.urbit.org/urbit-id/reference/bytestring) - Details of the bytestring format for L2 transactions and batches.
-* [Rollers](https://docs.urbit.org/urbit-id/reference/roller) - Overview of the L2 roller system.
-* [Roller HTTP RPC-API](https://docs.urbit.org/urbit-id/reference/roller) - A diagram summarizing the L2 API calls.
+* [Layer 2 Overview](./concepts/layer2.md) - An overview of how naive rollups work.
+* [Custom Roller Tutorial](./guides/roller-tutorial.md) - A guide to running your own L2 roller locally.
+* [Actions Reference](./reference/l2-actions.md) - Details of the L2 API's possible actions.
+* [Transaction Format Reference](./reference/bytestring.md) - Details of the bytestring format for L2 transactions and batches.
+* [Roller](./reference/roller.md) - Overview of the L2 roller system.

--- a/content/user-manual/os/dojo-tools.md
+++ b/content/user-manual/os/dojo-tools.md
@@ -529,7 +529,7 @@ ship: processing azimuth snapshot (106.177 points)
 
 List all Azimuth sources.
 
-This will print a [`state-eth-node:jael`](https://docs.urbit.org/system/kernel/jael/reference/data-types#state-eth-node) structure. Its contents is mostly other ships who are sources for updates about moons, but it will also include `%azimuth`.
+This will print a [`state-eth-node:jael`](../../urbit-os/kernel/jael/reference/data-types.md#state-eth-node) structure. Its contents is mostly other ships who are sources for updates about moons, but it will also include `%azimuth`.
 
 #### Example
 
@@ -1002,7 +1002,7 @@ verb verb verb...
 
 A `verb:ames` is one of `%snd %rcv %odd %msg %ges %for %rot`. Each one enables printing of different kinds of events. You can enable as many as you want at one time. If `|ames/verb` is given no argument, it disables all Ames debug printing.
 
-For details of the meaning of these `verb`s, see its entry in the [Ames Data Types documentation](https://docs.urbit.org/system/kernel/ames/reference/data-types#verb).
+For details of the meaning of these `verb`s, see its entry in the [Ames Data Types documentation](../../urbit-os/kernel/ames/reference/data-types.md#verb).
 
 #### Example
 
@@ -1203,7 +1203,7 @@ Query the state or [bowl][bowl] of a running agent.
 
 #### Arguments
 
-See the [dbug section of App School lesson 3](https://docs.urbit.org/build-on-urbit/app-school/3-imports-and-aliases#dbug) for details of usage.
+See the [dbug section of App School lesson 3](../../build-on-urbit/app-school/3-imports-and-aliases.md#dbug) for details of usage.
 
 #### Example
 
@@ -1378,7 +1378,7 @@ While [`+cat`](#cat) can only read text files, the `-read` [thread][thread] can 
 care ship desk case path
 ```
 
-- [care][care]: One of `%a %b %c %d %e %f %p %r %s %t %u %v %w %x %y %z`, denoting a [Clay][clay] submodule. For details of their meaning, see the [Clay data types documentation](https://docs.urbit.org/system/kernel/clay/reference/data-types#careclay-clay-submode) and [Clay scry reference](https://docs.urbit.org/system/kernel/clay/reference/scry).
+- [care][care]: One of `%a %b %c %d %e %f %p %r %s %t %u %v %w %x %y %z`, denoting a [Clay][clay] submodule. For details of their meaning, see the [Clay data types documentation](../../urbit-os/kernel/clay/reference/data-types.md#careclay-clay-submode) and [Clay scry reference](../../urbit-os/kernel/clay/reference/scry.md).
 - [ship][ship]: The target ship like `~sampel`, or `our` for the local ship.
 - [desk][desk]: The [desk] on that ship like `%base`.
 - [case][case]: The revision you're requesting. This can be one of:
@@ -1409,7 +1409,7 @@ Check for the existence of that same file:
 
 Bind a generator to a URL path.
 
-See the [Eyre Guide](https://docs.urbit.org/system/kernel/eyre/guides/guide#generators) for details of writing web-facing generators.
+See the [Eyre Guide](../../urbit-os/kernel/eyre/guides/guide.md#generators) for details of writing web-facing generators.
 
 #### Arguments
 
@@ -1522,7 +1522,7 @@ Each [path][path] is a path to a file to test, and must include the [path prefix
 
 #### Example
 
-Refer to the [Unit Test Guide](https://docs.urbit.org/userspace/apps/guides/unit-tests) for details of using the `-test` thread.
+Refer to the [Unit Test Guide](../../build-on-urbit/userspace/guides/unit-tests.md) for details of using the `-test` thread.
 
 ---
 


### PR DESCRIPTION
Fixes a few "external" links to `https://docs.urbit.org/...` and makes them regular internal links.