### PR TITLE
docs: document the +cric cryptosuite that replaced +crub in Ames and Jael

### DIFF
--- a/content/hoon/cryptography.md
+++ b/content/hoon/cryptography.md
@@ -21,11 +21,51 @@ Documentation for [Insecure Hashing](stdlib/2e.md) and the [SHA Hash Family](std
 
 ## Summary {#summary}
 
-`zuse` contains several cryptosuites. The ones utilized by Ames are [`+ed:crypto`](#ed), [`+aes:crypto`](#aes), and [`+crub:crypto`](#crub), with the latter being the only one which is implemented as an [`+acru:ames`](../urbit-os/kernel/ames/cryptography.md#crypto-core)-shaped core.
+`zuse` contains several cryptosuites. The ones utilized by Ames are [`+ed:crypto`](#ed), [`+aes:crypto`](#aes), and [`+cric:crypto`](#cric).
+
+[`+crub:crypto`](#crub) is the older suite and still exists in `zuse`, but Ames no longer uses it: at the current kernel there are no references to `+crub` anywhere in `sys/vane/ames.hoon`. Jael likewise builds keys through `+cric` (`pit:nu:cric:crypto`, `nol:nu:cric:crypto`).
+
+## `+cric:crypto` {#cric}
+
+`+cric:crypto` is the cryptosuite Ames and Jael use. Unlike `+crub`, which is
+fixed to Suite B, `+cric` is a door over a tagged payload and can carry either
+suite:
+
+```hoon
+++  cric
+  |_  $%  $:  suite=%b
+              pub=[cry=@ sgn=@ ~]
+              sek=$@(~ [sed=@ cry=@ sgn=@])
+          ==
+          $:  suite=%c
+              pub=[cry=@ sgn=@ tw=[ugn=@ dat=@ xtr=@]]
+              sek=$@(~ [sed=@ cry=@ sgn=@])
+          ==
+      ==
+```
+
+The `%b` case corresponds to [Suite B Cryptography](https://en.wikipedia.org/wiki/NSA_Suite_B_Cryptography),
+as `+crub` did; the `%c` case carries the additional `tw` material for Suite C.
+
+It contains four sub-cores:
+
+- `+as:cric` — asymmetric operations: `+sign`, `+sigh`, `+sure`, `+safe`, `+seal`, `+tear`.
+- `+ex:cric` — extraction: `+fig`, `+pac`, `+pub`, `+sec`, `+ven`, `+ded`, `+saf`, `+cry`, `+sgn`, `+num`.
+- `+nu:cric` — construction: `+pit` (create keypair), `+nol` (activate secret), `+com` (activate public).
+- `+cyf:cric` — symmetric encryption: `+de`, `+dy`, `+en`.
+
+Note that the symmetric arms live under `+cyf`, where `+crub` had them at the
+top level: what was `+en:crub:crypto` is now `+en:cyf:cric:crypto`.
+
+The suite in use for a given ship's keys is recorded on Azimuth as the
+`crypto-suite` field of [`$key-update:point`](../urbit-os/kernel/jael/data-types.md#key-updatepoint).
 
 ## `+crub:crypto` {#crub}
 
 `+crub:crypto` implements an [`+acru:ames`](../urbit-os/kernel/ames/cryptography.md#crypto-core) core that implements [Suite B Cryptography](https://en.wikipedia.org/wiki/NSA_Suite_B_Cryptography).
+
+It is superseded by [`+cric:crypto`](#cric) and is no longer used by Ames or
+Jael, but remains in `zuse` and is documented here.
 
 It utilizes AES symmetric key encryption and decryption from [`+aes:crypto`](#aes) implemented using the Diffie-Hellman key exchange protocol, elliptic curve digital signature algorithm (ECDSA) signing and verification with [`+ed:crypto`](#ed), and generates public/private key pairs using elliptic curve cryptography with `+ed:crypto`.
 
@@ -174,6 +214,6 @@ Most gates in `+ed:crypto` are [jetted](../build-on-urbit/runtime/jetting.md), m
 
 ## `+aes:crypto` {#aes}
 
-This core contains cryptographic primitives and helper functions for [AES](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard) symmetric key encryption and decryption. As is the case with `ed:crypto`, these functionalities are utilized by [`+crub:crypto`](#crub), and most gates are jetted. See also the Vere documentation on [AES SIV](../build-on-urbit/runtime/cryptography.md#aes) for more information about the library utilized by jets.
+This core contains cryptographic primitives and helper functions for [AES](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard) symmetric key encryption and decryption. As is the case with `ed:crypto`, these functionalities are utilized by [`+cric:crypto`](#cric) and [`+crub:crypto`](#crub), and most gates are jetted. See also the Vere documentation on [AES SIV](../build-on-urbit/runtime/cryptography.md#aes) for more information about the library utilized by jets.
 
 This core contains several doors, each one used for a different variation of AES according to key size and mode. The only ones currently in use are `+siva:aes:crypto` and `+sivc:aes:crypto`, which are 128-bit and 256-bit modes of [`AES-SIV`](https://www.aes-siv.com) respectively.

--- a/content/urbit-os/kernel/ames/cryptography.md
+++ b/content/urbit-os/kernel/ames/cryptography.md
@@ -29,7 +29,7 @@ The `$ames-state` includes a [`+acru:ames`](cryptography.md#crypto-core) core, a
 
 Each Urbit ship possesses two networking keypairs: one for encryption, and one for authentication. We often refer to these two keypairs as though they were a single keypair because they are stored as a single atom. [Elliptic Curve Diffie-Hellman](https://en.wikipedia.org/wiki/Elliptic-curve_Diffie%E2%80%93Hellman) is used for encryption, while [Elliptic Curve Digital Signature Algorithm](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm) is used for authentication
 
-The encrypted payload of each packet is a `$shut-packet`, which is the `+jam` of a cell with the [$bone](data-types.md#bone), message number, and message fragment or ack (see [Ames](README.md) for more information on packet structure). The message fragment is signed using the authentication key. It is encrypted using [`+en:crub:crypto`](../../../hoon/cryptography.md#en) found in `sys/zuse.hoon`, which utilizes the 256-bit AES-SIV algorithm.
+The encrypted payload of each packet is a `$shut-packet`, which is the `+jam` of a cell with the [$bone](data-types.md#bone), message number, and message fragment or ack (see [Ames](README.md) for more information on packet structure). The message fragment is signed using the authentication key. It is encrypted using [`+en:cyf:cric:crypto`](../../../hoon/cryptography.md#cric) found in `sys/zuse.hoon`, which utilizes the 256-bit AES-SIV algorithm.
 
 ## Diffie-Hellman key exchange <a href="#key-exchange" id="key-exchange"></a>
 
@@ -37,7 +37,7 @@ For each foreign ship a given ship has communicated with, `$ames-state` contains
 
 ## Comet self-attestation <a href="#comets" id="comets"></a>
 
-Recall that the `@p` of a comet is the hash of their 128-bit public key cast as a `@p`. Since the public key of a comet is not stored on Azimuth, a comet proves its identity with an "attestation packet". This is an unencrypted packet whose payload is the comet's signature created with its private key. This is the only circumstance under which a ship will send an unencrypted packet. The signature is generated with [`+sign:as:crub`](../../../hoon/cryptography.md#sign-as) found in `sys/zuse.hoon`.
+Recall that the `@p` of a comet is the hash of their 128-bit public key cast as a `@p`. Since the public key of a comet is not stored on Azimuth, a comet proves its identity with an "attestation packet". This is an unencrypted packet whose payload is the comet's signature created with its private key. This is the only circumstance under which a ship will send an unencrypted packet. The signature is generated with [`+sign-raw:ed:crypto`](../../../hoon/cryptography.md#ed) found in `sys/zuse.hoon`, using the signing keypair directly (`+etch-open-packet` in `sys/vane/ames.hoon`).
 
 Upon hearing an attestation packet, the receiving ship will generate a symmetric key for communications with the comet, according to the [key exchange](#key-exchange) protocol.
 
@@ -45,7 +45,9 @@ The fact that the first packet exchanged between a comet and another ship must b
 
 ## `+acru:ames` <a href="#crypto-core" id="crypto-core"></a>
 
-The `+crypto-core` in `$ames-state` is an `+acru:ames` core, a [lead](../../../hoon/advanced.md#dry-polymorphism-and-core-nesting-rules) interface core for asymmetric cryptosuites found in `sys/lull.hoon` which handles encryption, decryption, signing, and verifying. In practice, the only cryptosuite in use is [`+crub:crypto`](../../../hoon/cryptography.md#crub), which implements [Suite B Cryptography](https://en.wikipedia.org/wiki/NSA_Suite_B_Cryptography).
+`+acru:ames` is a [lead](../../../hoon/advanced.md#dry-polymorphism-and-core-nesting-rules) interface core for asymmetric cryptosuites, found in `sys/lull.hoon`, which handles encryption, decryption, signing, and verifying. The cryptosuite in use is [`+cric:crypto`](../../../hoon/cryptography.md#cric); `+crub:crypto` is no longer referenced by Ames.
+
+Note that Ames no longer stores a crypto core in its state. Earlier versions of `$ames-state` held a `crypto-core` field, and `sys/vane/ames.hoon` still defines `+acru-12` and `+acru-25` shapes — but those exist only to type *previous* states during a migration. The current `+$ axle` (`sys/lull.hoon`) instead stores the key material directly, as `[saf=keypairs =ring =pass]`, where `+$ keypairs` is `[pub=public-keys sek=private-keys]`.
 
 ```hoon
   ++  acru  $_  ^?                                      ::  asym cryptosuite
@@ -73,7 +75,7 @@ The `+crypto-core` in `$ames-state` is an `+acru:ames` core, a [lead](../../../h
     --  ::acru                                          ::
 ```
 
-As the `+acru` core is merely an interface, the details on how it is implemented may vary according to the cryptosuite. We summarize what each core is utilized for here, but see [`crub:crypto`](../../../hoon/cryptography.md#crub) for more details on how the specific cryptosuite utilized by Ames is implemented.
+As the `+acru` core is merely an interface, the details on how it is implemented may vary according to the cryptosuite. We summarize what each core is utilized for here, but see [`cric:crypto`](../../../hoon/cryptography.md#cric) for more details on how the specific cryptosuite utilized by Ames is implemented.
 
 #### `+as:acru`
 

--- a/content/urbit-os/kernel/jael/data-types.md
+++ b/content/urbit-os/kernel/jael/data-types.md
@@ -150,7 +150,7 @@ Structures for points (Ship IDs in Azimuth).
   ==
 ```
 
-Public key data for a particular ship. The `rift` is the current continuity breach number and `$life` is the current key revision number. The `.keys` `+map` contains the public key (`.pass`) for each `$life` up to the current one. The `.sponsor` is the current sponsor of the ship in question, if it has one.
+Public key data for a particular ship. The `rift` is the current continuity breach number and `$life` is the current key revision number. The `.keys` `+map` contains, for each `$life` up to the current one, the public key (`.pass`) and the `crypto-suite` version number identifying which cryptographic suite that key belongs to. The `.sponsor` is the current sponsor of the ship in question, if it has one.
 
 ### `$key-update:point` {#key-updatepoint}
 


### PR DESCRIPTION
Sixth PR from the audit against `urbit/urbit@08026c84b2`. Cross-cutting — this one was flagged independently by two passes of the audit, in two different doc trees, which is what pushed it up the queue.

Companion PRs: #266, #267, #268, #269, #270.

## What changed upstream

`+cric:crypto` (`zuse.hoon:1489`) is the suite Ames and Jael now use. Unlike `+crub`, which is fixed to Suite B, `+cric` is a door over a tagged payload and can carry either suite:

```hoon
$%  [suite=%b pub=[cry=@ sgn=@ ~] sek=...]
    [suite=%c pub=[cry=@ sgn=@ tw=[ugn=@ dat=@ xtr=@]] sek=...]
==
```

Counted rather than assumed: `sys/vane/ames.hoon` contains **zero** references to `crub` and **26** to `cric`. Jael builds keys through `+cric` too (`pit:nu:cric:crypto`, `nol:nu:cric:crypto` — `jael.hoon:266,338,854,1260,1271,1306`).

`+crub` still exists in `zuse` (`:1703`) and its documentation is **kept** — it's now labelled superseded rather than deleted, since the docs previously called it *"the only cryptosuite which Ames makes use of"*.

One structural change worth calling out: the symmetric arms moved into a `+cyf` sub-core. What the docs called `+en:crub:crypto` is now **`+en:cyf:cric:crypto`**. All four sub-cores are documented: `as`, `ex`, `nu`, `cyf`.

## Corrections that required reading the current state, not the migration code

Two things here are worth a reviewer's attention, because the obvious search gives the wrong answer.

**1. Ames no longer stores a crypto core at all.** The audit described Ames as wrapping `_cric:crypto` in an internal `+acru-25` core with a legacy `+acru-12` for old peers. That is true of the *migration types only*. The current `+$ axle` (`lull.hoon:1601`, `axle-31`) has **no `crypto-core` field** — it stores `[saf=keypairs =ring =pass]`, where `+$ keypairs` is `[pub=public-keys sek=private-keys]` (`lull.hoon:1069`). `+acru-12` (`ames.hoon:817`) and `+acru-25` (`:881`) appear only inside versioned definitions like `ames-state-13` and `ames-state-22`.

The docs now state this explicitly, so the next reader doesn't repeat the mistake. (This is the same shape of trap as the `heeds` field in #269.)

**2. Comet self-attestation no longer signs via an acru core.** `+etch-open-packet` (`ames.hoon:423-438`) signs with `(sign-raw:ed:crypto - [sgn.pub sgn.sek]:saf)`. The documented `+sign:as:crub` was wrong in both suite and arm.

## Not changed, having been checked

- **`jael/data-types.md` `$point` and `$key-update` already carry `crypto-suite=@ud`** and match `lull.hoon:4323,4327`. The audit listed these as needing the field added — they did not. Only `$point`'s prose omitted an explanation of what `crypto-suite` means, which is now supplied.
- `+crub:so` (`stdlib/4l.md`) is an unrelated date-parsing arm in `+so`. Untouched.
- `core-academy/ca02.md` quotes `+crub` source, but Core Academy declares itself a snapshot at Zuse 412k.

All anchor links in the touched files were verified to resolve, and this branch was test-merged against the five open companion PRs — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)