### PR TITLE
docs: document typed paths ($pith, $iota, +pave, +pout, +stip)

### DIFF
--- a/content/hoon/stdlib/4m.md
+++ b/content/hoon/stdlib/4m.md
@@ -15,6 +15,76 @@ layout:
 
 # 4m: Formatting Functions
 
+## `+pave` {#pave}
+
+Parse `$path` to [`$pith`](4o.md#pith).
+
+Parses each segment of a `$path` into a typed [`$iota`](4o.md#iota). A segment that does not parse as any recognised aura is kept as `[%ta segment]`.
+
+#### Accepts
+
+`.path` is a `$path`.
+
+#### Produces
+
+A [`$pith`](4o.md#pith).
+
+#### Source
+
+```hoon
+++  pave
+  |=  =path
+  ^-  pith
+  %+  turn  path
+  |=  i=@ta
+  (fall (rush i spot:stip) [%ta i])
+```
+
+#### Examples
+
+```
+> (pave /foo/123/0xdead)
+~[%foo [%ud 123] [%ux 0xdead]]
+```
+
+Note that a cast does not do this — `` `pith`/foo/123 `` produces `~[%foo %123]`, leaving the segments as bare `@tas`.
+
+---
+
+## `+pout` {#pout}
+
+Render [`$pith`](4o.md#pith) to `$path`.
+
+The inverse of [`+pave`](#pave): renders each [`$iota`](4o.md#iota) back to a `@ta` segment with [`+scot`](#scot).
+
+#### Accepts
+
+`.pith` is a [`$pith`](4o.md#pith).
+
+#### Produces
+
+A `$path`.
+
+#### Source
+
+```hoon
+++  pout
+  |=  =pith
+  ^-  path
+  %+  turn  pith
+  |=  i=iota
+  ?@(i i (scot i))
+```
+
+#### Examples
+
+```
+> (pout (pave /foo/123/0xdead))
+/foo/123/0xdead
+```
+
+---
+
 ## `+scot` {#scot}
 
 Render `$dime` as `$cord`.
@@ -523,6 +593,51 @@ A `$path`, or crash.
 ```
 > (stab '/as/lek/tor')
 /as/lek/tor
+```
+
+---
+
+## `+stip` {#stip}
+
+Typed path parser.
+
+A parser core for [`$pith`](4o.md#pith)s. Used by [`+pave`](#pave).
+
+#### Source
+
+```hoon
+++  stip
+  =<  swot
+  |%
+  ++  swot  |=(n=nail (;~(pfix fas (more fas spot)) n))
+  ::
+  ++  spot
+    %+  sear  (soft iota)
+```
+
+The core reduces to `+swot`, so `+stip` used directly parses a whole path.
+
+### `+spot:stip` {#spotstip}
+
+Parses a single path segment into an [`$iota`](4o.md#iota).
+
+```
+> (rash '123' spot:stip)
+[%ud 123]
+```
+
+```
+> (rash '0xdead' spot:stip)
+[%ux 0xdead]
+```
+
+### `+swot:stip` {#swotstip}
+
+Parses a whole `/`-separated path into a [`$pith`](4o.md#pith).
+
+```
+> (rash '/foo/123' swot:stip)
+[%foo [i=[%ud 123] t=~]]
 ```
 
 ---

--- a/content/hoon/stdlib/4o.md
+++ b/content/hoon/stdlib/4o.md
@@ -99,6 +99,76 @@ See also: [`$base`](#base), aura reference
 
 ---
 
+## `$iota` {#iota}
+
+Typed path segment.
+
+A single segment of a [`$pith`](#pith). Either a bare `@tas`, or a tagged pair naming the aura of the value it holds.
+
+#### Source
+
+```hoon
++$  iota
+  $+  iota
+  $~  [%n ~]
+  $@  @tas
+  $%  [%ub @ub]  [%uc @uc]  [%ud @ud]  [%ui @ui]
+      [%ux @ux]  [%uv @uv]  [%uw @uw]
+      [%sb @sb]  [%sc @sc]  [%sd @sd]  [%si @si]
+      [%sx @sx]  [%sv @sv]  [%sw @sw]
+      [%da @da]  [%dr @dr]
+      [%f ?]     [%n ~]
+      [%if @if]  [%is @is]
+      [%t @t]    [%ta @ta]
+      [%p @p]    [%q @q]
+      [%rs @rs]  [%rd @rd]  [%rh @rh]  [%rq @rq]
+  ==
+```
+
+#### Examples
+
+```
+> (rash '123' spot:stip)
+[%ud 123]
+```
+
+```
+> (rash '0xdead' spot:stip)
+[%ux 0xdead]
+```
+
+---
+
+## `$pith` {#pith}
+
+Typed Urbit path.
+
+A `$pith` is a `(list iota)` — a path whose segments carry their aura, rather than being flattened to `@ta` as in an ordinary `$path`.
+
+#### Source
+
+```hoon
++$  pith  (list iota)
+```
+
+#### Examples
+
+```
+> (pave /foo/123/0xdead)
+~[%foo [%ud 123] [%ux 0xdead]]
+```
+
+Note that **casting a `$path` to a `$pith` does not parse the segments** — it merely retypes them as bare `@tas`:
+
+```
+> `pith`/foo/123
+~[%foo %123]
+```
+
+Use [`+pave`](4m.md#pave) to actually parse a `$path` into a `$pith`.
+
+---
+
 ## `$base` {#base}
 
 Base type.


### PR DESCRIPTION
Fifteenth PR from the audit against `urbit/urbit@08026c84b2`. Typed paths were entirely undocumented. Every example was run on a fake ship (`urbit-408k-rc1.pill`).

Companion PRs: #266, #267, #269–#279.

## Molds (`stdlib/4o.md`)

- **`$iota`** — typed path segment (`hoon.hoon:2105`). Either a bare `@tas`, or a tagged pair naming the aura of the value it holds.
- **`$pith`** — typed Urbit path (`hoon.hoon:2097`). A `(list iota)`; a path whose segments carry their aura rather than being flattened to `@ta`.

## Formatting functions (`stdlib/4m.md`)

- **`+pave`** — `path` → `pith` (`:5999`). Segments matching no known aura fall back to `[%ta segment]`.
- **`+pout`** — `pith` → `path` (`:5992`). The inverse, rendering each `$iota` with `+scot`.
- **`+stip`** — typed path parser (`:5972`), with `+spot:stip` (one segment) and `+swot:stip` (a whole path). The core reduces to `+swot`, so `+stip` used directly parses a path.

## The trap, found by trying it rather than reading it

**Casting a `$path` to a `$pith` does not parse the segments.**

```
> (pave /foo/123/0xdead)
~[%foo [%ud 123] [%ux 0xdead]]

> `pith`/foo/123
~[%foo %123]
```

The cast merely retypes the existing `@ta` segments, so `%123` stays a term rather than becoming `[%ud 123]`. Anyone reaching for a `$pith` by casting gets something that type-checks and is silently wrong. Noted in both the `$pith` and `+pave` entries.

## All examples verified

```
(pave /foo/123/0xdead)          ~[%foo [%ud 123] [%ux 0xdead]]
(pout (pave /foo/123/0xdead))   /foo/123/0xdead
(rash '123' spot:stip)          [%ud 123]
(rash '0xdead' spot:stip)       [%ux 0xdead]
(rash '/foo/123' swot:stip)     [%foo [i=[%ud 123] t=~]]
```

## `+hew` went to #272 instead

`+hew` belongs in `stdlib/2c.md` immediately before `+lsh` — the same insertion point #272 already uses for `+ham`, so putting it here would have conflicted. It has been added to that branch instead, alongside the other bit-arithmetic arms, and #272 has been updated.

Worth noting how that went: I wrote `+hew`'s source block from inference on a first pass and it was **wrong** — I had the tail as two `=/` bindings threading `d` by hand, where the source uses `=^  f  d  $(b -.b)` twice and produces `[[f g] d]`. Caught by diffing against `hoon.hoon` before commit, the same check that caught `+rig` earlier on that branch. All five blocks in `2c.md` now verify as exact matches.

All anchors verified to resolve. Test-merged against the fourteen open companion PRs — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)