### PR TITLE
docs: correct Ethereum network options for roller, claz, and azimuth

### DIFF
--- a/content/urbit-id/advanced-azimuth-tools.md
+++ b/content/urbit-id/advanced-azimuth-tools.md
@@ -39,7 +39,7 @@ Here we have an example of generating a transaction to spawn a ship. Something t
 
 `%/spawn/eth-txs` is simply the path for the output file
 
-`%mainnet` specifies which network this is going to sent out on. Other options are possible including the test-net `%ropsten`.
+`%mainnet` specifies which network this is going to sent out on. The full set of options is `%mainnet`, `%goerli`, `%fakenet` and `[%other id=@]` (`+network` in `/sur/claz.hoon`), where `[%other id]` lets you give a chain ID directly. Note that Goerli has since been deprecated by the Ethereum Foundation, so `[%other id]` is the practical choice for a testnet today.
 
 `author` here is an Ethereum address that is issuing the transaction. It will need to be written in `@ux` notation, e.g. `0x3b17.d097.d9dd.711e.4ef8.517a.bbf1.8b2b.a643.81fe`.
 

--- a/content/urbit-id/flow.md
+++ b/content/urbit-id/flow.md
@@ -136,7 +136,7 @@ A `verifier` is a gate whose sample is of the form `[dat=octs v=@ r=@ s=@]` and 
 
 The `verifier` in use by `naive.hoon` runs the keccak hash function on `dat` to verify that `dat` is data signed by the ECDSA signature given by the `[v r s]` tuple, according to the format for signed transactions outlined in the [bytestring format](l2/bytestring.md) documentation.
 
-`chain-id` is the ID used by the Ethereum blockchain, which is `1337`. See [bytestring format](l2/bytestring.md) for more information. This is used so that e.g. transactions on the Ropsten test network cannot be replayed on the mainnet.
+`chain-id` is the ID used by the Ethereum blockchain, which is `1337`. See [bytestring format](l2/bytestring.md) for more information. This is used so that e.g. transactions on a test network cannot be replayed on the mainnet.
 
 `state` is the current state of the PKI. This is structured similarly to the state held in [Azimuth.eth](azimuth-eth.md), but will differ in general since `state` takes into account layer 2 transactions as well. See the [Layer 2 Overview](l2/README.md) for more on how PKI state is handled.
 

--- a/content/urbit-id/roller-tutorial.md
+++ b/content/urbit-id/roller-tutorial.md
@@ -15,7 +15,7 @@ layout:
 
 # Custom Roller Tutorial
 
