### PR TITLE
docs: add missing vane Gifts sections and undocumented tasks

### DIFF
--- a/content/urbit-os/kernel/behn/tasks.md
+++ b/content/urbit-os/kernel/behn/tasks.md
@@ -164,3 +164,26 @@ You would not use this task from userspace.
 #### Returns
 
 In response to receiving this task, Behn may `%give` a `%doze` gift containing the `@da` of the next timer to elapse. Behn may also `%give` a `%wake` gift to itself.
+
+---
+
+## Gifts {#gifts}
+
+The complete `$gift:behn` union:
+
+```hoon
++$  gift
+  $%  [%doze p=(unit @da)]
+      [%wake error=(unit tang)]
+      [%meta p=vase]
+      [%heck syn=sign-arvo]
+  ==
+```
+
+- `%doze` - The next alarm. Behn gives this to Unix, which does the real
+  timekeeping. A null `.p` means there is no timer set, so Unix can stop waiting.
+- `%wake` - A timer has elapsed, given to whoever set it with [`%wait`](#wait).
+  A non-null `.error` means the timer fired but the resulting event crashed.
+- `%meta` - Gives back the vase from a [`%drip`](#drip), in the following event.
+- `%heck` - Gives back the `$sign-arvo` from a [`%huck`](#huck).
+

--- a/content/urbit-os/kernel/dill/tasks.md
+++ b/content/urbit-os/kernel/dill/tasks.md
@@ -388,3 +388,80 @@ The `$tape` in `.p` will be printed to the terminal.
 Dill does not return a gift in response to a `%text` task.
 
 ***
+
+***
+
+### `%mass` <a href="#mass" id="mass"></a>
+
+Run a memory report.
+
+```hoon
+[%mass ~]
+```
+
+Asks the runtime to produce a memory report. This is the mechanism behind `|mass` in the dojo. The runtime replies with a [`%quac`](#quac) task carrying the result.
+
+#### Returns
+
+Dill does not return a gift in response to a `%mass` task.
+
+***
+
+### `%quac` <a href="#quac" id="quac"></a>
+
+Memory report from the runtime.
+
+```hoon
+[%quac p=(list quac)]
+```
+
+Carries the memory report produced in response to [`%mass`](#mass). This comes from the runtime; you would not send it from userspace.
+
+#### Returns
+
+Dill gives a `%meme` gift carrying the report.
+
+***
+
+### `%knob` <a href="#knob" id="knob"></a>
+
+Set error volume for a tag.
+
+```hoon
+[%knob tag=term level=?(%hush %soft %loud)]
+```
+
+**Deprecated.** This task is marked `:: deprecated removeme` in `lull.hoon` and should not be adopted in new code.
+
+#### Returns
+
+Dill does not return a gift in response to a `%knob` task.
+
+***
+
+## Gifts <a href="#gifts" id="gifts"></a>
+
+The complete `$gift:dill` union:
+
+```hoon
++$  gift
+  $%  [%blit p=(list blit)]
+      [%logo ~]
+      [%meld $@(~ [memo=? ford=?])]
+      [%pack ~]
+      [%trim p=@ud]
+      [%logs =told]
+      [%meme p=(list quac)]
+      [%quac ~]
+  ==
+```
+
+- `%blit` - Terminal output, given to Unix as a list of [`$blit`](data-types.md#blit)s.
+- `%logo` - Tells the runtime to shut the ship down.
+- `%meld` - Asks the runtime to deduplicate memory. Same payload as the [`%meld`](#meld) task.
+- `%pack` - Asks the runtime to defragment memory.
+- `%trim` - Asks the runtime to free memory.
+- `%logs` - System output, given to subscribers of the [`%logs`](#logs) task.
+- `%meme` - A memory report, given in response to a [`%quac`](#quac) task.
+- `%quac` - Asks the runtime for a memory report; the counterpart of the [`%mass`](#mass) task.
+

--- a/content/urbit-os/kernel/eyre/tasks.md
+++ b/content/urbit-os/kernel/eyre/tasks.md
@@ -268,3 +268,52 @@ Eyre gives a `%grow` gift in response to a `%set-response` task. A `%grow` gift 
 The `$path` will be of the format `/cache/[revision]/[url]`, for example `/cache/12/~~~2f.foo~2f.bar`. The revision number is incremented each time the entry is updated, including if it's removed, and is in `@ud` format. The url element uses `%t` [`+scot`](../../../hoon/stdlib/4m.md#scot) encoding, so will need to be decoded with `%t` [`+slav`](../../../hoon/stdlib/4m.md#slav).
 
 ***
+
+## `%eauth-host` <a href="#eauth-host" id="eauth-host"></a>
+
+Set the EAuth base URL.
+
+```hoon
+[%eauth-host host=(unit @t)]
+```
+
+Explicitly sets the base URL used for EAuth, for example `'https://sampel.com'`. Eyre appends `/~/eauth` to it internally when redirecting into the EAuth flow. A null `.host` clears it, so the endpoint is determined implicitly again.
+
+See the [EAuth guide](eauth.md) for how the endpoint is otherwise derived.
+
+***
+
+## `%spew` <a href="#spew" id="spew"></a>
+
+Set verbosity.
+
+```hoon
+[%spew veb=@]
+```
+
+Sets Eyre's debug verbosity toggle.
+
+***
+
+## Gifts <a href="#gifts" id="gifts"></a>
+
+The complete `$gift:eyre` union:
+
+```hoon
++$  gift
+  $%  $>(?(%boon %done) gift:ames)
+      [%set-config =http-config]
+      [%sessions ses=(set @t)]
+      [%response =http-event:http]
+      [%bound accepted=? =binding]
+      [%grow =path]
+  ==
+```
+
+- `%boon` / `%done` - Ames responses, reused from [`$gift:ames`](../ames/data-types.md). These carry results for requests that arrived over the network.
+- `%set-config` - Configures the external HTTP server, given to Unix.
+- `%sessions` - The set of valid authentication cookie strings.
+- `%response` - A response to an event from Unix, as an [`$http-event:http`](data-types.md#http-eventhttp).
+- `%bound` - The result of a [`%connect`](#connect) or [`%serve`](#serve). `.accepted` is false if the binding was rejected, which happens when it duplicates an existing one.
+- `%grow` - Notifies that a cache entry has changed. See [`%set-response`](#set-response) for the path format.
+

--- a/content/urbit-os/kernel/iris/tasks.md
+++ b/content/urbit-os/kernel/iris/tasks.md
@@ -70,3 +70,27 @@ Iris does not return any gift in response to a `%cancel-request` task. You will 
 Receives HTTP data from outside. This task is sent to Iris by the runtime, you would not use it manually.
 
 The `.id` is a sequential ID for the event and the [$http-event:http](../eyre/data-types.md#http-eventhttp) contains the HTTP headers and data.
+
+---
+
+## Gifts {#gifts}
+
+The complete `$gift:iris` union:
+
+```hoon
++$  gift
+  $%  [%request id=@ud request=request:http]
+      [%cancel-request id=@ud]
+      [%http-response =client-response]
+  ==
+```
+
+- `%request` - An outbound HTTP request, given to Unix to perform. Note this
+  shares a name with the [`%request`](#request) *task*: the task is how a vane
+  asks Iris to fetch something, and the gift is how Iris asks Unix to do it.
+- `%cancel-request` - Tells Unix to cancel a previously given `%request`. The
+  same naming applies as above.
+- `%http-response` - The result, given back to whoever sent the
+  [`%request`](#request) task, as a
+  [`$client-response`](data-types.md#client-response).
+

--- a/content/urbit-os/kernel/khan/tasks.md
+++ b/content/urbit-os/kernel/khan/tasks.md
@@ -65,6 +65,16 @@ When the thread eventually finishes (or if it fails), Khan with give an [`%arow`
 
 ---
 
+### `%done` {#done}
+
+Socket closed.
+
+```hoon
+[%done ~]
+```
+
+Tells Khan that the external control socket has closed. This comes from the runtime; you would not send it from userspace.
+
 ## Gifts {#gifts}
 
 These are the two gifts Khan can give. In userspace, you'd only receive an [`%arow`](#arow).


### PR DESCRIPTION
Thirteenth PR from the audit against `urbit/urbit@08026c84b2`. Four vanes documented their tasks but never their gifts — the cards existed only as passing mentions under whichever task produced them, if at all.

Companion PRs: #266, #267, #269, #270, #271, #272, #273, #274, #275, #276, #277.

## Gifts sections added

| Vane | Cards | Source |
|---|---|---|
| behn | 4 — `%doze` `%wake` `%meta` `%heck` | `lull.hoon:2404` |
| dill | 8 — `%blit` `%logo` `%meld` `%pack` `%trim` `%logs` `%meme` `%quac` | `:2861` |
| eyre | 6 — `%boon`/`%done` `%set-config` `%sessions` `%response` `%bound` `%grow` | `:2978` |
| iris | 3 — `%request` `%cancel-request` `%http-response` | `:4131` |

Coverage verified by script: every gift in each source union now appears in its doc.

**Two naming collisions are called out explicitly**, since both are easy to misread:

- **Iris** has `%request` and `%cancel-request` as *both* a task and a gift. The task is how a vane asks Iris to fetch something; the gift is how Iris asks Unix to do it.
- **Dill** has `%meld`, `%pack`, `%trim` and `%quac` in both unions, pointing in opposite directions.

## Tasks added

| Vane | Task | Note |
|---|---|---|
| dill | `%mass` | run a memory report — the mechanism behind `\|mass` |
| dill | `%quac` | the runtime's reply carrying that report |
| dill | `%knob` | **documented as deprecated** |
| eyre | `%eauth-host` | set the EAuth base URL |
| eyre | `%spew` | set verbosity toggle |
| khan | `%done` | external control socket closed |

`%knob` is marked `:: deprecated removeme` in `lull.hoon`. The entry exists to *stop* anyone adopting it, not to encourage use — an undocumented deprecated card is worse than a documented one, since nothing signals that it's on its way out.

`%eauth-host` is a nice illustration of the gap: the EAuth guide already described this task in detail, while `tasks.md` — the page that purports to enumerate Eyre's interface — never listed it. Now cross-referenced.

## Checked and deliberately not changed

- **khan** already had a complete Gifts section (`%arow`, `%avow`).
- **eyre's `%reject-origin` and `%set-response`** did not appear in a first partial extraction of the task union, which briefly looked like the docs had phantom cards. They exist at `lull.hoon:3063` and `:3069` — the docs were right and my extraction range was too narrow. No phantom cards in any of these files.

All anchors verified to resolve. Test-merged against the twelve open companion PRs — all clean, including confirmation that `dill/tasks.md` takes #269's `%meld` payload change and this PR's Gifts section together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)