### PR TITLE
docs: document Gall's five undocumented vane scries

### DIFF
--- a/content/urbit-os/kernel/gall/scry.md
+++ b/content/urbit-os/kernel/gall/scry.md
@@ -58,6 +58,22 @@ Gall itself provides the special vane-level endpoints listed below. They are org
 
 Note you can use `$` to make the last element empty since it won't allow a trailing `/`. Note how in the third example, the empty element is at the *beginning* of the `$spur` and *after* the `$beak`. If you fail to include this empty element, Gall will try route the scry to an agent for handling instead.
 
+### `%b`: blocked moves {#b-blocked-moves}
+
+A scry with a `%b` care will give you the moves queued for agents that have not been started yet.
+
+#### Produces
+
+A `(map term (qeu blocked-move))`, keyed by agent name.
+
+#### Example
+
+```
+> .^(* %gb /=//=/$)
+```
+
+---
+
 ### `%d`: get desk of app {#d-get-desk-of-app}
 
 A scry with a `%d` care and an agent in `q.beak` will give you the desk that agent is on.
@@ -126,6 +142,54 @@ A `(map dude @)` where the `@` is the nonce.
       [p=%s3-store q=1]
       [p=%hark-system-hook q=1]
 ......(truncated for brevity)......
+```
+
+---
+
+### `%g`: flubbed apps {#g-flubbed-apps}
+
+A scry with a `%g` care will give you, per ship, the agents that have refused a `$plea` — the apps for which Gall has given Ames a `%flub`. This is one half of the Ames/Gall backpressure mechanism: a `%flub` causes the corresponding flow to halt.
+
+#### Produces
+
+A `(jug ship app=term)`.
+
+#### Example
+
+```
+> .^(* %gg /=//=/$)
+```
+
+---
+
+### `%h`: halted apps {#h-halted-apps}
+
+A scry with an `%h` care will give you, per agent, the ships whose flows are halted because that agent is missing or suspended.
+
+#### Produces
+
+A `(jug app=term [ship =duct])`.
+
+#### Example
+
+```
+> .^(* %gh /=//=/$)
+```
+
+---
+
+### `%i`: flub ducts {#i-flub-ducts}
+
+A scry with an `%i` care will give you the duct Gall uses to send `%flub` notifications for each ship.
+
+#### Produces
+
+A `(map ship duct)`.
+
+#### Example
+
+```
+> .^(* %gi /=//=/$)
 ```
 
 ---
@@ -255,6 +319,24 @@ See the [remote scry guide](../../../build-on-urbit/userspace/remote-scry.md) fo
 #### Produces
 
 The type returned is the raw `$noun` from the `$page`. If the file has been tombstoned or does not exist, the scry will fail.
+
+---
+
+### `%y`: live agents {#y-live-agents}
+
+A scry with a `%y` care will give you every running agent and its state. Agents that are not live are excluded from the map.
+
+#### Produces
+
+A `(map term yoke)`.
+
+Note this is the scry the `+vats` generator uses to gather per-desk agent status.
+
+#### Example
+
+```
+> .^(* %gy /=//=/$)
+```
 
 ---
 


### PR DESCRIPTION
Eleventh PR from the audit against `urbit/urbit@08026c84b2`. The Gall vane scry arm (`sys/vane/gall.hoon:2897-3160`) dispatches **15** cares; `gall/scry.md` documented **10**.

Companion PRs: #266, #267, #268, #269, #270, #271, #272, #273, #274, #275.

## The five missing cares

| Care | Meaning | Produces | Source |
|---|---|---|---|
| `%b` | blocked moves | `(map term (qeu blocked-move))` | `gall.hoon:2936` |
| `%g` | flubbed apps | `(jug ship app=term)` | `gall.hoon:2984` |
| `%h` | halted apps | `(jug app=term [ship =duct])` | `gall.hoon:2993` |
| `%i` | flub ducts | `(map ship duct)` | `gall.hoon:3001` |
| `%y` | live agents | `(map term yoke)` | `gall.hoon:3138` |

Types and descriptions come from the `+$ state` definition (`gall.hoon:78-90`) and its own field comments. `%y` filters the yoke map to live agents only.

`%g`, `%h` and `%i` are the observability surface for the Ames/Gall backpressure protocol documented in #269: `%g` is which agents have refused a `$plea`, `%h` is which flows are halted because an agent is missing or suspended, and `%i` is the duct used to send `%flub` notifications per ship.

## Verification note — please read

Unlike the other PRs in this series, **these five were not verified by live scry.** Every attempt to type a vane-scry path wedged the dojo's line editor: the `$` path element did not survive `send-keys` or `paste-buffer`, and repeated attempts left the input line unusable until the ship was restarted.

Rather than keep fighting the terminal — or, worse, write a plausible-looking example product I had not actually observed — the entries are documented from the dispatch conditions and return marks in `gall.hoon`, which are unambiguous, and **the example blocks show only the invocation, not a fabricated output.** Every other PR in this series contains real captured output; these deliberately do not, and I would rather say so than have a reviewer assume otherwise.

`%y` is exercised indirectly and does work: the `+vats` generator scries it (`.^(yokes ... %gy ...)`) on every run, and `+vats` was verified live in #268.

## Avoided a cross-PR link

An earlier draft pointed `%g` at `[%halt](../ames/tasks.md#halt)`, but that anchor is added by #269 and does not exist on `master`. If these merged in the wrong order the link would break, so the reference is prose instead.

Test-merged against the ten open companion PRs — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)