### PR TITLE
Update Core Academy Runtime naming of Sword

### DIFF
--- a/content/build-on-urbit/core-academy/ca00.md
+++ b/content/build-on-urbit/core-academy/ca00.md
@@ -749,11 +749,11 @@ As hinted at by our jetting discussion above, Nock is not directly evaluated by 
 2. Jet dashboard
 3. Allocator
 
-This appendix summarizes some of the considerations and architecture that the current runtime interpreters (Vere and Sword, née Ares) must make in some respect.
+This appendix summarizes some of the considerations and architecture that the current runtime interpreters (Vere and NockVM, née Sword, née Ares) must make in some respect.
 
 ### Nock Bytecode <a href="#nock-bytecode" id="nock-bytecode"></a>
 
-The VM doesn't actually execute Nock directly from its noun form. Instead it produces a Nock-based bytecode. Producing computationally efficient bytecode from Nock is one key to building a practical Urbit runtime, and has been a focus of the Sword (née Ares) project. The details of this in Vere are in `vere/pkg/noun/nock.c`.
+The VM doesn't actually execute Nock directly from its noun form. Instead it produces a Nock-based bytecode. Producing computationally efficient bytecode from Nock is one key to building a practical Urbit runtime, and has been a focus of the NockVM (née Sword, née Ares) project. The details of this in Vere are in `vere/pkg/noun/nock.c`.
 
 ```
 > ~>(%xray (add 2 3))
@@ -782,7 +782,7 @@ Core Academy lessons will not further explore the Nock bytecode interpreter.
 
 * [`u3n`: Nock Execution](../runtime/api.md#u3n-nock-execution)
 * (no docs exist for the Vere bytecode convention)
-* [Sword (née Ares), “Codegen Bootstrapping”](https://github.com/urbit/ares/blob/status/docs/codegen-bootstrap.md?plain=1)
+* [NockVM (née Sword, née Ares), “Codegen Bootstrapping”](https://github.com/urbit/ares/blob/status/docs/codegen-bootstrap.md?plain=1)
 
 ### Jet Dashboard <a href="#jet-dashboard" id="jet-dashboard"></a>
 
@@ -809,4 +809,4 @@ Persistence means that we can store events and the event log, and that we can pr
 The allocator will be examined more in the runtime lessons on Vere.
 
 * [Vere, “Land of Nouns: `u3` the road model”](../runtime/nouns.md#u3-the-road-model)
-* [Sword (née Ares), “New Mars Persistence”](https://github.com/urbit/ares/blob/status/docs/persistence.md)
+* [NockVM (née Sword, née Ares), “New Mars Persistence”](https://github.com/urbit/ares/blob/status/docs/persistence.md)

--- a/content/build-on-urbit/core-academy/ca02.md
+++ b/content/build-on-urbit/core-academy/ca02.md
@@ -2543,7 +2543,7 @@ You can see this process in `+run-prelude:ford` in `/sys/vane/clay`. (`/` fas Fo
 
 ##### `/lib/tiny`
 
-The whole standard library is included in every piece of userspace Hoon, unless you go out of your way to remove it from the subject. This is only rarely a good idea, but you \*can* build a small working Hoon against a minimalist subject. For instance, this is done for the naïve rollup smart contract code and Sword (née Ares) development using `/lib/tiny`.
+The whole standard library is included in every piece of userspace Hoon, unless you go out of your way to remove it from the subject. This is only rarely a good idea, but you \*can* build a small working Hoon against a minimalist subject. For instance, this is done for the naïve rollup smart contract code and NockVM (née Sword, née Ares) development using `/lib/tiny`.
 
 ```hoon
 > =>  tiny  (add 1 1)

--- a/content/build-on-urbit/core-academy/ca04.md
+++ b/content/build-on-urbit/core-academy/ca04.md
@@ -303,7 +303,7 @@ The runtime spawns the king (`king.c`) and indirectly the serf (`serf.c`) proces
 
 - The serf is the Nock runtime. It tracks the current state of Arvo as a noun, updating the state by poking it with nouns. It informs the king of the new state.
   - Vere provides a standard serf, what was known formerly as the `urbit-worker` process.
-  - Sword (née Ares) can be used as a serf in its Nock interpreter capacity, but requires I/O driver support to function this way entirely for Urbit.
+  - NockVM (née Sword, née Ares) can be used as a serf in its Nock interpreter capacity, but requires I/O driver support to function this way entirely for Urbit.
 - The king manages snapshots of Arvo's state and interfaces with Unix.
   - Vere is the only Urbit king currently.
   - King Haskell was an alternative king process that was dropped for maintenance reasons.

