### PR TITLE
Update output description for `.a` in 2b.md

### DIFF
--- a/content/hoon/stdlib/2b.md
+++ b/content/hoon/stdlib/2b.md
@@ -680,7 +680,7 @@ Produces the last item in `+list` `.a`, crashing if `.a` is null.
 
 #### Produces
 
-The type of the last element in `.a`.
+The last element in `.a` if `.a` is non-null.
 
 #### Source
 


### PR DESCRIPTION
Clarified the output description for the last element in `.a`.