### PR TITLE
docs: document +dbug =depth, |eyre/clean, and missing test-library arms

### DIFF
--- a/content/build-on-urbit/app-school/3-imports-and-aliases.md
+++ b/content/build-on-urbit/app-school/3-imports-and-aliases.md
@@ -208,5 +208,5 @@ The key takeaways are:
 
 * Run through the [example](3-imports-and-aliases.md#example) yourself on a fake ship if you've not done so already.
 * Have a read through the [Ford rune documentation](../../hoon/rune/fas.md) for details about importing libraries, structures and other things.
-* Try the `+dbug` generator out on some other agents, like `:settings +dbug`, `:contacts +dbug`, etc, and try some of its options [described above](3-imports-and-aliases.md#dbug).
+* Try the `+dbug` generator out on some other agents, like `:azimuth +dbug`, `:spider +dbug`, `:hood +dbug`, etc, and try some of its options [described above](3-imports-and-aliases.md#dbug).
 * Have a quick look over the source of the `/lib/default-agent.hoon` library, located at `/lib/default-agent.hoon` in the `%base` desk. We've not yet covered what the different arms do but it's still useful to get a general idea, and you'll likely want to refer back to it later.

--- a/content/build-on-urbit/userspace/examples/dbug.md
+++ b/content/build-on-urbit/userspace/examples/dbug.md
@@ -89,9 +89,12 @@ There are four actions exposed by the wrapper via the `+dbug` generator:
         ::  inline arguments
         args=?(~ [what=?(%bowl %state) ~] [=poke ~])
         ::  named arguments
-        ~
+        depth=@ud
     ==
 :-  %dbug
+=;  =poke
+  ?:  =(0 depth)  poke
+  [%skip depth poke]
 ?-  args
   ~          [%state '']
   [@ ~]      ?-(what.args %bowl [%bowl ~], %state [%state ''])
@@ -111,7 +114,8 @@ There are four actions exposed by the wrapper via the `+dbug` generator:
 ::
 |%
 +$  poke
-  $%  [%bowl ~]
+  $%  [%skip depth=@ud =poke]
+      [%bowl ~]
       [%state grab=cord]
       [%incoming =about]
       [%outgoing =about]
@@ -141,6 +145,12 @@ There are four actions exposed by the wrapper via the `+dbug` generator:
       [cards this]
     =/  dbug
       !<(poke vase)
+    =?  dbug  ?=([%skip %0 *] dbug)  poke.dbug
+    ?:  ?=(%skip -.dbug)
+      =^  cards  agent
+        %+  on-poke:ag  %dbug
+        !>(`poke`dbug(depth (dec depth.dbug)))
+      [cards this]
     =;  =tang
       ((%*(. slog pri 1) tang) [~ this])
     ?-  -.dbug
@@ -289,6 +299,12 @@ By applying this door builder using `%-` censig, the `+on-poke` and `+on-peek` a
       [cards this]
     =/  dbug
       !<(poke vase)
+    =?  dbug  ?=([%skip %0 *] dbug)  poke.dbug
+    ?:  ?=(%skip -.dbug)
+      =^  cards  agent
+        %+  on-poke:ag  %dbug
+        !>(`poke`dbug(depth (dec depth.dbug)))
+      [cards this]
     =;  =tang
       ((%*(. slog pri 1) tang) [~ this])
     ?-  -.dbug

--- a/content/build-on-urbit/userspace/unit-tests.md
+++ b/content/build-on-urbit/userspace/unit-tests.md
@@ -36,11 +36,14 @@ The `%base` desk includes a `-test` thread which can run unit tests you've writt
 
 Any arms that don't begin with `test-` will be ignored. Each `+test-*` arm must produce a `$tang` (a `(list tank)`). If the `$tang` is empty (`~`), it indicates success. If the `$tang` is non-empty, it indicates failure, and the contents of the `$tang` is the error message.
 
-To make test-writing easier, the `%base` desk includes the `/lib/test.hoon` library which you can import into your test file. The library contains four functions which all produce `$tang`s:
+To make test-writing easier, the `%base` desk includes the `/lib/test.hoon` library which you can import into your test file. The library contains the following functions, which all produce `$tang`s:
 
 - `+expect-eq` - test whether an expression produces the expected value. This function takes `[expected=vase actual=vase]`, comparing `.expected` to `.actual`.
 - `+expect` - test whether an expression produces `%.y`. This function takes a `$vase` containing the result to check.
 - `+expect-fail` - tests whether the given `$trap` crashes, failing if it succeeds.
+- `+expect-success` - the converse of `+expect-fail`: tests whether the given `$trap` succeeds, failing if it crashes.
+- `+expect-fail-message` - takes `[msg=@t a=(trap)]`. Like `+expect-fail`, but also requires that `.msg` appear in the resulting error message, so you can assert on *why* something failed rather than just that it did.
+- `+run-chain` - takes an `$a-test-chain` and runs a sequence of tests, stopping at the first failure. Note that arms in the chain should not begin with `test-`, so that `-test %/... ~` does not also run them individually.
 - `+category` - this is a utility that prepends an error message to a failed test (non-null `$tang`), passing through an empty `$tang` (successful test) unchanged.
 
 The most commonly used function is `+expect-eq`, which is used like:

--- a/content/user-manual/os/dojo-tools.md
+++ b/content/user-manual/os/dojo-tools.md
@@ -1185,16 +1185,61 @@ Query the state or bowl of a running agent.
 
 #### Arguments
 
-See the [dbug section of App School lesson 3](../../build-on-urbit/app-school/3-imports-and-aliases.md#dbug) for details of usage.
+```
+?(~ [?(%bowl %state) ~] [poke ~]), =depth @ud
+```
+
+See the [dbug section of App School lesson 3](../../build-on-urbit/app-school/3-imports-and-aliases.md#dbug) for details of the positional argument.
+
+The named `=depth` argument addresses an agent running *underneath* a wrapper
+agent. With a non-zero depth the poke is wrapped as `[%skip depth poke]`, and
+each layer of `/lib/dbug` decrements it before passing the poke down. It is only
+meaningful for a nested agent; sending it to an ordinary agent produces
+`unexpected poke to %agent with mark %dbug`.
 
 #### Example
 
 This is only used with an `:agent`, not by itself.
 
 ```
-> :graph-store +dbug [%state '(~(got by graphs) ~zod %dm-inbox)']
+> :azimuth +dbug [%state 'whos']
 >=
->   [p={} q=[~ %graph-validator-dm]]
+>   {}
+```
+
+---
+
+### `|eyre/clean` {#eyreclean}
+
+Delete stale incoming HTTP subscriptions.
+
+Eyre channel subscriptions can be left behind when a channel goes away without
+its subscriptions being torn down. This generator finds those and can remove
+them.
+
+**It runs in dry mode by default**, only reporting how many stale subscriptions
+it found. Pass `=dry |` to actually delete them.
+
+#### Arguments
+
+```
+=dry ?, =veb ?(%1 %2 ~)
+```
+
+- `=dry` - defaults to `&` (dry run). Pass `|` to delete.
+- `=veb` - verbosity. `%1` prints each stale subscription; `%2` prints each
+  subscription that still exists.
+
+#### Examples
+
+```
+> |eyre/clean
+>=
+"#0 stale incoming subscriptions"
+```
+
+```
+> |eyre/clean, =dry |
 ```
 
 ---
@@ -1822,7 +1867,7 @@ These are more advanced desk and filesystem tools.
 
 Enable automatic commits for a mounted desk
 
-Auto-commits can be disabled with [`|clay/cancel-autocommit`](#claycancelautocommit).
+Auto-commits can be disabled with [`|clay/cancel-autocommit`](#claycancel-autocommit).
 
 #### Arguments
 
@@ -1886,7 +1931,7 @@ The `$desk` is mandatory, the `.auto` is optional.
 
 If `.auto` is `%.y`, auto-commits will be enabled, meaning changes to that desk on the host side will automatically be committed as soon as they happen.
 
-Auto-commits can be disabled with [`|clay/cancel-autocommit`](#claycancelautocommit).
+Auto-commits can be disabled with [`|clay/cancel-autocommit`](#claycancel-autocommit).
 
 #### Example
 


### PR DESCRIPTION
Eighth PR from the audit against `urbit/urbit@08026c84b2`. Developer tooling. Everything below was run on a fake ship (`urbit-408k-rc1.pill`).

Companion PRs: #266, #267, #268, #269, #270, #271, #272.

## `+dbug` gained `=depth`

The generator has a named `depth=@ud` argument (`gen/dbug.hoon`) which wraps the poke as `[%skip depth poke]`. `/lib/dbug`'s `+$ poke` gained a matching `[%skip depth=@ud =poke]` case, and its `+on-poke` unwraps one layer per hop, decrementing as it passes the poke down. This lets you address an agent running *underneath* a wrapper agent.

`examples/dbug.md` is a line-by-line walkthrough of both files, so its quoted source was stale in three places: the generator's named-argument slot, the `+$ poke` union, and `+on-poke`.

**Worth flagging for review:** that file quotes `+on-poke` **twice** — once in the full library listing and once in its own `<details>` section. My first patch attempt asserted a single occurrence and aborted before writing, which is how I caught it; both copies are now updated. Each refreshed block was then checked against upstream by script.

Documented the caveat that `=depth` only makes sense for a nested agent — verified that sending it to an ordinary one fails:

```
> :azimuth +dbug, =depth 1
"unexpected poke to %azimuth with mark %dbug"
```

## `|eyre/clean` — new entry

Added 2025-06, undocumented. Deletes stale incoming HTTP channel subscriptions. `dry=?` bunts to `%.y`, so it runs as a **dry run by default** and only reports a count; `=dry |` actually deletes. `=veb` takes `%1` (print each stale subscription) or `%2` (print each surviving one).

```
> |eyre/clean
"#0 stale incoming subscriptions"
```

## `+dbug` examples referenced agents that don't ship

`:graph-store +dbug` fails with `gall: not running %graph-store yet` — that agent lives only in frozen `pkg/landscape`. Same for the `:settings` / `:contacts` suggestions in App School 3. Replaced with agents present on a bare ship (checked against `%base`'s `desk.bill`: `azimuth`, `spider`, `hood`), using real captured output:

```
> :azimuth +dbug [%state 'whos']
{}
```

## `/lib/test.hoon` exports seven arms, not four

`unit-tests.md` described "four functions". Added the three missing ones:

- `+expect-success` — the converse of `+expect-fail`
- `+expect-fail-message` — asserts on the error *text*, not merely that a crash occurred
- `+run-chain` — runs a sequence, stopping at first failure; includes the source's note that chained arms must not begin with `test-`, or `-test` will also run them individually

## Incidental

Fixed two pre-existing broken anchor links to `#claycancelautocommit`; the heading anchor is `#claycancel-autocommit`.

The remaining broken `#vat` link in this file is **deliberately left alone** — it is already fixed in #266, and fixing it twice would create a conflict. Verified in a combined test-merge that the result has zero broken `#vat` and zero broken autocommit links.

Test-merged against the seven open companion PRs — all clean, including the three that now touch `dojo-tools.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)