### PR TITLE
remove azimuth.shop listing

### DIFF
--- a/content/get-on-urbit.md
+++ b/content/get-on-urbit.md
@@ -58,7 +58,6 @@ Here are the best places to buy planets:
 | Layer   | Market                                                   | Description                                            |
 | ------- | -------------------------------------------------------- | ------------------------------------------------------ |
 | Layer 1 | OpenSea [Urbit ID: Planet](https://opensea.io/collection/urbit-id-planet) and [Urbit ID](https://opensea.io/collection/urbit-id) collections. | The largest NFT marketplace. Accepts ETH. |
-| Layer 2 | [azimuth.shop](https://azimuth.shop)                     | Third-party L2 planet store. Accepts ETH.              |
 | Layer 2 | [Pocwet](https://store.pocwet.com)                       | Third-party L2 planet store. Accepts credit cards.     |
 
 Originally, all Urbit IDs were ERC-721 NFTs on Ethereum. In 2021, Tlon [introduced a Layer 2 solution](https://urbit.org/blog/rollups) to reduce transaction costs on Ethereum. This means there are two places where ownership of your Urbit ID could be recorded:


### PR DESCRIPTION
Azimuth.shop is no longer live; removing it from the planet sales listing table.