### PR TITLE
add example to tree addressing peg doc

### DIFF
--- a/content/hoon/stdlib/1b.md
+++ b/content/hoon/stdlib/1b.md
@@ -289,6 +289,13 @@ An `$atom`.
 %2
 ```
 
+```
+> %+  peg
+      (add (mul 2 +:(~(dig by outer) outer-key)) 1)
+      (add (mul 2 +:(~(dig by inner) inner-key)) 1)
+477
+```
+
 #### Discussion
 
 In other words, the subtree at address `.a` is treated as a tree in its own right (starting with root `+1`, head `+2`, and tail `+3`). Relative address `.b` is found with respect to `.a`, and then its absolute address, within the greater tree, is returned.


### PR DESCRIPTION
Add example to tree addressing peg doc using `dig by` to calculate address in `(map (map)`.