--- a/content/build-on-urbit/core-academy/ca05.md
+++ b/content/build-on-urbit/core-academy/ca05.md
@@ -29,10 +29,10 @@ _We need some C background to fluently read the runtime source. If you are not f
 
 If the vision of Urbit is to implement `[2 [0 3] 0 2]` as a frozen lifecycle function, then it needs some scaffolding on any real system. Real computers have memories, chipset architectures, operating system conventions, and other affordances (and limitations). Conventionally, an operating system takes explicit care of such niceties, which is one reason why calling Urbit an “OS” has been controversial. The runtime interpreter is designed to take Nock as a specification and produce a practical computer of it.
 
-Today, there are two primary Nock executable runtimes:  Vere and Sword (née Ares). (Jaque, the JVM experiment, and King Haskell have fallen by the wayside.)
+Today, there are two primary Nock executable runtimes:  Vere and NockVM (née Sword, née Ares). (Jaque, the JVM experiment, and King Haskell have fallen by the wayside.)
 
 - Vere is written in C and is the standard runtime for Arvo.
-- Sword is written in Rust and aims to solve some deep theoretical challenges to producing efficient Nock on a contemporary chipset. Sword is under development by [Zorp](https://zorp.io) and formerly with contributions from [Tlon Corporation](https://tlon.io), and the [Urbit Foundation](https://urbit.org).
+- NockVM is written in Rust and aims to solve some deep theoretical challenges to producing efficient Nock on a contemporary chipset. NockVM is under development by [Zorp](https://zorp.io) and formerly with contributions from [Tlon Corporation](https://tlon.io), and the [Urbit Foundation](https://urbit.org).
 
 We will take Vere as the normative runtime for Core Academy.
 
@@ -249,7 +249,7 @@ As a consequence of the architecture of Vere today, we see a lot of expensive ca
 
 Since many things are computed in virtual Nock, `+mock`, we have bail/trace/bounded computation at the price of slow virtualization.
 
-One objective of Sword (née Ares), subject knowledge analysis, is to improve on Nock bytecode generation. This is being implemented into Vere as well.
+One objective of NockVM, subject knowledge analysis, is to improve on Nock bytecode generation. This is being implemented into Vere as well.
 
 ### Jet Dashboard (`u3j`) {#jet-dashboard-u3j}
 

--- a/content/build-on-urbit/core-academy/ca05.md
+++ b/content/build-on-urbit/core-academy/ca05.md
@@ -89,7 +89,7 @@ Vere is provided in the [`urbit/vere`](https://github.com/urbit/vere) repo. It i
 
 - `/urcrypt` is a C library to standardize cryptographic calls across a number of libraries.
   
-    This library is a dependency for both Vere and Ares, and is in the process of being moved into a standalone repo.
+    This library is a dependency for both Vere and NockVM, and is in the process of being moved into a standalone repo.
 
 - `/vere` contains the runtime architecture itself, the king and the serf and related tooling, as independent from `u3`.
 

--- a/content/build-on-urbit/core-academy/ca06.md
+++ b/content/build-on-urbit/core-academy/ca06.md
@@ -353,7 +353,7 @@ A [socket](https://en.wikipedia.org/wiki/Unix_domain_socket) is an endpoint for 
 
 ## Debugging the Runtime <a href="#debugging-the-runtime" id="debugging-the-runtime"></a>
 
-To conclude today's material, we would like to briefly demonstrate several debugging principles with VereAres.
+To conclude today's material, we would like to briefly demonstrate several debugging principles with Vere / NockVM.
 
 ### `printf` <a href="#printf" id="printf"></a>
 

--- a/content/build-on-urbit/core-academy/ca06.md
+++ b/content/build-on-urbit/core-academy/ca06.md
@@ -119,6 +119,11 @@ Keep in mind that atoms do not retain leading zeros.
 
 The reference counters introduced last time, `u3a_gain()`=`u3k()` and `u3a_lose()`=`u3z()`, are also part of `u3a`. However, other than these you typically use `u3a` indirectly through `u3i` and `u3r`/`u3x`.
 
+{% hint style="warning" %}
+### Note on allocator documentation
+As of the [Vere 4.0 release](https://github.com/urbit/vere/releases/tag/vere-v4.0), the allocator has been completely rewritten to reduce memory usage and decreases snapshot size. Some of the finer details of it's documentation here may thus be out of date. 
+{% endhint %}
+
 Some details of the allocator [are in flux right now](https://github.com/urbit/urbit/issues/6805#issuecomment-1754208392): “As an experiment, \[\~master-morzod has] rewritten the serf to a) stop allocating events, effects, and IPC messages on the home road, and b) keep the Arvo kernel on an inner road for as long as possible (i.e. until we need to save/pack/meld/\&c.).”
 
 * [“Land of Nouns”, section “`u3`: the road model”](../runtime/nouns.md#u3-the-road-model)


### PR DESCRIPTION
Renaming Sword to NockVM where it appears in the docs