### PR TITLE
fix invite link to come from bitdeg

### DIFF
--- a/content/get-on-urbit.md
+++ b/content/get-on-urbit.md
@@ -22,7 +22,7 @@ This guide will walk through the steps of getting an Urbit ID, downloading its k
 {% hint style="warning" %}
 ### Get on Urbit faster
 
-If you want a quicker and easier way to get on Urbit, you can skip this guide and use a hosting provider instead. Tlon offers a free Urbit ID and hosting in the cloud that only takes a few clicks to get up and running, [available here](https://join.tlon.io/0v1.cr43s.b0o2b.nllrg.sf25p.62l4h).
+If you want a quicker and easier way to get on Urbit, you can skip this guide and use a hosting provider instead. Tlon offers a free Urbit ID and hosting in the cloud that only takes a few clicks to get up and running, [available here](https://join.tlon.io/0v3.r87kb.fjpft.3k7b5.pbsr5.5em17).
 {% endhint %}
 
 **Requirements**


### PR DESCRIPTION
This should fix the issue of @bonbud-macryg getting DMs setup when a user onboards via the tlon invite link on https://docs.urbit.org/get-on-urbit