### PR TITLE
Move style guide into /content directory

### DIFF
--- a/content/SUMMARY.md
+++ b/content/SUMMARY.md
@@ -2,6 +2,7 @@
 
 * [What is Urbit?](README.md)
 * [Get on Urbit](get-on-urbit.md)
+* [Style Guide](style.md)
 
 ## Build on Urbit
 

--- a/content/style.md
+++ b/content/style.md
@@ -1,4 +1,5 @@
 ---
+hidden: true
 description: "Urbit docs style guide."
 layout:
   title:

--- a/content/style.md
+++ b/content/style.md
@@ -1,3 +1,18 @@
+---
+description: "Urbit docs style guide."
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
 # Urbit Docs Style Guide
 
 ## Style & Tone of Voice


### PR DESCRIPTION
This makes the style guide viewable at https://docs.urbit.org/style.