### PR TITLE
docs: mechanical corrections and kelvin refresh

### DIFF
--- a/content/build-on-urbit/app-school-full-stack/8-desk.md
+++ b/content/build-on-urbit/app-school-full-stack/8-desk.md
@@ -52,7 +52,7 @@ We only have one agent to start, so `desk.bill` is very simple:
 Likewise, `sys.kelvin` just contains:
 
 ```
-[%zuse 414]
+[%zuse 408]
 ```
 
 The `desk.docket-0` file is slightly more complicated:

--- a/content/build-on-urbit/app-school/README.md
+++ b/content/build-on-urbit/app-school/README.md
@@ -21,7 +21,7 @@ App School I is suitable for anyone with an intermediate knowledge of Hoon. If y
 
 ## What are Gall agents? {#what-are-gall-agents}
 
-Gall is one of the nine vanes (kernel modules) of Arvo, Urbit's operating system. Gall's purpose is to manage userspace applications called "agents".
+Gall is one of the ten vanes (kernel modules) of Arvo, Urbit's operating system. Gall's purpose is to manage userspace applications called "agents".
 
 An agent is a piece of software that is primarily focused on maintaining and distributing a piece of state with a defined structure. It exposes an interface that lets programs read, subscribe to, and manipulate the state. Every event happens in an atomic transaction, so the state is never inconsistent. Since the state is permanent, when the agent is upgraded with a change to the structure of the state, the developer provides a migration function from the old state type to the new state type.
 

--- a/content/build-on-urbit/environment.md
+++ b/content/build-on-urbit/environment.md
@@ -154,7 +154,7 @@ mydesk
 └── sys.kelvin
 ```
 
-The mark files in `/mar` are for handling some basic filetypes, and `sys.kelvin` specifies which kernel version(s) the desk is compatible with. The `|new-desk` generator populates `sys.kelvin` with the current kernel version like `[%zuse 410]`.
+The mark files in `/mar` are for handling some basic filetypes, and `sys.kelvin` specifies which kernel version(s) the desk is compatible with. The `|new-desk` generator populates `sys.kelvin` with the current kernel version like `[%zuse 408]`.
 
 You can delete these files, copy in your own and run `|commit %mydesk` in the Dojo.
 

--- a/content/build-on-urbit/hoon-school/H-libraries.md
+++ b/content/build-on-urbit/hoon-school/H-libraries.md
@@ -293,7 +293,7 @@ At this point, you've likely only worked on the `%base` desk. You can see data a
 ```hoon
 > +vats %base
 %base
-  /sys/kelvin:          [%zuse 413]
+  /sys/kelvin:          [%zuse 408]
   base hash ends in:    hih5c
   %cz hash ends in:     hih5c
   app status:           running
@@ -301,7 +301,7 @@ At this point, you've likely only worked on the `%base` desk. You can see data a
 
 > +vats %base, =verb %.y
 %base
-  /sys/kelvin:     [%zuse 413]
+  /sys/kelvin:     [%zuse 408]
   base hash:       0v2.vhcjk.rj42q.e3la7.1679q.u2qs2.35vnn.9n1jm.mj66h.kgpe5.hih5c
   %cz hash:        0v2.vhcjk.rj42q.e3la7.1679q.u2qs2.35vnn.9n1jm.mj66h.kgpe5.hih5c
   app status:      running

--- a/content/build-on-urbit/userspace/README.md
+++ b/content/build-on-urbit/userspace/README.md
@@ -15,7 +15,7 @@ layout:
 
 # Userspace
 
-Gall is one of the nine vanes (kernel modules) of Arvo, Urbit's operating system. Gall's purpose is to manage userspace applications called _agents_. **Agents** are the main kind of userspace application on Urbit. They have a persistent state and API that handles events and produces effects.Gall agents can variously be treated as databases with developer-defined logic, services, daemons, or a kind of state machine.
+Gall is one of the ten vanes (kernel modules) of Arvo, Urbit's operating system. Gall's purpose is to manage userspace applications called _agents_. **Agents** are the main kind of userspace application on Urbit. They have a persistent state and API that handles events and produces effects.Gall agents can variously be treated as databases with developer-defined logic, services, daemons, or a kind of state machine.
 
 One or more Gall agents can be put together in a "desk" in Clay (the filesystem vane) and, along with a front-end, can be published and distributed as a cohesive app for users to install.
 