-This tutorial is an outline for how to set up your own L2 roller for Urbit. Some familiarity with how L2 works in general, as well as the role of the roller, is expected. See [Layer 2 Overview](l2/README.md) for a technical overview of L2, [Azimuth Data Flow](flow.md) to gain an understanding of how Azimuth data handling and processing is done on Urbit, and [Rollers](l2/roller.md) for a short summary of what the different Gall agents involved for rollers are. This tutorial is focused on setting up a roller to work on the main Ethereum network, but only minor changes are needed to utilize the Ropsten Ethereum network. We also explain how to set up a front end (Bridge) from which transactions to be batched by the roller are sent, but use of a front end is not mandatory.
+This tutorial is an outline for how to set up your own L2 roller for Urbit. Some familiarity with how L2 works in general, as well as the role of the roller, is expected. See [Layer 2 Overview](l2/README.md) for a technical overview of L2, [Azimuth Data Flow](flow.md) to gain an understanding of how Azimuth data handling and processing is done on Urbit, and [Rollers](l2/roller.md) for a short summary of what the different Gall agents involved for rollers are. This tutorial is focused on setting up a roller to work on the main Ethereum network. We also explain how to set up a front end (Bridge) from which transactions to be batched by the roller are sent, but use of a front end is not mandatory.
 
 Note that this process involves giving the private key of an Ethereum wallet to the ship running the roller so that it may spend ETH to submit transactions. If you do not fully understand what this entails, we recommend against running your own roller on the Ethereum mainnet. See [below](roller-tutorial.md#step2) for more information on this.
 
@@ -88,12 +88,24 @@ This will launch a server running Bridge that utilizes the mainnet roller you se
 
 | Dojo Command         | Description                                                           | Argument                           |
 | -------------------- | --------------------------------------------------------------------- | ---------------------------------- |
+| `:roller\|assign`    | Assigns a quota to a ship; omit the quota to allow unlimited txs.     | `[ship (unit @ud)]`                |
 | `:roller\|commit`    | Submits a new L2 batch with all pending transactions.                 | None.                              |
 | `:roller\|config`    | General configuration command.                                        | `$config` (see `/sur/dice.hoon`)   |
-| `:roller\|endpoint`  | Set the Infura endpoint.                                              | `[@t ?(%mainnet %ropsten %local)]` |
+| `:roller\|endpoint`  | Set the Infura endpoint.                                              | `[@t ?(%mainnet %goerli %local)]`  |
 | `:roller\|frequency` | Sets the frequency at which batches are submitted.                    | `@dr`                              |
 | `:roller\|local`     | Configures `%roller` to listen to a local Ethereum node at port 8545. | None.                              |
 | `:roller\|quota`     | Modified the number of txs a ship is allowed to send per unit time.   | `@ud`                              |
-| `:roller\|ropsten`   | Configure `%roller` to listen to a preset Ropsten Infura node.        | None.                              |
+| `:roller\|refuel`    | Bumps the gas price for a sending transaction.                        | `[@ @ud (unit @ux)]`               |
+| `:roller\|goerli`    | Configure `%roller` to listen to a preset Goerli Infura node.         | None.                              |
 | `:roller\|setkey`    | Load a private key into the roller and retrieves its L1 nonce.        | `@t`                               |
 | `:roller\|slice`     | Modified the unit of time for each ship's quota.                      | `@dr`                              |
+
+> **A note on testnets.** The only testnet this tooling supports is Goerli:
+> `:roller|goerli` points `%roller` at a Goerli Infura node whose URL is
+> hardcoded in `/gen/roller/goerli.hoon`. Goerli has since been deprecated by
+> the Ethereum Foundation, as was the earlier Ropsten network that this page
+> previously referred to. There is no Sepolia or Holešky generator in
+> `pkg/arvo/gen/roller/`, so the testnet path is unmaintained upstream, not just
+> in these docs. If you want a non-mainnet roller today, use `:roller|local`
+> against your own node and set the endpoint explicitly with
+> `:roller|endpoint`.

--- a/content/user-manual/os/dojo-tools.md
+++ b/content/user-manual/os/dojo-tools.md
@@ -535,7 +535,7 @@ Change node URL and network for Azimuth.
 #### Arguments
 
 ```
-cord ?(%mainnet %ropsten %local %default)
+cord ?(%mainnet %ropsten %goerli %local %default)
 ```
 
 The first argument is the note URL in a cord like `'http://eth-mainnet.urbit.org:8545' `. The second argument specifies the network.


### PR DESCRIPTION
Ninth PR from the audit against `urbit/urbit@08026c84b2`. Urbit ID network options.

Companion PRs: #266, #267, #268, #269, #270, #271, #272, #273.

**The headline for reviewers:** these three pages each name a *different* network type, and they are **not the same set**. Checking one and generalising gives the wrong answer for the other two — which is exactly the mistake this PR avoids.

| Where | Type | Contains `%ropsten`? |
|---|---|---|
| `gen/roller/endpoint.hoon` | `?(%mainnet %goerli %local)` | no |
| `sur/claz.hoon` `+network` | `?(%mainnet %goerli %fakenet [%other id=@])` | no |
| `sur/dice.hoon` `+$ net` | `?(%mainnet %ropsten %goerli %local %default)` | **yes** |

## `roller-tutorial.md`

`:roller|ropsten` does not exist — `pkg/arvo/gen/roller/` contains `goerli.hoon`, not `ropsten.hoon`, and `endpoint.hoon` declares its own inline type that doesn't accept `%ropsten` at all. Corrected the command name, the documented argument type, and the intro prose which offered Ropsten as a supported alternative.

Also added two roller generators missing from the command table entirely: `|assign` `[ship (unit @ud)]` (per-ship quota; omit the quota for unlimited) and `|refuel` `[@ @ud (unit @ux)]` (bump gas price for a sending transaction).

Added a note that the testnet path is unmaintained **upstream**, not merely in the docs: `gen/roller/goerli.hoon` hardcodes a Goerli Infura URL, Goerli has been deprecated by the Ethereum Foundation, and there is no Sepolia or Holešky generator in the directory. Readers are pointed at `|local` plus an explicit `|endpoint` instead.

## `advanced-azimuth-tools.md`

Said other `claz` networks are *"possible including the test-net `%ropsten`"*. `+network` in `/sur/claz.hoon` has no `%ropsten`, and the dispatch in `app/claz.hoon:187-192` agrees. Replaced with the real set, noting `[%other id]` takes a chain ID directly and is the practical testnet choice now.

## `dojo-tools.md`

`:azimuth|watch` documented its network argument as `?(%mainnet %ropsten %local %default)`. **Here `%ropsten` is not stale** — `+$ net` in `/sur/dice.hoon` still includes it. The doc was merely *incomplete*, missing `%goerli`, so that is what was added. Removing `%ropsten` — the obvious move after the other two files — would have been wrong.

## `flow.md`

Used Ropsten as the illustrative example for replay protection. Changed to "a test network" so the example doesn't go stale again; the point is about chain IDs, not any particular chain.

## Not touched

Two broken anchors in `dojo-tools.md` (`#vat`, `#claycancelautocommit` ×2) are deliberately left alone — already fixed in #266 and #273 respectively. Verified in a combined test-merge of all nine branches that the merged `dojo-tools.md` has **zero** broken anchors and the correct `$net` type, with each fix applied exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)