--- a/content/build-on-urbit/userspace/dist/README.md
+++ b/content/build-on-urbit/userspace/dist/README.md
@@ -42,7 +42,7 @@ The `%docket` agent in Landscape reads the `/desk/docket-0` file to display an a
 Desks contain helper files in `/lib` and `/sur`, generators in `/gen`, marks in `/mar`, threads in `/ted`, tests in `/tests`, and Gall agents in `/app`. In addition, desks also contain these files:
 
 ```
-/sys/kelvin     ::  Kernel kelvin, e.g. [%zuse 410] (mandatory)
+/sys/kelvin     ::  Kernel kelvin, e.g. [%zuse 408] (mandatory)
 /desk/bill      ::  list of agents to start on install (optional, read by Kiln) 
 /desk/docket-0  ::  app metadata (optional, read by Docket) 
 /desk/ship      ::  ship of original desk publisher (optional, read by Docket) 

--- a/content/build-on-urbit/userspace/examples/flap.md
+++ b/content/build-on-urbit/userspace/examples/flap.md
@@ -60,7 +60,7 @@ Back on Earth:
 ```sh
 rm -rf comet/flap/*
 echo "~[%flap]" > comet/flap/desk.bill
-echo "[%zuse 417]" > comet/flap/sys.kelvin
+echo "[%zuse 408]" > comet/flap/sys.kelvin
 ```
 
 At this point, we need to take stock of what kind of file marks and libraries we need to make available: `kelvin`, `docket-0`, and so forth. While there are marks for `js` and `png`, there is no `wav` so we'll handle that directly.

--- a/content/hoon/generators.md
+++ b/content/hoon/generators.md
@@ -112,7 +112,7 @@ The Dojo will modify the sample by inserting `%~` (constant null) at the end of 
 ```
 > +vats
 %base
-  /sys/kelvin:           [%zuse 414]
+  /sys/kelvin:           [%zuse 408]
   base hash ends in:     drceb
   %cz hash ends in:      drceb
   app status:            running
@@ -120,7 +120,7 @@ The Dojo will modify the sample by inserting `%~` (constant null) at the end of 
 
 > +vats, =verb %.n
 %base
-  /sys/kelvin:           [%zuse 414]
+  /sys/kelvin:           [%zuse 408]
   base hash ends in:     drceb
   %cz hash ends in:      drceb
   app status:            running

--- a/content/hoon/math.md
+++ b/content/hoon/math.md
@@ -43,7 +43,7 @@ A container core for operations related to single-precision binary floats.
 ```hoon
 ++  rs
   ^|
-  |_  $$:  r=$?(%n %u %d %z)   :: round nearest, up, down, to zero
+  |_  $:  r=$?(%n %u %d %z)   :: round nearest, up, down, to zero
           rtol=_.1e-5         :: relative tolerance for precision of operations
       ==
 ```
@@ -302,26 +302,6 @@ A floating-point atom (`@rs`).
 
 ```hoon
 ++  san  san:^rs
-```
-
----
-
-### `+exp` {#exp}
-
-The value of e^x for a given floating-point atom.
-
-#### Accepts
-
-A floating-point atom (`@rs`).
-
-#### Produces
-
-A floating-point atom (`@rs`).
-
-#### Source
-
-```hoon
-++  exp  exp:^rs  :: no pass-through because of exp function
 ```
 
 ---
@@ -592,7 +572,7 @@ A `$flag`.
     %.y
   ?.  (is-close p (snag i q))
     %.n
-  $$(i +(i))
+  $(i +(i))
 ```
 
 ---
@@ -827,7 +807,7 @@ A floating-point atom (`@rs`).
   |-  ^-  @rs
   ?:  (is-close x .1)
     t
-  $$(x (sub x .1), t (mul t x))
+  $(x (sub x .1), t (mul t x))
 ```
 
 ---
@@ -907,7 +887,7 @@ A floating-point atom (`@rs`).
   |-  ^-  @rs
   ?:  (lth (abs (sub po p)) rtol)
     p
-  $$(i (add i .1), p (add p (div (pow-n x i) (factorial i))), po p)
+  $(i (add i .1), p (add p (div (pow-n x i) (factorial i))), po p)
 ```
 
 ---
@@ -960,7 +940,7 @@ A floating-point atom (`@rs`).
     p
   =/  i2  (add (sun i) (sun i))
   =.  term  (mul (neg term) (div (mul x x) (mul i2 (add i2 .1))))
-  $$(i +(i), p (add p term), po p)
+  $(i +(i), p (add p term), po p)
 ```
 
 ---
@@ -1013,7 +993,7 @@ A floating-point atom (`@rs`).
     p
   =/  i2  (add (sun i) (sun i))
   =.  term  (mul (neg term) (div (mul x x) (mul i2 (sub i2 .1))))
-  $$(i +(i), p (add p term), po p)
+  $(i +(i), p (add p term), po p)
 ```
 
 ---
@@ -1171,7 +1151,7 @@ A floating-point atom (`@rs`).
     (div x (mul (pow (add .1 (mul x x)) .0.5) b))
   =/  ai  (mul .0.5 (add a b))
   =/  bi  (sqt (mul ai b))
-  $$(a ai, b bi)
+  $(a ai, b bi)
 ```
 
 ---
@@ -1257,7 +1237,7 @@ A floating-point atom (`@rs`).
   |-  ^-  @rs
   ?:  (lth n .2)
     p
-  $$(n (sub n .1), p (mul p x))
+  $(n (sub n .1), p (mul p x))
 ```
 
 ---
@@ -1315,7 +1295,7 @@ A floating-point atom (`@rs`).
   =/  term2  (mul (sub z .1) (sub z .1))
   =/  term3  (mul (add z .1) (add z .1))
   =/  term  (mul term1 (pow-n (div term2 term3) i))
-  $$(i (add i .1), p (add p term), po p)
+  $(i (add i .1), p (add p term), po p)
 ```
 
 ---
@@ -1503,7 +1483,7 @@ A floating-point atom (`@rs`).
   =/  n=@rs  (mul .0.5 (add g (div x g)))
   ?.  (gth (abs (sub g n)) rtol)
     n
-  $$(g n)
+  $(g n)
 ```
 
 ---
@@ -1760,7 +1740,7 @@ A container core for operations related to double-precision binary floats.
 ```hoon
 ++  rd
   ^|
-  |_  $$:  r=$?(%n %u %d %z)   :: round nearest, up, down, to zero
+  |_  $:  r=$?(%n %u %d %z)   :: round nearest, up, down, to zero
           rtol=_.~1e-10       :: relative tolerance for precision of operations
       ==
 ```
@@ -2543,7 +2523,7 @@ A `$flag`.
     %.y
   ?.  (is-close p (snag i q))
     %.n
-  $$(i +(i))
+  $(i +(i))
 ```
 
 ---
@@ -2840,7 +2820,7 @@ A floating-point atom (`@rd`).
   |-  ^-  @rd
   ?:  (is-close x .~1)
     t
-  $$(x (sub x .~1), t (mul t x))
+  $(x (sub x .~1), t (mul t x))
 ```
 
 ---
@@ -2926,7 +2906,7 @@ A floating-point atom (`@rd`).
   |-  ^-  @rd
   ?:  (lth (abs (sub po p)) rtol)
     p
-  $$(i (add i .~1), p (add p (div (pow-n x i) (factorial i))), po p)
+  $(i (add i .~1), p (add p (div (pow-n x i) (factorial i))), po p)
 ```
 
 ---
@@ -2977,7 +2957,7 @@ A floating-point atom (`@rd`).
     p
   =/  i2  (add (sun i) (sun i))
   =.  term  (mul (neg term) (div (mul x x) (mul i2 (add i2 .~1))))
-  $$(i +(i), p (add p term), po p)
+  $(i +(i), p (add p term), po p)
 ```
 
 ---
@@ -3028,7 +3008,7 @@ A floating-point atom (`@rd`).
     p
   =/  i2  (add (sun i) (sun i))
   =.  term  (mul (neg term) (div (mul x x) (mul i2 (sub i2 .~1))))
-  $$(i +(i), p (add p term), po p)
+  $(i +(i), p (add p term), po p)
 ```
 
 ---
@@ -3176,7 +3156,7 @@ A floating-point atom (`@rd`).
     (div x (mul (pow (add .~1 (mul x x)) .~0.5) b))
   =/  ai  (mul .~0.5 (add a b))
   =/  bi  (sqt (mul ai b))
-  $$(a ai, b bi)
+  $(a ai, b bi)
 ```
 
 ---
@@ -3260,7 +3240,7 @@ A floating-point atom (`@rd`).
     |-  ^-  @rd
     ?:  (lth n .~2)
       p
-    $$(n (sub n .~1), p (mul p x))
+    $(n (sub n .~1), p (mul p x))
 ```
 
 ### `+log` {#log}
@@ -3313,7 +3293,7 @@ A floating-point atom (`@rd`).
   =/  term2  (mul (sub z .~1) (sub z .~1))
   =/  term3  (mul (add z .~1) (add z .~1))
   =/  term  (mul term1 (pow-n (div term2 term3) i))
-  $$(i (add i .~1), p (add p term), po p)
+  $(i (add i .~1), p (add p term), po p)
 ```
 
 ### `+log-10` {#log10}
@@ -3488,7 +3468,7 @@ A floating-point atom (`@rd`).
   =/  n=@rd  (mul .~0.5 (add g (div x g)))
   ?.  (gth (abs (sub g n)) rtol)
     n
-  $$(g n)
+  $(g n)
 ```
 
 ### `+cbrt` {#cbrt}
@@ -3726,7 +3706,7 @@ A container core for operations related to half-precision binary floats.
 ```hoon
 ++  rh
   ^|
-  |_  $$:  r=$?(%n %u %d %z)   :: round nearest, up, down, to zero
+  |_  $:  r=$?(%n %u %d %z)   :: round nearest, up, down, to zero
           rtol=_.~~1e-2       :: relative tolerance for precision of operations
       ==
 ```
@@ -4478,7 +4458,7 @@ A `$flag`.
     %.y
   ?.  (is-close p (snag i q))
     %.n
-  $$(i +(i))
+  $(i +(i))
 ```
 
 ---
@@ -4773,7 +4753,7 @@ A floating-point atom (`@rh`).
   |-  ^-  @rh
   ?:  (is-close x .~~1)
     t
-  $$(x (sub x .~~1), t (mul t x))
+  $(x (sub x .~~1), t (mul t x))
 ```
 
 ---
@@ -4859,7 +4839,7 @@ A floating-point atom (`@rh`).
   |-  ^-  @rh
   ?:  (lth (abs (sub po p)) rtol)
     p
-  $$(i (add i .~~1), p (add p (div (pow-n x i) (factorial i))), po p)
+  $(i (add i .~~1), p (add p (div (pow-n x i) (factorial i))), po p)
 ```
 
 ---
@@ -4910,7 +4890,7 @@ A floating-point atom (`@rh`).
     p
   =/  i2  (add (sun i) (sun i))
   =.  term  (mul (neg term) (div (mul x x) (mul i2 (add i2 .~~1))))
-  $$(i +(i), p (add p term), po p)
+  $(i +(i), p (add p term), po p)
 ```
 
 ---
@@ -4961,7 +4941,7 @@ A floating-point atom (`@rh`).
     p
   =/  i2  (add (sun i) (sun i))
   =.  term  (mul (neg term) (div (mul x x) (mul i2 (sub i2 .~~1))))
-  $$(i +(i), p (add p term), po p)
+  $(i +(i), p (add p term), po p)
 ```
 
 ---
@@ -5109,7 +5089,7 @@ A floating-point atom (`@rh`).
     (div x (mul (pow (add .~~1 (mul x x)) .~~0.5) b))
   =/  ai  (mul .~~0.5 (add a b))
   =/  bi  (sqt (mul ai b))
-  $$(a ai, b bi)
+  $(a ai, b bi)
 ```
 
 ---
@@ -5191,7 +5171,7 @@ A floating-point atom (`@rh`).
   |-  ^-  @rh
   ?:  (lth n .~~2)
     p
-  $$(n (sub n .~~1), p (mul p x))
+  $(n (sub n .~~1), p (mul p x))
 ```
 
 ---
@@ -5241,7 +5221,7 @@ A floating-point atom (`@rh`).
   =/  term2  (mul (sub z .~~1) (sub z .~~1))
   =/  term3  (mul (add z .~~1) (add z .~~1))
   =/  term  (mul term1 (pow-n (div term2 term3) i))
-  $$(i (add i .~~1), p (add p term), po p)
+  $(i (add i .~~1), p (add p term), po p)
 ```
 
 ---
@@ -5413,7 +5393,7 @@ A floating-point atom (`@rh`).
   =/  n=@rh  (mul .~~0.5 (add g (div x g)))
   ?.  (gth (abs (sub g n)) rtol)
     n
-  $$(g n)
+  $(g n)
 ```
 
 ---
@@ -5529,7 +5509,7 @@ A container core for operations related to quadruple-precision binary floats.
 ```hoon
 ++  rq
   ^|
-  |_  $$:  r=$?(%n %u %d %z)   :: round nearest, up, down, to zero
+  |_  $:  r=$?(%n %u %d %z)   :: round nearest, up, down, to zero
           rtol=_.~~~1e-20     :: relative tolerance for precision of operations
       ==
 ```
@@ -6115,7 +6095,7 @@ A `$flag`.
     %.y
   ?.  (is-close p (snag i q))
     %.n
-  $$(i +(i))
+  $(i +(i))
 ```
 
 ---
@@ -6326,7 +6306,7 @@ A floating-point atom (`@rq`).
   |-  ^-  @rq
   ?:  (is-close x .~~~1)
     t
-  $$(x (sub x .~~~1), t (mul t x))
+  $(x (sub x .~~~1), t (mul t x))
 ```
 
 ---
@@ -6406,7 +6386,7 @@ A floating-point atom (`@rq`).
   |-  ^-  @rq
   ?:  (lth (abs (sub po p)) rtol)
     p
-  $$(i (add i .~~~1), p (add p (div (pow-n x i) (factorial i))), po p)
+  $(i (add i .~~~1), p (add p (div (pow-n x i) (factorial i))), po p)
 ```
 
 ---
@@ -6459,7 +6439,7 @@ A floating-point atom (`@rq`).
     p
   =/  i2  (add (sun i) (sun i))
   =.  term  (mul (neg term) (div (mul x x) (mul i2 (add i2 .~~~1))))
-  $$(i +(i), p (add p term), po p)
+  $(i +(i), p (add p term), po p)
 ```
 
 ---
@@ -6512,7 +6492,7 @@ A floating-point atom (`@rq`).
     p
   =/  i2  (add (sun i) (sun i))
   =.  term  (mul (neg term) (div (mul x x) (mul i2 (sub i2 .~~~1))))
-  $$(i +(i), p (add p term), po p)
+  $(i +(i), p (add p term), po p)
 ```
 
 ---
@@ -6668,7 +6648,7 @@ A floating-point atom (`@rq`).
     (div x (mul (pow (add .~~~1 (mul x x)) .~~~0.5) b))
   =/  ai  (mul .~~~0.5 (add a b))
   =/  bi  (sqt (mul ai b))
-  $$(a ai, b bi)
+  $(a ai, b bi)
 ```
 
 ---
@@ -6751,7 +6731,7 @@ A floating-point atom (`@rq`).
   |-  ^-  @rq
   ?:  (lth n .~~~2)
     p
-  $$(n (sub n .~~~1), p (mul p x))
+  $(n (sub n .~~~1), p (mul p x))
 ```
 
 ---
@@ -6806,7 +6786,7 @@ A floating-point atom (`@rq`).
   =/  term2  (mul (sub z .~~~1) (sub z .~~~1))
   =/  term3  (mul (add z .~~~1) (add z .~~~1))
   =/  term  (mul term1 (pow-n (div term2 term3) i))
-  $$(i (add i .~~~1), p (add p term), po p)
+  $(i (add i .~~~1), p (add p term), po p)
 ```
 
 ---
@@ -6962,7 +6942,7 @@ A floating-point atom (`@rq`).
   =/  n=@rq  (mul .~~~0.5 (add g (div x g)))
   ?.  (gth (abs (sub g n)) rtol)
     n
-  $$(g n)
+  $(g n)
 ```
 
 ---

--- a/content/hoon/stdlib/1c.md
+++ b/content/hoon/stdlib/1c.md
@@ -61,7 +61,7 @@ Either a single `$atom` representing block size, or a cell containing a block si
 0
 ```
 
-## `+bloq` {#bloq}
+## `$bloq` {#bloq}
 
 Blocksize.
 

--- a/content/hoon/stdlib/2d.md
+++ b/content/hoon/stdlib/2d.md
@@ -323,7 +323,7 @@ Computes the bitwise logical NOT of the bottom `.b` blocks of size `.a` of `.c`.
 
 #### Accepts
 
-`.a` is a block size (see [`+bloq`](../stdlib/1c.md#bloq)).
+`.a` is a block size (see [`$bloq`](../stdlib/1c.md#bloq)).
 
 `.b` is an `$atom`.
 

--- a/content/hoon/stdlib/2l.md
+++ b/content/hoon/stdlib/2l.md
@@ -70,7 +70,7 @@ A `+map`.
 ```hoon
 ++  molt
   |*  a=(list (pair))
-  (~(gas by `(tree [p=_p.i.-.a q=_q.i.-.a})`~) a)
+  (~(gas by `(tree [p=_p.i.-.a q=_q.i.-.a])`~) a)
 ```
 
 #### Examples

--- a/content/hoon/stdlib/4b.md
+++ b/content/hoon/stdlib/4b.md
@@ -176,7 +176,7 @@ A `$tape`.
 #### Source
 
 ```hoon
-++  rt    `tape`['\'' (weld (mesc (trip a)) `$tape`['\'' ~])]
+++  rt    `tape`['\'' (weld (mesc (trip a)) `tape`['\'' ~])]
 ```
 
 #### Examples

--- a/content/hoon/stdlib/4i.md
+++ b/content/hoon/stdlib/4i.md
@@ -815,7 +815,7 @@ Parse a hexbyte.
 
 ```hoon
 ++  mes  %+  cook
-           |=({a/@ b/@} (add (mul 16 a) b))
+           |=([a=@ b=@] (add (mul 16 a) b))
          ;~(plug hit hit)
 ```
 

--- a/content/hoon/stdlib/4j.md
+++ b/content/hoon/stdlib/4j.md
@@ -169,7 +169,7 @@ Parsing `$rule`. Parses an `$atom` of aura `@pE`, without leading `~` or `.~`. A
 #### Source
 
 ```hoon
-++  hif  (boss 256 ;~(plug tip tiq (easy ~)))
+++  hif  (bass 256 ;~(plug tip tiq (easy ~)))
 ```
 
 #### Examples

--- a/content/hoon/stdlib/4m.md
+++ b/content/hoon/stdlib/4m.md
@@ -515,7 +515,7 @@ A `$path`, or crash.
 #### Source
 
 ```hoon
-++  stab  |=(zep=@t `$path`(rash zep stap))
+++  stab  |=(zep=@t `path`(rash zep stap))
 ```
 
 #### Examples

--- a/content/hoon/zuse/README.md
+++ b/content/hoon/zuse/README.md
@@ -17,7 +17,7 @@ layout:
 
 Documentation for the `%base` desk's `/sys/zuse.hoon` library, which contains helper functions for the kernel.
 
-Zuse is the farthest downstream component of the kernel in terms of dependency, so its version number is used to represent the version of the kernel as a whole. For example, a new kernel release might be referred to as "410k" to refer to Zuse kelvin version 410.
+Zuse is the farthest downstream component of the kernel in terms of dependency, so its version number is used to represent the version of the kernel as a whole. For example, a new kernel release might be referred to as "408k" to refer to Zuse kelvin version 408.
 
 ## 2d: Formatting functions {#2d-formatting-functions}
 

--- a/content/urbit-os/kernel/arvo/README.md
+++ b/content/urbit-os/kernel/arvo/README.md
@@ -378,7 +378,7 @@ The Arvo kernel can do very little on its own. Its functionality is extended in 
 
 As described above, we use Arvo proper to route and control the flow of `$move`s. However, Arvo proper is rarely directly responsible for processing the event data that directly causes the desired outcome of a `$move`. This event data is contained within a `$card`. Instead, Arvo proper passes the `$card` off to one of its vanes, which each present an interface to clients for a particular well-defined, stable, and general-purpose piece of functionality.
 
-As of this writing, we have nine vanes, which each provide the following services:
+As of this writing, we have ten vanes, which each provide the following services:
 
 - [Ames](../ames): the name of both our network and the vane that communicates over it.
 - [Behn](../behn): a simple timer.
@@ -389,6 +389,7 @@ As of this writing, we have nine vanes, which each provide the following service
 - [Iris](../iris): an http client.
 - [Jael](../jael): storage for Azimuth information.
 - [Khan](../khan): control plane and thread runner.
+- [Lick](../lick): an inter-process communication (IPC) vane, for talking to Unix processes over a socket.
 
 ##### Applying your knowledge {#applying-your-knowledge}
 

--- a/content/urbit-os/kernel/arvo/scry.md
+++ b/content/urbit-os/kernel/arvo/scry.md
@@ -45,7 +45,7 @@ There are two places where scry endpoints are defined:
 
 ### Vanes {#vanes}
 
-Each of Arvo's nine vanes (kernel modules) include a `+scry` arm which defines that vane's scry endpoints. The number of endpoints and extent of data available varies between vanes. For example, Clay has a very extensive set of scry endpoints which provide read access to all files in all desks across all revisions, as well as the ability to build files, perform mark conversions, and various other functions. Jael provides access to a great deal of PKI data. On the other hand, Dill has only a couple of endpoints which are mostly useful for debugging, and Iris has none at all (apart from standard memory reporting endpoints you'd not typically use in your applications).
+Each of Arvo's ten vanes (kernel modules) include a `+scry` arm which defines that vane's scry endpoints. The number of endpoints and extent of data available varies between vanes. For example, Clay has a very extensive set of scry endpoints which provide read access to all files in all desks across all revisions, as well as the ability to build files, perform mark conversions, and various other functions. Jael provides access to a great deal of PKI data. On the other hand, Dill has only a couple of endpoints which are mostly useful for debugging, and Iris has none at all (apart from standard memory reporting endpoints you'd not typically use in your applications).
 
 To explore what scry endpoints are available for vanes, you can refer to the Scry Reference section of each vane in the [Arvo](..) section of the documents.
 

--- a/content/urbit-os/kernel/clay/data-types.md
+++ b/content/urbit-os/kernel/clay/data-types.md
@@ -1071,7 +1071,7 @@ Kelvin range
   weft
 ```
 
-A `$waft` is the result of reading a `sys.kelvin` file in a desk. It lists all the `$weft`s (kernel versions) a desk is compatible with. It may either be a single `$weft` like `[%zuse 410]`, or a range like:
+A `$waft` is the result of reading a `sys.kelvin` file in a desk. It lists all the `$weft`s (kernel versions) a desk is compatible with. It may either be a single `$weft` like `[%zuse 408]`, or a range like:
 
 ```hoon
 [[%1 ~] (silt zuse+417 zuse+416 ~)]

--- a/content/urbit-os/kernel/lick/guide.md
+++ b/content/urbit-os/kernel/lick/guide.md
@@ -292,7 +292,7 @@ cp -r zod/base/lib/{default-agent*,skeleton*} licker/desk/lib/
 Add a `desk.bill` `sys.kelvin` files:
 
 ```
-echo "[%zuse 410]" > licker/desk/sys.kelvin
+echo "[%zuse 408]" > licker/desk/sys.kelvin
 echo "~[%licker]" > licker/desk/desk.bill
 ```
 

--- a/content/user-manual/os/dojo-tools.md
+++ b/content/user-manual/os/dojo-tools.md
@@ -295,7 +295,7 @@ desk
 
 Print out the status of each installed desk.
 
-Also see the related [`+vat`](#vat) command, which prints the status of a single desk rather than all desks.
+To print the status of a single desk rather than all desks, pass the desk name: `+vats %base`.
 
 Fields:
 

--- a/content/user-manual/running/vere.md
+++ b/content/user-manual/running/vere.md
@@ -827,7 +827,7 @@ The scry path is in the format `/[care]/[path]`, omitting the ship and case elem
 - Undocked: `./urbit -X /cx/base/gen/code/hoon [pier]`
 - Docked: `[pier]/.run -X /cx/base/gen/code/hoon`
 
-### `-Y, --scry-info FILE` {#y---scry-info-file}
+### `-Y, --scry-into FILE` {#y---scry-into-file}
 
 Optional name for the file produced by a scry performed with `-X`, rather than the scry path.
 


### PR DESCRIPTION
First of three PRs from an audit of the docs against `urbit/urbit@08026c84b2` and `urbit/vere@92847eb3fd`. This one is deliberately the low-risk batch: mechanical corrections that need no domain review. The other two cover Hoon stdlib signatures and user-manual commands.

Claims were verified against upstream source, and where possible reproduced on a fake ship booted from `urbit-408k-rc1.pill` (`[%zuse 408]`).

## `math.md`: 40 corrupted `$$` inside code fences

A stray doubling made 34 `$(` recursion calls and 4 `$:` bunts invalid Hoon, so every affected listing fails to parse when copied. Confirmed in the dojo:

```
> =/  i  1  |-  ?:  (gth i 3)  i  $(i +(i))
4
```

while the `$$(` form as printed is rejected by the parser outright.

Scope was checked carefully, because a naive replace would do damage:

- the 16 out-of-fence `$$...$$` in `math.md` are **LaTeX** and are preserved
- `stdlib/3b.md`, `hoon-school/S-math.md` and others contain only LaTeX `$$` — untouched
- `stdlib/4o.md` and `core-academy/ca02.md` contain `::  $$, recursion`, which is **verbatim source** (`$$` is the `%bcbc` rune) — untouched

## `math.md`: phantom `+exp` section

`lib/math.hoon:148` is `::++  exp  exp:^rs` — commented out. The doc dropped the `::` and presented it as a live pass-through arm, which also created a duplicate `{#exp}` anchor colliding with the real `+exp`. Removed. (The same line is commented out four times in source, once per float core; only the `rs` one had leaked in.)

## Vane count

"nine vanes" → ten, in four files. Lick was missing from the list in `arvo/README.md` entirely.

## Source-block typos

Each checked against `sys/hoon.hoon`:

| File | Arm | Fix |
|---|---|---|
| `4j.md` | `+hif:ab` | `boss` → `bass` |
| `2l.md` | `+molt` | `}` → `]` |
| `4b.md` | `+rt:at` | `` `$tape` `` → `` `tape` `` |
| `4m.md` | `+stab` | `` `$path` `` → `` `path` `` |
| `4i.md` | `+mes` | `{a/@ b/@}` → `[a=@ b=@]` |
| `1c.md` | `+bloq` | → `$bloq` (it is `+$` in source); anchor left intact |

Note `+til` legitimately uses `+boss`, so the `+hif` fix is deliberately not a global replace. The `$tape`/`$path` cases look like a `$`-prefixing pass that leaked into code blocks.

## Runtime and dojo

- `vere.md`: `--scry-info` → `--scry-into`. The long option never existed under the documented name (`main.c:303`).
- `dojo-tools.md`: `+vat` does not exist — verified `%generator-build-fail`. Dead cross-reference replaced with `+vats %base`.

## Kelvins → 408

Ten illustrative or instructional sites updated. Two of them are commands a reader actually runs (`echo "[%zuse 417]" > sys.kelvin` in `flap.md`, same in `lick/guide.md`); a desk declaring an unsupported kelvin is rejected, so those were not merely cosmetic. Verified `|new-desk` writes `[%zuse 408]`.

**Deliberately not changed** — these state when a feature was introduced and remain true: remote scry at 413 and path-format version at 411 (`remote-scry.md`), `%kroc` no-op at 410 (`hood.md`), noun channels at 413 (`noun-channels.md`), and Core Academy's explicit "snapshot at Zuse 412k".

🤖 Generated with [Claude Code](https://claude.com/claude-code)